### PR TITLE
remove incorrect image reference for empty state

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
@@ -45,7 +45,6 @@ function EmptyStateNoCRHCredentials() {
             message={<Trans i18nKey={'emptystate.defaultState.msg'} components={{ bold: <strong /> }} />}
             key="dcEmptyState"
             showIcon={true}
-            image={AcmEmptyStateImage.folder}
             action={
                 <AcmButton component={Link} to={NavigationPath.addCredentials}>
                     {t('emptystate.addCredential')}


### PR DESCRIPTION
related issue: https://github.com/stolostron/backlog/issues/20263
Signed-off-by: rhowingt@redhat.com <rhowingt@redhat.com>

Before:
<kbd><img width="893" alt="Screen Shot 2022-03-03 at 12 49 35 AM" src="https://user-images.githubusercontent.com/10394596/156504449-d9beade5-ddee-48a5-91fa-7159591d2217.png"></kbd>

After:
<kbd><img width="889" alt="Screen Shot 2022-03-03 at 12 49 26 AM" src="https://user-images.githubusercontent.com/10394596/156504512-428a6a9e-5ff7-4e34-a299-5b377407a004.png"></kbd>

