### PR TITLE
BZ2065276: Enable adding hosts in more cluster states than just pendingimport

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
@@ -122,7 +122,10 @@ export function getClusterActions(cluster: Cluster) {
     }
 
     if (
-        !(cluster.provider === Provider.hybrid && cluster.status === ClusterStatus.pendingimport) ||
+        !(
+            cluster.provider === Provider.hybrid &&
+            [ClusterStatus.pendingimport, ClusterStatus.ready, ClusterStatus.unknown].includes(cluster.status)
+        ) ||
         cluster.isSNOCluster
     ) {
         actionIds = actionIds.filter((id) => id !== 'ai-scale-up')


### PR DESCRIPTION
Scale up the cluster is possible in pendingimport, ready and unknown
cluster states.

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>