### PR TITLE
disable view details link for view-user in policy results tab

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
@@ -1,10 +1,12 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { render } from '@testing-library/react'
+import nock from 'nock'
 import { MemoryRouter } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
 import { policiesState } from '../../../../atoms'
+import { nockIgnoreRBAC } from '../../../../lib/nock-util'
 import { waitForText } from '../../../../lib/test-util'
-import { Policy } from '../../../../resources'
+import { Policy, Project, ProjectApiVersion, ProjectKind } from '../../../../resources'
 import PolicyDetailsResults from './PolicyDetailsResults'
 
 const rootPolicy: Policy = {
@@ -96,7 +98,20 @@ const policy0: Policy = {
 
 export const mockPolicy: Policy[] = [rootPolicy, policy0]
 
+const mockProjects: Project[] = ['namespace1', 'namespace2', 'namespace3'].map((name) => ({
+    apiVersion: ProjectApiVersion,
+    kind: ProjectKind,
+    metadata: { name },
+}))
+
 describe('Policy Details Results', () => {
+    beforeEach(async () => {
+        nockIgnoreRBAC()
+        nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
+            .persist()
+            .get('/apis/project.openshift.io/v1/projects')
+            .reply(200, mockProjects)
+    })
     test('Should render Policy Details Results Page content correctly', async () => {
         render(
             <RecoilRoot

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -1,16 +1,17 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { PageSection, Title } from '@patternfly/react-core'
+import { PageSection, Title, Tooltip } from '@patternfly/react-core'
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
 import { AcmTable, AcmTablePaginationContextProvider, compareStrings } from '@stolostron/ui-components'
 import moment from 'moment'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useRecoilState } from 'recoil'
 import { policiesState } from '../../../../atoms'
 import { useTranslation } from '../../../../lib/acm-i18next'
+import { checkPermission, rbacCreate } from '../../../../lib/rbac-util'
 import { transformBrowserUrlToFilterPresets } from '../../../../lib/urlQuery'
 import { NavigationPath } from '../../../../NavigationPath'
-import { getGroupFromApiVersion, Policy, PolicyStatusDetails } from '../../../../resources'
+import { getGroupFromApiVersion, Policy, PolicyDefinition, PolicyStatusDetails } from '../../../../resources'
 
 interface resultsTableData {
     templateName: string
@@ -30,6 +31,11 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
     const filterPresets = transformBrowserUrlToFilterPresets(window.location.search)
     const { policy } = props
     const [policies] = useRecoilState(policiesState)
+    const [canCreatePolicy, setCanCreatePolicy] = useState<boolean>(false)
+
+    useEffect(() => {
+        checkPermission(rbacCreate(PolicyDefinition), setCanCreatePolicy)
+    }, [])
 
     const policiesDeployedOnCluster: resultsTableData[] = useMemo(() => {
         const policyName = policy.metadata.name ?? ''
@@ -164,7 +170,17 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
                             <div>
                                 {/* message may need to be limited to 300 chars? */}
                                 {prunedMessage}{' '}
-                                {templateDetailURL && <Link to={templateDetailURL}>{t('View details')}</Link>}
+                                {canCreatePolicy ? (
+                                    templateDetailURL && (
+                                        <span>
+                                            -<Link to={templateDetailURL}>{` ${t('View details')}`}</Link>
+                                        </span>
+                                    )
+                                ) : (
+                                    <Tooltip content={t('rbac.unauthorized')}>
+                                        <span className="link-disabled">{`- ${t('View details')}`}</span>
+                                    </Tooltip>
+                                )}
                             </div>
                         )
                     }
@@ -197,7 +213,7 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
                 },
             },
         ],
-        [t]
+        [canCreatePolicy, t]
     )
 
     return (


### PR DESCRIPTION
Signed-off-by: rhowingt@redhat.com <rhowingt@redhat.com>

Related Issue: https://github.com/stolostron/backlog/issues/21290

Has permission:
<kbd>![Screen Shot 2022-04-05 at 10 10 22 AM](https://user-images.githubusercontent.com/10394596/161777962-24380759-a4e2-411c-925a-f1f5aac8e0da.png)</kbd>

No Permission:
<kbd><img width="1358" alt="Screen Shot 2022-04-05 at 10 10 36 AM" src="https://user-images.githubusercontent.com/10394596/161778049-85d1d6fd-4ef5-4899-a54a-6499a31265ba.png"></kbd>