### PR TITLE
Bug 2084093: Change naming of AI items in Cluster and Credentials wizards

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -313,7 +313,6 @@
     "cluster.create.aws.title": "Select to create an OpenShift Container Platform on Amazon Web Services",
     "cluster.create.azure.subtitle": "Microsoft Azure",
     "cluster.create.baremetal.subtitle": "Bare metal",
-    "cluster.create.centrallymanaged.section.tooltip": "Simplify cluster self-service with infrastructure environments, which enable you to manage hosts, create ready-to-use host groups, and quickly create clusters based on provided infrastructure. To use infrastructure environments, select <strong>On Premise</strong>.",
     "cluster.create.cim.subtitle": "Use existing discovered hosts",
     "cluster.create.cim.tooltip": "Create a cluster from hosts that have been discovered and made available via infrastructure environments.",
     "cluster.create.configure.advancedparameters": "Configure advanced parameters",

--- a/frontend/src/routes/Credentials/CredentialsForm.tsx
+++ b/frontend/src/routes/Credentials/CredentialsForm.tsx
@@ -70,7 +70,6 @@ enum ProviderGroup {
     Automation = 'Automation & other credentials',
     Datacenter = 'Datacenter credentials',
     CloudProvider = 'Cloud provider credentials',
-    CentrallyManaged = 'Centrally managed',
 }
 
 const providerGroup: Record<string, string> = {
@@ -84,7 +83,7 @@ const providerGroup: Record<string, string> = {
     [Provider.redhatvirtualization]: ProviderGroup.Datacenter,
     [Provider.baremetal]: ProviderGroup.Datacenter,
     [Provider.vmware]: ProviderGroup.Datacenter,
-    [Provider.hybrid]: ProviderGroup.CentrallyManaged,
+    [Provider.hybrid]: ProviderGroup.Datacenter,
 }
 
 export default function CredentialsFormPage() {
@@ -605,19 +604,6 @@ export function CredentialsForm(props: {
                                 group: ProviderGroup.Automation,
                                 options: credentialProviders
                                     .filter((provider) => providerGroup[provider] === ProviderGroup.Automation)
-                                    .map((provider) => {
-                                        return {
-                                            id: provider,
-                                            value: provider,
-                                            icon: <AcmIcon icon={ProviderIconMap[provider]} />,
-                                            text: ProviderLongTextMap[provider],
-                                        }
-                                    }),
-                            },
-                            {
-                                group: ProviderGroup.CentrallyManaged,
-                                options: credentialProviders
-                                    .filter((provider) => providerGroup[provider] === ProviderGroup.CentrallyManaged)
                                     .map((provider) => {
                                         return {
                                             id: provider,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlData.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlData.js
@@ -2,7 +2,6 @@
 
 // eslint-disable-next-line no-use-before-define
 import React from 'react'
-import { Trans } from '../../../../../../lib/acm-i18next'
 
 import Handlebars from 'handlebars'
 import installConfigHbs from '../templates/install-config.hbs'
@@ -189,9 +188,6 @@ export const getControlData = (
                 section: 'Assisted installation',
             },
         ],
-        sectionTooltips: {
-            'Centrally managed': <Trans i18nKey="create:cluster.create.centrallymanaged.section.tooltip" />,
-        },
         active: getActiveCardID,
         validation: {
             notification: 'creation.ocp.cluster.must.select.infrastructure',


### PR DESCRIPTION
Credentials wizard - `On Premise` card moved to Datacenter section and was renamed to `Assisted installation`
![Screenshot from 2022-06-02 10-10-37](https://user-images.githubusercontent.com/2078045/171585554-09c737f0-b1bb-4bc6-bd6d-a0fa4071df8d.png)


requires updated ui-components https://github.com/stolostron/ui-components/pull/453