### PR TITLE
Fallback to searchClusters when SubscriptionReport is not created

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeRelated.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeRelated.js
@@ -125,7 +125,8 @@ export const addDiagramDetails = (resourceStatuses, resourceMap, isClusterGroupe
                         (kind === 'subscription' ? name === resourceName : name === nameNoHash) &&
                         namespace === relatedKind.namespace &&
                         type === relatedKind.kind &&
-                        (specs.clustersNames || []).includes(relatedKind.cluster)
+                        ((specs.clustersNames || []).includes(relatedKind.cluster) ||
+                            (specs.searchClusters || []).find((cls) => cls.name === relatedKind.cluster)) // fallback to searchclusters if SubscriptionReport is not created
                     )
                 }
             })


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issues:

- https://github.com/stolostron/backlog/issues/22063
- https://github.com/stolostron/backlog/issues/22061

Changes:

- Made changes to use searchClusters if the SubscriptionReport is not created.
![fixedsubscriptionode](https://user-images.githubusercontent.com/38960034/165849096-5a46a3fc-764f-4966-bdfd-9fcb372ec5ba.jpg)

