### PR TITLE
handle watch errors

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "type": "module",
     "scripts": {
-        "start": "NODE_ENV=development nodemon --watch './**/*.ts' --exec 'node --experimental-specifier-resolution=node --loader ts-node/esm/transpile-only' src/lib/main.ts | pino-zen -r msg=5 -d fields -d labels -d apiVersion -e error",
+        "start": "NODE_ENV=development nodemon --watch './**/*.ts' --exec 'node --experimental-specifier-resolution=node --loader ts-node/esm/transpile-only' src/lib/main.ts | pino-zen -r msg=6 -d fields -d labels -d apiVersion -e error",
         "postinstall": "[ ! -d ./certs ] && npm run generate-certs || true",
         "generate-certs": "mkdir -p certs && openssl req -subj '/C=US' -new -newkey rsa:2048 -sha256 -days 365 -nodes -x509 -keyout certs/tls.key -out certs/tls.crt",
         "build": "tsc --sourceMap false --declaration false && npx rollup --format es --file backend.mjs -- build/lib/main.js",

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -322,10 +322,14 @@ async function watchKubernetesObjects(options: IWatchOptions, resourceVersion: s
                                 resourceVersion = watchEvent.object.metadata.resourceVersion
                                 break
                             case 'ERROR':
-                                if ((watchEvent.object as any).message.startsWith('too old resource version')) {
+                                if (
+                                    (watchEvent.object as unknown as { message?: string }).message.startsWith(
+                                        'too old resource version'
+                                    )
+                                ) {
                                     logger.warn({
                                         msg: 'watch',
-                                        warning: (watchEvent.object as any).message,
+                                        warning: (watchEvent.object as unknown as { message?: string }).message,
                                         action: 'retrying watch',
                                         kind: options.kind,
                                         apiVersion: options.apiVersion,

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -126,7 +126,7 @@ export function startWatching(): void {
     ServerSideEvents.eventFilter = eventFilter
 
     for (const definition of definitions) {
-        void watch(definition)
+        void listAndWatch(definition)
     }
 }
 
@@ -138,13 +138,17 @@ interface IWatchOptions {
 }
 
 // https://kubernetes.io/docs/reference/using-api/api-concepts/
-async function watch(options: IWatchOptions) {
+async function listAndWatch(options: IWatchOptions) {
     while (!stopping) {
         try {
             const resourceVersion = await listKubernetesObjects(options)
             await watchKubernetesObjects(options, resourceVersion)
         } catch (err: unknown) {
-            if (err instanceof HTTPError) {
+            if (err instanceof SyntaxError) {
+                // Happens when the response body is not JSON
+                // Such as the case when the resource version if too old
+                // fall through to rerun the list function
+            } else if (err instanceof HTTPError) {
                 switch (err.response.statusCode) {
                     case 404:
                         logger.trace({ msg: 'watch', ...options, status: 'Not found' })
@@ -157,13 +161,11 @@ async function watch(options: IWatchOptions) {
                 if (err.message === 'Premature close') {
                     // Do nothing
                 } else {
-                    logger.warn({ msg: 'watch', error: err.message, name: err.name, ...options })
                     await new Promise((resolve) =>
                         setTimeout(resolve, 60 * 1000 + Math.ceil(Math.random() * 10 * 1000)).unref()
                     )
                 }
             } else {
-                logger.warn({ msg: 'watch', err, ...options })
                 await new Promise((resolve) =>
                     setTimeout(resolve, 60 * 1000 + Math.ceil(Math.random() * 10 * 1000)).unref()
                 )
@@ -250,6 +252,7 @@ async function watchKubernetesObjects(options: IWatchOptions, resourceVersion: s
             fields: options.fieldSelector,
             apiVersion: options.apiVersion,
         })
+
         try {
             const url = resourceUrl(options, { watch: undefined, allowWatchBookmarks: undefined, resourceVersion })
             const request = got.stream(url, {
@@ -319,12 +322,23 @@ async function watchKubernetesObjects(options: IWatchOptions, resourceVersion: s
                                 resourceVersion = watchEvent.object.metadata.resourceVersion
                                 break
                             case 'ERROR':
-                                logger.error({
-                                    msg: 'watch error',
-                                    kind: options.kind,
-                                    apiVersion: options.apiVersion,
-                                    event: watchEvent,
-                                })
+                                if ((watchEvent.object as any).message.startsWith('too old resource version')) {
+                                    logger.warn({
+                                        msg: 'watch',
+                                        warning: (watchEvent.object as any).message,
+                                        action: 'retrying watch',
+                                        kind: options.kind,
+                                        apiVersion: options.apiVersion,
+                                    })
+                                } else {
+                                    logger.warn({
+                                        msg: 'watch',
+                                        action: 'retrying watch',
+                                        kind: options.kind,
+                                        apiVersion: options.apiVersion,
+                                        event: watchEvent,
+                                    })
+                                }
                                 break
                         }
                     })
@@ -334,21 +348,50 @@ async function watchKubernetesObjects(options: IWatchOptions, resourceVersion: s
             }
         } catch (err: unknown) {
             if (err instanceof TimeoutError) {
-                logger.debug({ msg: 'retry', ...options })
+                // Timeout when we have not recieved an event in 5 min
+                // Do nothing - retry the watch
             } else if (err instanceof CancelError) {
-                // Do Nothing
+                // Aborting the list/watch causes a CancelError
+                // Do nothing - fall through to allow exit
             } else if (err instanceof SyntaxError) {
-                logger.debug({ msg: 'retry', ...options })
+                // Happens when the response body is not JSON
+                // Such as the case when the resource version if too old
+                // Need to throw error to cause a list function to rerun
+                logger.trace({ msg: 'SyntaxError', ...options })
+                throw err
             } else if (err instanceof HTTPError) {
                 switch (err.response.statusCode) {
                     case 410:
-                        logger.debug({ msg: 'retry', ...options })
-                        break
+                        // https://kubernetes.io/docs/reference/using-api/api-concepts/
+                        // A given Kubernetes server will only preserve a historical record of changes for a limited time.
+                        // Clusters using etcd 3 preserve changes in the last 5 minutes by default.
+                        // When the requested watch operations fail because the historical version of that resource is not available,
+                        // clients must handle the case by recognizing the status code 410 Gone, clearing their local cache,
+                        // performing a new get or list operation, and starting the watch from the resourceVersion that was returned.
+                        //
+                        // Throw error fall through to perform a list and reconcile
+                        throw err
                     default:
+                        logger.warn({
+                            msg: 'watch',
+                            warning: (err as Error)?.message,
+                            ...options,
+                            errorName: (err as Error)?.name,
+                        })
                         throw err
                 }
             } else {
-                throw err
+                if ((err as Error)?.message === 'Premature close') {
+                    // Do nothing
+                } else {
+                    logger.warn({
+                        msg: 'watch',
+                        warning: (err as Error)?.message,
+                        ...options,
+                        errorName: (err as Error)?.name,
+                    })
+                    throw err
+                }
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: James Talton <jtalton@redhat.com>

https://github.com/stolostron/backlog/issues/19710

I have reproduced every morning until it stops happening and then wait until the next day.
I believe I have logic in place to handle the issue.

```
 INFO list    kind Channel  apiVersion apps.open-cluster-management.io/v1  count 2
DEBUG watch   kind Channel  apiVersion apps.open-cluster-management.io/v1
 WARN watch   warning too old resource version: 211822 (211825)  action retrying watch  kind Channel  apiVersion apps.open-cluster-management.io/v1
 INFO list    kind Channel  apiVersion apps.open-cluster-management.io/v1  count 2
DEBUG watch   kind Channel  apiVersion apps.open-cluster-management.io/v1
```

This follows https://kubernetes.io/docs/reference/using-api/api-concepts/

> When the requested watch operations fail because the historical version of that resource is not available, clients must handle the case by recognizing the status code 410 Gone, clearing their local cache, performing a new get or list operation, and starting the watch from the resourceVersion that was returned.