### PR TITLE
Removed bad logic from OCP version check

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -457,7 +457,6 @@ export const isHidden_lt_OCP48 = (control, controlData) => {
 }
 
 export const isHidden_gt_OCP46 = (control, controlData) => {
-    const singleNodeFeatureFlag = controlData.find(({ id }) => id === 'singleNodeFeatureFlag')
     const imageSet = controlData.find(({ id }) => id === 'imageSet')
     if (imageSet && imageSet.active && imageSet.active.includes('release:4.6')) {
         return false

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -458,10 +458,7 @@ export const isHidden_lt_OCP48 = (control, controlData) => {
 
 export const isHidden_gt_OCP46 = (control, controlData) => {
     const imageSet = controlData.find(({ id }) => id === 'imageSet')
-    if (imageSet && imageSet.active && imageSet.active.includes('release:4.6')) {
-        return false
-    }
-    return true
+    return !(imageSet && imageSet.active && imageSet.active.includes('release:4.6'))
 }
 
 export const isHidden_SNO = (control, controlData) => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -459,13 +459,7 @@ export const isHidden_lt_OCP48 = (control, controlData) => {
 export const isHidden_gt_OCP46 = (control, controlData) => {
     const singleNodeFeatureFlag = controlData.find(({ id }) => id === 'singleNodeFeatureFlag')
     const imageSet = controlData.find(({ id }) => id === 'imageSet')
-    if (
-        singleNodeFeatureFlag &&
-        singleNodeFeatureFlag.active &&
-        imageSet &&
-        imageSet.active &&
-        imageSet.active.includes('release:4.6')
-    ) {
+    if (imageSet && imageSet.active && imageSet.active.includes('release:4.6')) {
         return false
     }
     return true


### PR DESCRIPTION
Regarding: 
- https://github.com/stolostron/backlog/issues/17837
- https://bugzilla.redhat.com/show_bug.cgi?id=2056610


Removed unneeded logic interfering with check on Openshift version. When SNO was disabled, check would always return true. 