### PR TITLE
fix policy edit crash

### DIFF
--- a/frontend/src/atoms.tsx
+++ b/frontend/src/atoms.tsx
@@ -516,5 +516,8 @@ export function LoadData(props: { children?: ReactNode }) {
 
 export function usePolicies() {
     const [policies] = useRecoilState(policiesState)
-    return policies.filter((policy) => !policy.metadata.labels?.['policy.open-cluster-management.io/root-policy'])
+    return useMemo(
+        () => policies.filter((policy) => !policy.metadata.labels?.['policy.open-cluster-management.io/root-policy']),
+        [policies]
+    )
 }


### PR DESCRIPTION
Signed-off-by: James Talton <jtalton@redhat.com>

https://github.com/stolostron/backlog/issues/20729

Basically the react hook always changed, which caused other useEffects to get into infinity loops.
useMemo solves this.