### PR TITLE
create/edit policy navigation

### DIFF
--- a/frontend/src/routes/Governance/components/PolicyActionDropdown.tsx
+++ b/frontend/src/routes/Governance/components/PolicyActionDropdown.tsx
@@ -241,11 +241,13 @@ export function PolicyActionDropdown(props: {
                 tooltip: t('Edit policy'),
                 addSeparator: true,
                 click: (item: PolicyTableItem) => {
-                    history.push(
-                        NavigationPath.editPolicy
-                            .replace(':namespace', item.policy.metadata.namespace!)
-                            .replace(':name', item.policy.metadata.name!)
-                    )
+                    let path = NavigationPath.editPolicy
+                        .replace(':namespace', item.policy.metadata.namespace!)
+                        .replace(':name', item.policy.metadata.name!)
+                    if (props.isKebab) {
+                        path += '?context=policies'
+                    }
+                    history.push(path)
                 },
                 rbac: [rbacPatch(PolicyDefinition, item.policy.metadata.namespace)],
             },
@@ -268,6 +270,7 @@ export function PolicyActionDropdown(props: {
             item.policy.metadata.namespace,
             item.policy.spec.disabled,
             item.policy.spec.remediationAction,
+            props.isKebab,
             setModal,
             t,
         ]

--- a/frontend/src/routes/Governance/policies/CreatePolicy.tsx
+++ b/frontend/src/routes/Governance/policies/CreatePolicy.tsx
@@ -48,8 +48,12 @@ export function CreatePolicy() {
                             type: 'success',
                             autoClose: true,
                         })
+                        history.push(
+                            NavigationPath.policyDetails
+                                .replace(':namespace', policy.metadata?.namespace ?? '')
+                                .replace(':name', policy.metadata?.name ?? '')
+                        )
                     }
-                    history.push(NavigationPath.policies)
                 })
             }}
         />


### PR DESCRIPTION
Signed-off-by: James Talton <jtalton@redhat.com>
https://github.com/stolostron/backlog/issues/20959

Tables save/restore the last sort state the user selected.
This is so that the user can control the table sorting and it is a consistent experience.

Create should take the user to the detail view for the item upon submit.
Edit should take the user to with the table view or the details view based on where the user initiated the edit action.

This should be consistent across ACM. It may not have been so in the past, but we need to standardize on consistency.