### PR TITLE
Fix log tab and pod node status

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/components/LogsContainer.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/components/LogsContainer.tsx
@@ -43,9 +43,9 @@ export function LogsContainer(props: ILogsContainerProps) {
         initialCluster = pods[0].cluster
         initialPodURL = createResourceURL(
             {
-                initialCluster,
+                cluster: initialCluster,
                 type: pods[0].kind,
-                initialNamespace,
+                namespace: initialNamespace,
                 name: initialPod,
                 specs: {
                     raw: {

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.js
@@ -37,7 +37,7 @@ export const warningCode = 2
 export const pendingCode = 1
 export const failureCode = 0
 //pod state contains any of these strings
-const resErrorStates = ['err', 'off', 'invalid', 'kill', 'propagationfailed']
+const resErrorStates = ['err', 'off', 'invalid', 'kill', 'propagationfailed', 'imagepullbackoff', 'crashloopbackoff']
 const resWarningStates = [pendingStatus, 'creating', 'terminating']
 const apiVersionPath = 'specs.raw.apiVersion'
 


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issues:
 - https://github.com/stolostron/backlog/issues/21984
 - https://github.com/stolostron/backlog/issues/21956

Changes:
- Made sure cluster and namespace is set for the `View pod logs details in search` link
- Add pod error status to the list of error statuses for setting the pulse to red