### PR TITLE
Updating RbacDropdown to only show tooltip if also disabled

### DIFF
--- a/frontend/src/components/Rbac.tsx
+++ b/frontend/src/components/Rbac.tsx
@@ -81,7 +81,7 @@ export function RbacDropdown<T = unknown>(props: RbacDropdownProps<T>) {
             text={props.text}
             onToggle={onToggle}
             isDisabled={props.isDisabled}
-            tooltip={props.tooltip}
+            tooltip={props.isDisabled ? props.tooltip : undefined}
         />
     )
 }


### PR DESCRIPTION
RbacDropdown passes its tooltip prop to AcmDropdown only if its isDisabled prop is set to true. Otherwise it passes undefined as the tooltip. 
Signed-off-by: Ella Juengst <ellajuengst@gmail.com>