### PR TITLE
Let ManagedCluster cloud label take precedence over cluster claim

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -353,7 +353,7 @@ export function getProvider(
     let providerLabel =
         hivePlatformLabel && hivePlatformLabel !== 'unknown'
             ? hivePlatformLabel
-            : platformClusterClaim?.value ?? cloudLabel ?? ''
+            : cloudLabel ?? platformClusterClaim?.value ?? ''
     providerLabel = providerLabel.toUpperCase()
 
     let provider: Provider | undefined


### PR DESCRIPTION
Signed-off-by: Sho Weimer <sweimer@redhat.com>