### PR TITLE
Fix node status and Argo editor link

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.data.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.data.js
@@ -33,10 +33,6 @@ export const genericNodeYellowNotDefined = {
     type: 'service',
     specs: {
         clustersNames: ['feng'],
-        serviceModel: {
-            'mortgage-app-service-feng': {},
-            'mortgage-app-service-cluster1': {},
-        },
         raw: {
             apiVersion: 'apps/v1',
             kind: 'Service',
@@ -510,16 +506,6 @@ export const deploymentNodeRed = {
     specs: {
         clustersNames: ['feng'],
         pulse: 'red',
-        deploymentModel: {
-            'mortgage-app-deploy-feng': [
-                {
-                    namespace: 'default',
-                    ready: 2,
-                    desired: 3,
-                },
-            ],
-            'mortgage-app-deploy-cluster1': [],
-        },
     },
 }
 
@@ -561,16 +547,6 @@ export const deploymentNodeYellow4 = {
             metadata: {
                 namespace: 'default',
             },
-        },
-        deploymentModel: {
-            'mortgage-app-deployable-feng': [
-                {
-                    namespace: 'default',
-                    ready: 2,
-                    desired: 3,
-                },
-            ],
-            'mortgage-app-deploy-cluster1': [],
         },
     },
 }
@@ -616,16 +592,6 @@ export const deploymentNodeYellow2 = {
                 replicas: 3,
             },
         },
-        deploymentModel: {
-            'mortgage-app-deploy-feng': [
-                {
-                    namespace: 'default',
-                    ready: 3,
-                    desired: 3,
-                },
-            ],
-            'mortgage-app-deploy-cluster1': [],
-        },
     },
 }
 
@@ -662,16 +628,6 @@ export const deploymentNodeNoPODS = {
     type: 'deployment',
     specs: {
         clustersNames: ['feng'],
-        deploymentModel: {
-            'mortgage-app-deploy-feng': [
-                {
-                    namespace: 'default',
-                    ready: 2,
-                    desired: 3,
-                },
-            ],
-            'mortgage-app-deploy-cluster1': [],
-        },
         raw: {
             apiVersion: 'apps/v1',
             kind: 'Deployment',
@@ -824,16 +780,6 @@ export const deploymentNodeNoPODSNoRes = {
     type: 'deployment',
     specs: {
         clustersNames: ['feng4', 'cluster1', 'cluster2'],
-        deploymentModel: {
-            'mortgage-app-deploy-feng4': [
-                {
-                    namespace: 'default',
-                    ready: 2,
-                    desired: 3,
-                },
-            ],
-            'mortgage-app-deploy-cluster1': [],
-        },
         raw: {
             apiVersion: 'apps/v1',
             kind: 'Deployment',
@@ -1181,16 +1127,6 @@ export const deploymentNodeNoPodModel = {
     type: 'deployment',
     specs: {
         clustersNames: ['feng'],
-        deploymentModel: {
-            'mortgage-app-deploy-feng': [
-                {
-                    namespace: 'default',
-                    ready: 3,
-                    desired: 3,
-                },
-            ],
-            'mortgage-app-deploy-cluster1': [],
-        },
         raw: {
             apiVersion: 'apps/v1',
             kind: 'Deployment',
@@ -1277,10 +1213,6 @@ export const genericNodeYellow = {
     type: 'service',
     specs: {
         clustersNames: ['feng'],
-        serviceModel: {
-            'mortgage-app-service-feng': {},
-            'mortgage-app-service-cluster1': {},
-        },
         raw: {
             apiVersion: 'apps/v1',
             kind: 'Service',

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.js
@@ -378,6 +378,7 @@ const getPulseStatusForGenericNode = (node, t) => {
 
     //go through all clusters to make sure all pods are counted, even if they are not deployed there
     let highestPulse = 3
+    let pendingPulseCount = 0
     clusterNames.forEach((clusterName) => {
         clusterName = R.trim(clusterName)
         //get target cluster namespaces
@@ -390,7 +391,8 @@ const getPulseStatusForGenericNode = (node, t) => {
         targetNSList.forEach((targetNS) => {
             const resourceItems = _.filter(resourcesForCluster, (obj) => _.get(obj, resourceNSString, '') === targetNS)
             if (resourceItems.length === 0) {
-                pulse = 'orange' // search didn't find this resource in this cluster so mark it unknown
+                pendingPulseCount++
+                //pulse = 'orange' // search didn't find this resource in this cluster so mark it unknown
             } else {
                 resourceItems.forEach((resourceItem) => {
                     // does resource have a desired resource count?
@@ -431,6 +433,13 @@ const getPulseStatusForGenericNode = (node, t) => {
             highestPulse = index
         }
     })
+
+    if (pendingPulseCount > 0 && pendingPulseCount < clusterNames.length) {
+        const index = pulseValueArr.indexOf('yellow')
+        if (index < highestPulse) {
+            highestPulse = index
+        }
+    }
     return pulseValueArr[highestPulse]
 }
 

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.js
@@ -3,7 +3,7 @@
 import { uniqBy, get, set } from 'lodash'
 import { getClusterName, addClusters } from './utils'
 import { createReplicaChild } from './topologySubscription'
-import { fireManagedClusterView, listResources } from '../../../../../resources'
+import { fireManagedClusterView, listNamespacedResources } from '../../../../../resources'
 import { convertStringToQuery } from '../helpers/search-helper'
 import { searchClient } from '../../../../Home/Search/search-sdk/search-client'
 import { SearchResultRelatedItemsDocument } from '../../../../Home/Search/search-sdk/search-sdk'
@@ -154,9 +154,10 @@ const getArgoRoute = async (appName, appNamespace, cluster, managedclusterviewda
     // this only works for OCP clusters, needs more work to support other vendors
     if (cluster === 'local-cluster') {
         try {
-            routes = await listResources({
+            routes = await listNamespacedResources({
                 apiVersion: 'route.openshift.io/v1',
                 kind: 'Route',
+                metadata: { namespace: appNamespace },
             }).promise
         } catch (err) {
             console.error('Error listing resource:', err)
@@ -193,7 +194,7 @@ const getArgoRoute = async (appName, appNamespace, cluster, managedclusterviewda
                 }
             })
             .catch((err) => {
-                console.error('Error getting ersource: ', err)
+                console.error('Error getting resource: ', err)
             })
     }
 }


### PR DESCRIPTION
Changes:

- Fix node status showing pending when there's only one pending resource from a cluster, should show a warning in this case
- Fix issue when RBAC user clicks Argo editor link they get no permission to list Routes, changed to list Routes from namespace instead