### PR TITLE
Bug 2064387: UI when trying to delete an infraenv during installation there is no alert saying we can't

### DIFF
--- a/frontend/src/routes/Infrastructure/InfraEnvironments/InfraEnvironmentsPage.tsx
+++ b/frontend/src/routes/Infrastructure/InfraEnvironments/InfraEnvironmentsPage.tsx
@@ -41,7 +41,27 @@ const deleteInfraEnv = (infraEnv: InfraEnvK8sResource) => {
             },
         })
     }
-    return deleteResources(resources)
+    const deleteResourcesResult = deleteResources(resources)
+
+    return {
+        promise: new Promise((resolve, reject) => {
+            deleteResourcesResult.promise.then((promisesSettledResult) => {
+                if (promisesSettledResult[0]?.status === 'rejected') {
+                    const error = promisesSettledResult[0].reason
+                    if (error) {
+                        reject(promisesSettledResult[0].reason)
+                        return
+                    }
+                }
+                if (promisesSettledResult[1]?.status === 'rejected') {
+                    reject(promisesSettledResult[1].reason)
+                    return
+                }
+                resolve(promisesSettledResult)
+            })
+        }),
+        abort: deleteResourcesResult.abort,
+    }
 }
 
 const InfraEnvironmentsPage: React.FC = () => {


### PR DESCRIPTION
Related to: https://bugzilla.redhat.com/show_bug.cgi?id=2064387