### PR TITLE
RHV provider label detection logic added

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -389,6 +389,7 @@ export function getProvider(
         case 'BAREMETAL':
             provider = Provider.baremetal
             break
+        case 'VMWARE':
         case 'VSPHERE':
             provider = Provider.vmware
             break

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -392,6 +392,9 @@ export function getProvider(
         case 'VSPHERE':
             provider = Provider.vmware
             break
+        case 'RHV':
+            provider = Provider.redhatvirtualization
+            break
         case 'AUTO-DETECT':
             provider = undefined
             break

--- a/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
@@ -13,22 +13,7 @@ import { nockGet } from '../../../lib/nock-util'
 import { wait, waitForNocks } from '../../../lib/test-util'
 import { ManagedCluster, ManagedClusterApiVersion, ManagedClusterKind, Policy } from '../../../resources'
 import { SearchResultCountDocument, SearchResultItemsDocument } from '../Search/search-sdk/search-sdk'
-import OverviewPage, { mapProviderFromLabel } from './OverviewPage'
-
-it('should responsed with correct value for mapProviderFromLabel function', () => {
-    expect(mapProviderFromLabel('Amazon')).toEqual('aws')
-    expect(mapProviderFromLabel('Azure')).toEqual('azr')
-    expect(mapProviderFromLabel('Baremetal')).toEqual('bmc')
-    expect(mapProviderFromLabel('Google')).toEqual('gcp')
-    expect(mapProviderFromLabel('IBM')).toEqual('ibm')
-    expect(mapProviderFromLabel('IBMPowerPlatform')).toEqual('ibmpower')
-    expect(mapProviderFromLabel('IBMZPlatform')).toEqual('ibmz')
-    expect(mapProviderFromLabel('RedHat')).toEqual('rhocm')
-    expect(mapProviderFromLabel('VMware')).toEqual('vmw')
-    expect(mapProviderFromLabel('VSphere')).toEqual('vmw')
-    expect(mapProviderFromLabel('vSphere')).toEqual('vmw')
-    expect(mapProviderFromLabel('other')).toEqual('other')
-})
+import OverviewPage from './OverviewPage'
 
 const getAddonRequest = {
     apiVersion: 'view.open-cluster-management.io/v1beta1',

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -38,41 +38,14 @@ import { ClusterManagementAddOn } from '../../../resources/cluster-management-ad
 import { fireManagedClusterView } from '../../../resources/managedclusterview'
 import { searchClient } from '../Search/search-sdk/search-client'
 import { useSearchResultCountLazyQuery, useSearchResultItemsLazyQuery } from '../Search/search-sdk/search-sdk'
-
-export function mapProviderFromLabel(provider: string): Provider {
-    switch (provider.toLowerCase()) {
-        case 'amazon':
-            return Provider.aws
-        case 'azure':
-            return Provider.azure
-        case 'baremetal':
-            return Provider.baremetal
-        case 'google':
-            return Provider.gcp
-        case 'ibm':
-            return Provider.ibm
-        case 'ibmpowerplatform':
-            return Provider.ibmpower
-        case 'ibmzplatform':
-            return Provider.ibmz
-        case 'redhat':
-            return Provider.redhatcloud
-        case 'vmware':
-        case 'vsphere':
-            return Provider.vmware
-        case 'openstack':
-            return Provider.openstack
-        default:
-            return Provider.other
-    }
-}
+import { getProvider } from '../../../resources'
 
 function getClusterSummary(clusters: any, selectedCloud: string, setSelectedCloud: Dispatch<SetStateAction<string>>) {
     const clusterSummary = clusters.reduce(
         (prev: any, curr: any) => {
             // Data for Providers section.
             const cloudLabel = curr.metadata?.labels?.cloud || ''
-            const cloud = mapProviderFromLabel(cloudLabel)
+            const cloud = getProvider(curr) || Provider.other
             const provider = prev.providers.find((p: any) => p.provider === cloud)
             if (provider) {
                 provider.clusterCount = provider.clusterCount + 1


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

Regarding: https://github.com/stolostron/backlog/issues/19273

ManagedClusterInfos supports RHV with this PR: https://github.com/stolostron/multicloud-operators-foundation/pull/457/files#diff-1464a4dd52c947d03556e70191424b21fd8f8a4fe2ea7abe2ce0c145aeaf4ce3R274-R279

The CloudVendor field is copied to the the 'cloud' resource label here: https://github.com/stolostron/multicloud-operators-foundation/blob/b852c6001862038284f080113fb0c7479726f0c1/pkg/controllers/autodetect/autodetect_controller.go#L95-L99