### PR TITLE
update moment, nconf via temptifly

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19708,9 +19708,9 @@
             "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
         },
         "temptifly": {
-            "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/temptifly/-/temptifly-0.5.9.tgz",
-            "integrity": "sha512-BS9XBHVEldds9bsFivt7+R355DVArWSMFPS/xJMFEyVvlMHJQ1Z0ulanKm0oYy9wU9EO3fwJhqZPQw9fbZ0OKw==",
+            "version": "0.3.60",
+            "resolved": "https://registry.npmjs.org/temptifly/-/temptifly-0.3.60.tgz",
+            "integrity": "sha512-097fGTE1T2qGObDFzgkmYl5w1+aYjxD9VNBrN1lpCseGB9X4OeGLO42QpoFwdJQXCFX+muoBM98V2c75fpdmdA==",
             "requires": {
                 "@loadable/component": "^5.14.1",
                 "apollo-client": "^2.2.8",
@@ -21519,8 +21519,7 @@
                     "dependencies": {
                         "ansi-regex": {
                             "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                            "resolved": ""
                         },
                         "strip-ansi": {
                             "version": "5.2.0",
@@ -21727,8 +21726,7 @@
                     "dependencies": {
                         "ansi-regex": {
                             "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                            "resolved": ""
                         },
                         "strip-ansi": {
                             "version": "5.2.0",
@@ -21777,8 +21775,7 @@
                     "dependencies": {
                         "ansi-regex": {
                             "version": "4.1.0",
-                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                            "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+                            "resolved": ""
                         },
                         "strip-ansi": {
                             "version": "5.2.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3789,9 +3789,9 @@
             }
         },
         "@loadable/component": {
-            "version": "5.15.0",
-            "resolved": "https://registry.npmjs.org/@loadable/component/-/component-5.15.0.tgz",
-            "integrity": "sha512-g63rQzypPOZi0BeGsK4ST2MYhsFR+i7bhL8k/McUoWDNMDuTTdUlQ2GACKxqh5sI/dNC/6nVoPrycMnSylnAgQ==",
+            "version": "5.15.2",
+            "resolved": "https://registry.npmjs.org/@loadable/component/-/component-5.15.2.tgz",
+            "integrity": "sha512-ryFAZOX5P2vFkUdzaAtTG88IGnr9qxSdvLRvJySXcUA4B4xVWurUNADu3AnKPksxOZajljqTrDEDcYjeL4lvLw==",
             "requires": {
                 "@babel/runtime": "^7.7.7",
                 "hoist-non-react-statics": "^3.3.1",
@@ -13820,9 +13820,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "minipass": {
             "version": "3.1.6",
@@ -13915,9 +13915,9 @@
             "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         },
         "moment": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-            "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+            "version": "2.29.3",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
+            "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
         },
         "monaco-editor": {
             "version": "0.20.0",
@@ -14055,9 +14055,9 @@
             "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
         },
         "nconf": {
-            "version": "0.11.3",
-            "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.11.3.tgz",
-            "integrity": "sha512-iYsAuDS9pzjVMGIzJrGE0Vk3Eh8r/suJanRAnWGBd29rVS2XtSgzcAo5l6asV3e4hH2idVONHirg1efoBOslBg==",
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.11.4.tgz",
+            "integrity": "sha512-YaDR846q11JnG1vTrhJ0QIlhiGY6+W1bgWtReG9SS3vkTl3AoNwFvUItdhG6/ZjGCfWpUVuRTNEBTDAQ3nWhGw==",
             "requires": {
                 "async": "^1.4.0",
                 "ini": "^2.0.0",
@@ -14998,9 +14998,9 @@
             },
             "dependencies": {
                 "async": {
-                    "version": "2.6.3",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "version": "2.6.4",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+                    "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
                     "requires": {
                         "lodash": "^4.17.14"
                     }
@@ -19708,9 +19708,9 @@
             "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
         },
         "temptifly": {
-            "version": "0.3.60",
-            "resolved": "https://registry.npmjs.org/temptifly/-/temptifly-0.3.60.tgz",
-            "integrity": "sha512-097fGTE1T2qGObDFzgkmYl5w1+aYjxD9VNBrN1lpCseGB9X4OeGLO42QpoFwdJQXCFX+muoBM98V2c75fpdmdA==",
+            "version": "0.5.9",
+            "resolved": "https://registry.npmjs.org/temptifly/-/temptifly-0.5.9.tgz",
+            "integrity": "sha512-BS9XBHVEldds9bsFivt7+R355DVArWSMFPS/xJMFEyVvlMHJQ1Z0ulanKm0oYy9wU9EO3fwJhqZPQw9fbZ0OKw==",
             "requires": {
                 "@loadable/component": "^5.14.1",
                 "apollo-client": "^2.2.8",
@@ -20463,9 +20463,9 @@
             }
         },
         "url-parse": {
-            "version": "1.5.7",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.7.tgz",
-            "integrity": "sha512-HxWkieX+STA38EDk7CE9MEryFeHCKzgagxlGvsdS7WBImq9Mk+PGwiT56w82WI3aicwJA8REp42Cxo98c8FZMA==",
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "requires": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "^4.0.3",
         "recoil": "^0.3.1",
-        "temptifly": "^0.5.9",
+        "temptifly": "^0.3.60",
         "typescript": "^4.2.4",
         "yaml": "^1.10.2"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
         "i18next-http-backend": "^1.3.2",
         "js-yaml": "^3.14.1",
         "lodash": "^4.17.21",
-        "moment": "^2.29.1",
+        "moment": "^2.29.3",
         "monaco-editor": "^0.20.0",
         "monaco-editor-webpack-plugin": "^1.9.0",
         "react": "^17.0.2",
@@ -35,7 +35,7 @@
         "react-router-dom": "^5.2.0",
         "react-scripts": "^4.0.3",
         "recoil": "^0.3.1",
-        "temptifly": "^0.3.60",
+        "temptifly": "^0.5.9",
         "typescript": "^4.2.4",
         "yaml": "^1.10.2"
     },


### PR DESCRIPTION
Signed-off-by: rhowingt@redhat.com <rhowingt@redhat.com>

https://github.com/stolostron/backlog/issues/21680
https://github.com/stolostron/backlog/issues/21871

Ran `npm audit fix` to update

Manually updated `temptifly` to bump `nconf` version from `0.11.3` to `0.11.4`

Before
```
@stolostron/console-frontend@0.0.1 
└─┬ temptifly@0.3.60
  └── nconf@0.11.3 
├─┬ @stolostron/ui-components@0.180.2
│ └── moment@2.29.1  deduped
├─┬ @types/moment@2.13.0
│ └── moment@2.29.1  deduped
└── moment@2.29.1 
```

After
```
@stolostron/console-frontend@0.0.1
└─┬ temptifly@0.3.60
  └── nconf@0.11.4 
├─┬ @stolostron/ui-components@0.180.2
│ └── moment@2.29.3  deduped
├─┬ @types/moment@2.13.0
│ └── moment@2.29.3  deduped
└── moment@2.29.3 
```