### PR TITLE
Fallback to local-cluster if there are no searchClusters

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeRelated.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeRelated.js
@@ -126,7 +126,8 @@ export const addDiagramDetails = (resourceStatuses, resourceMap, isClusterGroupe
                         namespace === relatedKind.namespace &&
                         type === relatedKind.kind &&
                         ((specs.clustersNames || []).includes(relatedKind.cluster) ||
-                            (specs.searchClusters || []).find((cls) => cls.name === relatedKind.cluster)) // fallback to searchclusters if SubscriptionReport is not created
+                            (specs.searchClusters || []).find((cls) => cls.name === relatedKind.cluster) ||
+                            relatedKind.cluster === 'local-cluster') // fallback to searchclusters if SubscriptionReport is not created
                     )
                 }
             })


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issues:
- https://github.com/stolostron/backlog/issues/22063
- https://github.com/stolostron/backlog/issues/22061

Looks like there might not be searchClusters found sometimes so we need to fallback to `local-cluster`.