### PR TITLE
Hide AWS Gov Regions (2.4.5)

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
@@ -53,7 +53,7 @@ const mo48Cpu64Gib = '48 vCPU, 384 GiB RAM - Memory Optimized'
 const mo64Cpu64Gib = '64 vCPU, 512 GiB RAM - Memory Optimized'
 const mo96Cpu64Gib = '96 vCPU, 768 GiB RAM - Memory Optimized'
 
-export const awsRegions = {
+export let awsRegions = {
     'us-east-1': [usEast1a, usEast1b, usEast1c, usEast1d, usEast1e, usEast1f],
     'us-east-2': ['us-east-2a', 'us-east-2b', 'us-east-2c'],
     'us-west-1': ['us-west-1a', 'us-west-1c'],
@@ -75,6 +75,9 @@ export const awsRegions = {
     'eu-west-3': ['eu-west-3a', 'eu-west-3b', 'eu-west-3c'],
     'me-south-1': ['me-south-1a', 'me-south-1b', 'me-south-1c'],
     'sa-east-1': ['sa-east-1a', 'sa-east-1b', 'sa-east-1c'],
+}
+
+export const awsGovRegions = {
     'us-gov-west-1': ['us-gov-west-1a', 'us-gov-west-1b', 'us-gov-west-1c'],
     'us-gov-east-1': ['us-gov-east-1a', 'us-gov-east-1b', 'us-gov-east-1c'],
 }
@@ -91,6 +94,22 @@ const setAWSZones = (control, controlData) => {
 
     setZones('masterPool', 'masterZones')
     setZones('workerPools', 'workerZones')
+}
+
+export const getControlDataAWS = (includeAutomation = true, includeAwsPrivate = true, includeSno = false) => {
+    if (includeSno) addSnoText(controlDataAWS)
+    let controlData = [...controlDataAWS]
+    if (includeAutomation) controlData.push(...automationControlData)
+
+    if (includeAwsPrivate) {
+        controlData.push(...awsPrivateControlData)
+        const regionObject = controlData.find((object) => object.id === 'region')
+        if (regionObject && regionObject.available) {
+            awsRegions = { ...awsRegions, ...awsGovRegions }
+            regionObject.available = regionObject.available.concat(Object.keys(awsRegions))
+        }
+    }
+    return controlData
 }
 
 const AWSmasterInstanceTypes = [
@@ -593,14 +612,6 @@ export const AWSworkerInstanceTypes = [
         ],
     },
 ]
-
-export const getControlDataAWS = (includeAutomation = true, includeAwsPrivate = true, includeSno = false) => {
-    if (includeSno) addSnoText(controlDataAWS)
-    let controlData = [...controlDataAWS]
-    if (includeAwsPrivate) controlData.push(...awsPrivateControlData)
-    if (includeAutomation) controlData.push(...automationControlData)
-    return controlData
-}
 
 const controlDataAWS = [
     ////////////////////////////////////////////////////////////////////////////////////

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
@@ -99,8 +99,6 @@ const setAWSZones = (control, controlData) => {
 export const getControlDataAWS = (includeAutomation = true, includeAwsPrivate = true, includeSno = false) => {
     if (includeSno) addSnoText(controlDataAWS)
     let controlData = [...controlDataAWS]
-    if (includeAutomation) controlData.push(...automationControlData)
-
     if (includeAwsPrivate) {
         controlData.push(...awsPrivateControlData)
         const regionObject = controlData.find((object) => object.id === 'region')
@@ -109,6 +107,7 @@ export const getControlDataAWS = (includeAutomation = true, includeAwsPrivate = 
             regionObject.available = regionObject.available.concat(Object.keys(awsRegions))
         }
     }
+    if (includeAutomation) controlData.push(...automationControlData)
     return controlData
 }
 


### PR DESCRIPTION
Regarding: https://github.com/stolostron/backlog/issues/20485

- AWS Gov regions added when config enables AWS Private (PR for 2.4)