### PR TITLE
[2.4 backport] Fix nodes count calculation in AcmCountCardSection

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
@@ -64,7 +64,7 @@ export function StatusSummaryCount() {
                 cards={[
                     {
                         id: 'nodes',
-                        count: /* istanbul ignore next */ cluster?.nodes?.nodeList?.length ?? 0,
+                        count: /* istanbul ignore next */ (cluster?.nodes?.nodeList ?? []).length,
                         countClick: () => push(NavigationPath.clusterNodes.replace(':id', cluster?.name!)),
                         title: t('summary.nodes'),
                         description: (


### PR DESCRIPTION
This fixes nodes count calculation in case when cluster.nodes.nodeList
is undefined.

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>