### PR TITLE
When loading state is false, stop re-attempting fetch

### DIFF
--- a/frontend/src/routes/Applications/CreateApplication/Subscription/controlData/utils.js
+++ b/frontend/src/routes/Applications/CreateApplication/Subscription/controlData/utils.js
@@ -609,6 +609,7 @@ export const setAvailableSecrets = (control, result) => {
         }
     } else {
         control.isLoading = loading
+        if (!loading) control.isLoaded = true
     }
 }
 

--- a/frontend/src/routes/Applications/CreateApplication/Subscription/controlData/utils.js
+++ b/frontend/src/routes/Applications/CreateApplication/Subscription/controlData/utils.js
@@ -609,7 +609,9 @@ export const setAvailableSecrets = (control, result) => {
         }
     } else {
         control.isLoading = loading
-        if (!loading) control.isLoaded = true
+        if (!loading) {
+            control.isLoaded = true
+        }
     }
 }
 


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>
regarding: https://github.com/stolostron/backlog/issues/20510

@jeswanke Would you mind reviewing this? I tested to see that we still fetch the corresponding secret when choosing a previously used repo, and checked that the fetch is called once, but since this keeps coming back we should probably be thorough. Also Thanks for the break down on this issue back in March. Referring to those notes helped me with the fix this time. 

