### PR TITLE
Remove application table timer

### DIFF
--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -157,7 +157,7 @@ export default function ApplicationsOverview() {
         open: false,
     })
     const tableItems: IResource[] = []
-    const { data, loading, startPolling } = useQuery(useCallback(() => queryRemoteArgoApps(), []))
+    const { data, loading, startPolling } = useQuery(queryRemoteArgoApps)
     useEffect(startPolling, [startPolling])
 
     const calculateClusterCount = (resource: ArgoApplication, clusterCount: any, clusterList: string[]) => {

--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -4,7 +4,7 @@ import { AcmButton, AcmEmptyState, AcmTable, IAcmRowAction, IAcmTableColumn } fr
 import { ButtonVariant, PageSection } from '@patternfly/react-core'
 import { cellWidth } from '@patternfly/react-table'
 import _ from 'lodash'
-import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '../../lib/acm-i18next'
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
 import { TFunction } from 'react-i18next'
@@ -571,7 +571,6 @@ export default function ApplicationsOverview() {
     const [canCreateApplication, setCanCreateApplication] = useState<boolean>(false)
     const [canDeleteApplication, setCanDeleteApplication] = useState<boolean>(false)
     const [canDeleteApplicationSet, setCanDeleteApplicationSet] = useState<boolean>(false)
-    const [tableContent, setTableContent] = useState<ReactNode>()
 
     let modalWarnings: string
     const getAppChildResources = (app: IResource) => {
@@ -836,8 +835,31 @@ export default function ApplicationsOverview() {
         return actions
     }
 
-    const generateTable = () => {
-        return (
+    useEffect(() => {
+        const canCreateApplicationPromise = canUser('create', ApplicationDefinition)
+        canCreateApplicationPromise.promise
+            .then((result) => setCanCreateApplication(result.status?.allowed!))
+            .catch((err) => console.error(err))
+        return () => canCreateApplicationPromise.abort()
+    }, [])
+    useEffect(() => {
+        const canDeleteApplicationPromise = canUser('delete', ApplicationDefinition)
+        canDeleteApplicationPromise.promise
+            .then((result) => setCanDeleteApplication(result.status?.allowed!))
+            .catch((err) => console.error(err))
+        return () => canDeleteApplicationPromise.abort()
+    }, [])
+    useEffect(() => {
+        const canDeleteApplicationSetPromise = canUser('delete', ApplicationSetDefinition)
+        canDeleteApplicationSetPromise.promise
+            .then((result) => setCanDeleteApplicationSet(result.status?.allowed!))
+            .catch((err) => console.error(err))
+        return () => canDeleteApplicationSetPromise.abort()
+    }, [])
+
+    return (
+        <PageSection>
+            <DeleteResourceModal {...modalProps} />
             <AcmTable<IResource>
                 key="data-table"
                 plural={t('Applications')}
@@ -871,46 +893,6 @@ export default function ApplicationsOverview() {
                 }
                 rowActionResolver={rowActionResolver}
             />
-        )
-    }
-
-    useEffect(() => {
-        const canCreateApplicationPromise = canUser('create', ApplicationDefinition)
-        canCreateApplicationPromise.promise
-            .then((result) => setCanCreateApplication(result.status?.allowed!))
-            .catch((err) => console.error(err))
-        return () => canCreateApplicationPromise.abort()
-    }, [])
-    useEffect(() => {
-        const canDeleteApplicationPromise = canUser('delete', ApplicationDefinition)
-        canDeleteApplicationPromise.promise
-            .then((result) => setCanDeleteApplication(result.status?.allowed!))
-            .catch((err) => console.error(err))
-        return () => canDeleteApplicationPromise.abort()
-    }, [])
-    useEffect(() => {
-        const canDeleteApplicationSetPromise = canUser('delete', ApplicationSetDefinition)
-        canDeleteApplicationSetPromise.promise
-            .then((result) => setCanDeleteApplicationSet(result.status?.allowed!))
-            .catch((err) => console.error(err))
-        return () => canDeleteApplicationSetPromise.abort()
-    }, [])
-
-    useEffect(() => {
-        setTableContent(generateTable())
-
-        const interval = setInterval(() => {
-            setTableContent(generateTable())
-        }, 5000)
-        return () => {
-            clearInterval(interval)
-        }
-    }, [canCreateApplication, canDeleteApplication, canDeleteApplicationSet, data])
-
-    return (
-        <PageSection>
-            <DeleteResourceModal {...modalProps} />
-            {tableContent}
         </PageSection>
     )
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetAccessManagement/ClusterSetAccessManagement.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetAccessManagement/ClusterSetAccessManagement.tsx
@@ -41,7 +41,7 @@ import {
     ToggleGroupItem,
 } from '@patternfly/react-core'
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons'
-import { useCallback, useContext, useMemo, useState } from 'react'
+import { useContext, useMemo, useState } from 'react'
 import { Trans, useTranslation } from '../../../../../../lib/acm-i18next'
 import { BulkActionModel, errorIsNot, IBulkActionModelProps } from '../../../../../../components/BulkActionModel'
 import { ErrorPage, getErrorInfo } from '../../../../../../components/ErrorPage'
@@ -56,9 +56,9 @@ export function ClusterSetAccessManagement() {
     })
     const [addModalOpen, setAddModalOpen] = useState<boolean>(false)
 
-    const { data, refresh, error } = useQuery(useCallback(() => listClusterRoleBindings(), []))
-    const { data: users } = useQuery(useCallback(() => listUsers(), []))
-    const { data: groups } = useQuery(useCallback(() => listGroups(), []))
+    const { data, refresh, error } = useQuery(listClusterRoleBindings)
+    const { data: users } = useQuery(listUsers)
+    const { data: groups } = useQuery(listGroups)
 
     let clusterRoleBindings: ClusterRoleBinding[] | undefined
     if (data) {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { AcmCountCardSection, AcmDrawerContext } from '@stolostron/ui-components'
-import { useCallback, useContext, useEffect } from 'react'
+import { useContext, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
 import { useRecoilState } from 'recoil'
 import { policyreportState } from '../../../../../atoms'
@@ -27,9 +27,7 @@ export function StatusSummaryCount() {
     const { t } = useTranslation()
     const { push } = useHistory()
     /* istanbul ignore next */
-    const { data, loading, startPolling } = useQuery(
-        useCallback(() => queryStatusCount(cluster?.name!), [cluster?.name])
-    )
+    const { data, loading, startPolling } = useQuery(() => queryStatusCount(cluster?.name!))
     useEffect(startPolling, [startPolling])
 
     const policyReport = policyReports.filter(


### PR DESCRIPTION
I think there may have been a previous environmental issue that was triggering constant rerendering of the table. Removing this code to reduce rendering, I only see renders as expected from the polling search query. Verified using this React dev tools option:

![image](https://user-images.githubusercontent.com/42188127/150597578-cb8326af-e313-47f3-9e11-fe004d7e6344.png)

I think there may be more room to improve by updating the useQuery hook to only update state when the result of the query actually changes. Will investigate further and open a separate PR for that if it seems feasible.