### PR TITLE
BZ2066324 Show Hosts discovery hint link above infraenv hosts list

### DIFF
--- a/frontend/src/routes/Infrastructure/InfraEnvironments/Details/HostsTab.tsx
+++ b/frontend/src/routes/Infrastructure/InfraEnvironments/Details/HostsTab.tsx
@@ -24,7 +24,14 @@ import {
 } from '../../Clusters/ManagedClusters/CreateCluster/components/assisted-installer/utils'
 import { isBMPlatform } from '../utils'
 
-const { InfraEnvAgentTable, EditBMHModal, getAgentsHostsNames, AgentAlerts } = CIM
+const {
+    HostsNotShowingLink,
+    InfraEnvAgentTable,
+    EditBMHModal,
+    getAgentsHostsNames,
+    AgentAlerts,
+    DiscoveryTroubleshootingModal,
+} = CIM
 
 const canEditHost = (agent: CIM.AgentK8sResource) => !!agent
 
@@ -38,6 +45,7 @@ type HostsTabProps = {
 const HostsTab: React.FC<HostsTabProps> = ({ infraEnv, infraAgents, bareMetalHosts, aiConfigMap }) => {
     const [editBMH, setEditBMH] = useState<CIM.BareMetalHostK8sResource>()
     const [editAgent, setEditAgent] = useState<CIM.AgentK8sResource | undefined>()
+    const [isDiscoveryHintModalOpen, setDiscoveryHintModalOpen] = useState(false)
     const [bulkModalProps, setBulkModalProps] = useState<IBulkActionModelProps<CIM.AgentK8sResource> | { open: false }>(
         { open: false }
     )
@@ -64,6 +72,22 @@ const HostsTab: React.FC<HostsTabProps> = ({ infraEnv, infraAgents, bareMetalHos
                         docVersion={DOC_VERSION}
                         aiConfigMap={aiConfigMap}
                     />
+                    {!!infraAgents.length && (
+                        <Card isPlain isCompact>
+                            <CardBody>
+                                <HostsNotShowingLink
+                                    key="hosts-not-showing"
+                                    setDiscoveryHintModalOpen={setDiscoveryHintModalOpen}
+                                />
+                                {isDiscoveryHintModalOpen && (
+                                    <DiscoveryTroubleshootingModal
+                                        isOpen={isDiscoveryHintModalOpen}
+                                        setDiscoveryHintModalOpen={setDiscoveryHintModalOpen}
+                                    />
+                                )}
+                            </CardBody>
+                        </Card>
+                    )}
                     <Card>
                         <CardBody>
                             <InfraEnvAgentTable


### PR DESCRIPTION
- show the link only if there are some hosts
- if no hosts are discovered yet, the link is included in
  hosts table empty state

<img width="1065" alt="Screenshot 2022-03-25 at 10 48 55" src="https://user-images.githubusercontent.com/1121740/160098136-40f79f83-ea7d-4e5c-b1db-b2c5719fea42.png">

<img width="1065" alt="Screenshot 2022-03-25 at 10 49 26" src="https://user-images.githubusercontent.com/1121740/160098169-6202b8a6-412e-423d-91f0-3bfb3248ffe4.png">


Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>