### PR TITLE
Bug 2060453 : cluster in creating state provides incorrect link to installation logs

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterDestroy.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterDestroy.tsx
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
-
+import { useContext } from 'react'
 import { Cluster, ClusterStatus } from '../../../../../resources'
-import { AcmButton, AcmPageProcess } from '@stolostron/ui-components'
+import { AcmButton, AcmPageProcess, Provider } from '@stolostron/ui-components'
 import { ExternalLinkAltIcon } from '@patternfly/react-icons'
 import { Trans, useTranslation } from '../../../../../lib/acm-i18next'
 import { useHistory } from 'react-router-dom'
@@ -10,11 +10,18 @@ import { configMapsState } from '../../../../../atoms'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { AddCluster } from './AddCluster'
 import { launchLogs } from './HiveNotification'
+import { CIM } from 'openshift-assisted-ui-lib'
+import { ButtonVariant } from '@patternfly/react-core'
+import { ClusterContext } from '../../../../../routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterDetails'
+
+const { LogsDownloadButton } = CIM
 
 export function ClusterDestroy(props: { isLoading: boolean; cluster?: Cluster }) {
     const { t } = useTranslation()
     const history = useHistory()
     const [configMaps] = useRecoilState(configMapsState)
+    const isHybrid = props.cluster?.provider === Provider.hybrid
+    const { agentClusterInstall } = useContext(ClusterContext)
 
     return (
         <AcmPageProcess
@@ -42,16 +49,23 @@ export function ClusterDestroy(props: { isLoading: boolean; cluster?: Cluster })
             }
             loadingSecondaryActions={
                 <>
-                    {props.cluster?.status === ClusterStatus.destroying && (
-                        <AcmButton
-                            variant="link"
-                            icon={<ExternalLinkAltIcon />}
-                            iconPosition="right"
-                            onClick={() => launchLogs(props.cluster!, configMaps)}
-                        >
-                            {t('view.logs')}
-                        </AcmButton>
-                    )}
+                    {props.cluster?.status === ClusterStatus.destroying &&
+                        (!isHybrid ? (
+                            <AcmButton
+                                variant="link"
+                                icon={<ExternalLinkAltIcon />}
+                                iconPosition="right"
+                                onClick={() => launchLogs(props.cluster!, configMaps)}
+                            >
+                                {t('view.logs')}
+                            </AcmButton>
+                        ) : (
+                            <LogsDownloadButton
+                                id="cluster-logs-button"
+                                agentClusterInstall={agentClusterInstall}
+                                variant={ButtonVariant.link}
+                            />
+                        ))}
                 </>
             }
             primaryAction={

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HiveNotification.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HiveNotification.tsx
@@ -11,7 +11,7 @@ import {
     getHivePod,
     getLatest,
 } from '../../../../../resources'
-import { AcmAlert, AcmButton } from '@stolostron/ui-components'
+import { AcmAlert, AcmButton, Provider } from '@stolostron/ui-components'
 import { AlertVariant, ButtonVariant } from '@patternfly/react-core'
 import { ExternalLinkAltIcon } from '@patternfly/react-icons'
 import { Fragment, useContext } from 'react'
@@ -47,6 +47,8 @@ export function HiveNotification() {
     const clusterProvisionStatus =
         provisionFailedCondition?.status === 'True' ? provisionFailedCondition.message : cluster!.statusMessage
 
+    const isHybrid = cluster?.provider === Provider.hybrid
+
     const provisionStatuses: string[] = [
         ClusterStatus.destroying,
         ClusterStatus.provisionfailed,
@@ -58,6 +60,13 @@ export function HiveNotification() {
     }
 
     if (cluster!.statusMessage) {
+        return null
+    }
+
+    if (
+        isHybrid &&
+        (cluster?.status === ClusterStatus.provisionfailed || cluster?.status === ClusterStatus.deprovisionfailed)
+    ) {
         return null
     }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
@@ -1,8 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
-
 import { Cluster, ClusterStatus, getLatestAnsibleJob } from '../../../../../resources'
-import { AcmButton, AcmInlineStatus, StatusType } from '@stolostron/ui-components'
-import { ExternalLinkAltIcon } from '@patternfly/react-icons'
+import { AcmButton, AcmInlineStatus, StatusType, Provider } from '@stolostron/ui-components'
+import { ExternalLinkAltIcon, DownloadIcon } from '@patternfly/react-icons'
 import { Trans, useTranslation } from '../../../../../lib/acm-i18next'
 import { Link } from 'react-router-dom'
 import { useRecoilState } from 'recoil'
@@ -10,15 +9,24 @@ import { ansibleJobState, configMapsState } from '../../../../../atoms'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { ClusterStatusMessageAlert } from './ClusterStatusMessageAlert'
 import { launchLogs, launchToYaml } from './HiveNotification'
+import { CIM } from 'openshift-assisted-ui-lib'
+import { ButtonVariant, Button } from '@patternfly/react-core'
+import { useAgentClusterInstall } from '../CreateCluster/components/assisted-installer/utils'
+
+const { LogsDownloadButton } = CIM
 
 export function StatusField(props: { cluster: Cluster }) {
     const { t } = useTranslation()
     const [configMaps] = useRecoilState(configMapsState)
     const [ansibleJobs] = useRecoilState(ansibleJobState)
     const latestJob = getLatestAnsibleJob(ansibleJobs, props.cluster?.name!)
+    const agentClusterInstall = useAgentClusterInstall({
+        name: props.cluster?.name!,
+        namespace: props.cluster?.namespace!,
+    })
 
     let type: StatusType
-
+    const isHybrid = props.cluster?.provider === Provider.hybrid
     switch (props.cluster?.status) {
         case ClusterStatus.ready:
             type = StatusType.healthy
@@ -125,19 +133,33 @@ export function StatusField(props: { cluster: Cluster }) {
         case ClusterStatus.destroying:
         case ClusterStatus.provisionfailed:
             hasAction = true
-            Action = () => (
-                <AcmButton
-                    style={{ padding: 0, fontSize: 'inherit' }}
-                    key={props.cluster.name}
-                    onClick={() => launchLogs(props.cluster, configMaps)}
-                    variant="link"
-                    role="link"
-                    icon={<ExternalLinkAltIcon />}
-                    iconPosition="right"
-                >
-                    {t('view.logs')}
-                </AcmButton>
-            )
+            if (isHybrid) {
+                Action = () => (
+                    <LogsDownloadButton
+                        Component={(props) => (
+                            <Button {...props} icon={<DownloadIcon />} iconPosition="right" isInline />
+                        )}
+                        id="cluster-logs-button"
+                        agentClusterInstall={agentClusterInstall}
+                        variant={ButtonVariant.link}
+                    />
+                )
+            } else {
+                Action = () => (
+                    <AcmButton
+                        style={{ padding: 0, fontSize: 'inherit' }}
+                        key={props.cluster.name}
+                        onClick={() => launchLogs(props.cluster, configMaps)}
+                        variant="link"
+                        role="link"
+                        icon={<ExternalLinkAltIcon />}
+                        iconPosition="right"
+                    >
+                        {t('view.logs')}
+                    </AcmButton>
+                )
+            }
+
             break
         case ClusterStatus.degraded:
             hasAction = true


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=2060453
Replace the links for assisted clusters with logs download button