### PR TITLE
Add namespace check for pre/post hook AnsibleJobs

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/applicationSubscription.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/applicationSubscription.js
@@ -276,11 +276,11 @@ const getAppHooks = async (hooks, isPreHooks) => {
 
             if (response) {
                 response.forEach((deployable) => {
-                    const name = get(deployable, 'metadata.name')
-                    const namespace = get(deployable, 'metadata.namespace')
+                    const hookName = get(deployable, 'metadata.name')
+                    const hookNamespace = get(deployable, 'metadata.namespace')
                     values.forEach(({ deployableName, subscription }) => {
                         const subNS = get(subscription, 'metadata.namespace')
-                        if (name === deployableName && namespace === subNS) {
+                        if (hookName === deployableName && hookNamespace === subNS) {
                             if (isPreHooks) {
                                 if (!subscription.prehooks) {
                                     subscription.prehooks = []

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/applicationSubscription.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/applicationSubscription.js
@@ -277,8 +277,10 @@ const getAppHooks = async (hooks, isPreHooks) => {
             if (response) {
                 response.forEach((deployable) => {
                     const name = get(deployable, 'metadata.name')
+                    const namespace = get(deployable, 'metadata.namespace')
                     values.forEach(({ deployableName, subscription }) => {
-                        if (name === deployableName) {
+                        const subNS = get(subscription, 'metadata.namespace')
+                        if (name === deployableName && namespace === subNS) {
                             if (isPreHooks) {
                                 if (!subscription.prehooks) {
                                     subscription.prehooks = []


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/22426

- Add namespace check for pre/post hook AnsibleJobs

The topology now only contains pre/post hooks AnsibleJobs for the current app:
![image](https://user-images.githubusercontent.com/38960034/167721759-e49bf879-0776-4a8d-922e-28601e7b19bb.png)
