### PR TITLE
Allow cluster creation with no ClusterImageSets

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1458,7 +1458,6 @@
     "managed.hibernate.plural": "Hibernate clusters",
     "managed.import": "Import cluster",
     "managed.importCluster": "Import cluster",
-    "managed.noClusterImages": "It is not possible to create a cluster when there is no cluster image available. Contact your administrator to define it.",
     "managed.removeSet": "Remove from cluster set",
     "managed.resume": "Resume cluster",
     "managed.resume.plural": "Resume clusters",

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/templates/hive-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/templates/hive-template.hbs
@@ -78,6 +78,8 @@ apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
   name: {{{clusterImageSetName}}}
+  labels:
+    visible: 'true'
 spec:
   releaseImage: {{{clusterReleaseImage}}}
 {{/if}}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/hive-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/hive-template.hbs
@@ -210,6 +210,8 @@ apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
   name: {{{clusterImageSetName}}}
+  labels:
+    visible: 'true'
 spec:
   releaseImage: {{{clusterReleaseImage}}}
 {{/if}}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -22,8 +22,8 @@ import {
 } from '@stolostron/ui-components'
 import { Fragment, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { Link, useHistory } from 'react-router-dom'
-import { useRecoilState, useRecoilValue } from 'recoil'
-import { clusterCuratorsState, clusterImageSetsState, clusterManagementAddonsState } from '../../../../atoms'
+import { useRecoilState } from 'recoil'
+import { clusterCuratorsState, clusterManagementAddonsState } from '../../../../atoms'
 import { BulkActionModel, errorIsNot, IBulkActionModelProps } from '../../../../components/BulkActionModel'
 import { Trans, useTranslation } from '../../../../lib/acm-i18next'
 import { deleteCluster, detachCluster } from '../../../../lib/delete-cluster'
@@ -65,7 +65,6 @@ function InfraEnvLinkButton() {
 export default function ManagedClusters() {
     const { t } = useTranslation()
     const alertContext = useContext(AcmAlertContext)
-    const clusterImageSets = useRecoilValue(clusterImageSetsState)
     let clusters = useAllClusters()
     clusters = clusters.filter((cluster) => {
         // don't show clusters in cluster pools in table
@@ -109,8 +108,8 @@ export default function ManagedClusters() {
                                     id: 'createCluster',
                                     title: t('managed.createCluster'),
                                     click: () => history.push(NavigationPath.createCluster),
-                                    isDisabled: !canCreateCluster || !clusterImageSets.length,
-                                    tooltip: !canCreateCluster ? t('rbac.unauthorized') : t('managed.noClusterImages'),
+                                    isDisabled: !canCreateCluster,
+                                    tooltip: t('rbac.unauthorized'),
                                     variant: ButtonVariant.primary,
                                 },
                                 {


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/21673
https://github.com/stolostron/backlog/issues/21831

This reverts https://github.com/stolostron/console/pull/1543 because it is not applicable for non-CIM cluster creation. In the Hive-based cluster and cluster pool creation, we allow the user to enter a release image URL and automatically create a ClusterImageSet.

This PR also labels that ClusterImageSet so that it is visible in the UI for subsequent uses of the wizards.

We may want to adopt the same approach for the CIM wizard.