### PR TITLE
Fix argo editor link and app table crash

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyAppSet.js
@@ -167,7 +167,7 @@ const getArgoRoute = async (appName, appNamespace, cluster, managedclusterviewda
             const routeObjs = routes.filter(
                 (route) =>
                     get(route, 'metadata.labels["app.kubernetes.io/part-of"]', '') === 'argocd' &&
-                    get(route, 'metadata.labels["app.kubernetes.io/name"]', '') === `${appNamespace}-server` &&
+                    get(route, 'metadata.labels["app.kubernetes.io/name"]', '').endsWith('-server') &&
                     !get(route, 'metadata.name', '').toLowerCase().includes('grafana') &&
                     !get(route, 'metadata.name', '').toLowerCase().includes('prometheus')
             )

--- a/frontend/src/routes/Applications/helpers/resource-helper.tsx
+++ b/frontend/src/routes/Applications/helpers/resource-helper.tsx
@@ -66,7 +66,7 @@ const getArgoClusterList = (
     const clusterSet = new Set<string>()
 
     resources.forEach((resource) => {
-        const isRemoteArgoApp = resource.status.cluster ? true : false
+        const isRemoteArgoApp = resource.status?.cluster ? true : false
 
         if (
             (resource.spec.destination?.name === 'in-cluster' ||


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/22145

- Fix issue when user creates an Argo app in a namespace that they forgot to deploy a Gitops instance the app table would crash
- Fix an issue with the Argo editor link not working with non-default Gitops installs