### PR TITLE
Adjust warning host count calculation

### DIFF
--- a/frontend/src/routes/Infrastructure/InfraEnvironments/InfraEnvironmentsPage.tsx
+++ b/frontend/src/routes/Infrastructure/InfraEnvironments/InfraEnvironmentsPage.tsx
@@ -153,7 +153,11 @@ const InfraEnvsTable: React.FC<InfraEnvsTableProps> = ({ infraEnvs, agents }) =>
                                 isMatch(a.metadata.labels, infraEnv.status?.agentLabelSelector?.matchLabels)
                             )
                             const errorAgents = infraAgents.filter((a) => getAgentStatus(a)[0] === 'error')
-                            const warningAgents = infraAgents.filter((a) => getAgentStatus(a)[0] === 'insufficient')
+                            const warningAgents = infraAgents.filter((a) =>
+                                ['pending-for-input', 'insufficient', 'insufficient-unbound'].includes(
+                                    getAgentStatus(a)[0]
+                                )
+                            )
 
                             return (
                                 <Link to={`${getDetailsLink(infraEnv)}/hosts`}>


### PR DESCRIPTION
Include 'pending-for-input' and 'insufficient-unbound' agent states
when calculating warning hosts count.

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>