### PR TITLE
Discovery operator - ocp 4.6 is no longer supported in 2.5

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/DiscoveryConfig.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/DiscoveryConfig.tsx
@@ -48,7 +48,7 @@ import {
     Secret,
 } from '../../../../../resources'
 
-const discoveryVersions = ['4.6', '4.7', '4.8', '4.9']
+const discoveryVersions = ['4.7', '4.8', '4.9', '4.10']
 
 export default function DiscoveryConfigPage() {
     const { t } = useTranslation()


### PR DESCRIPTION
Signed-off-by: eemurphy <erinmurphy897@gmail.com>
[stolostron/backlog#20594](https://github.com/stolostron/backlog/issues/20594)