### PR TITLE
Add the window.getEditorValue method

### DIFF
--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -167,8 +167,16 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
         )
 
         editorRef.current = editor
+        window.getEditorValue = () => editor.getValue()
         monacoRef.current = monaco
     }
+
+    // clear our the getEditorValue method
+    useEffect(() => {
+        return () => {
+            window.getEditorValue = undefined
+        }
+    }, [])
 
     useEffect(() => {
         monacoRef.current.editor.setTheme(readonly ? 'readonly-resource-editor' : 'resource-editor')

--- a/frontend/src/globals.d.ts
+++ b/frontend/src/globals.d.ts
@@ -3,5 +3,6 @@
 export declare global {
     interface Window {
         acmConsolePluginProxyPath: string
+        getEditorValue: any
     }
 }


### PR DESCRIPTION
Without having access to the Monaco Editor's API, it's very difficult to
get the entire text of the editor in Cypress based tests. Exposing the
Monaco Editor's getValue method makes this much easier without
exposing any additional APIs that may be of concern.