### PR TITLE
fix issue 22431 for 2.5.1

### DIFF
--- a/frontend/src/routes/Applications/CreateApplication/Subscription/transformers/transform-resources-to-controls.js
+++ b/frontend/src/routes/Applications/CreateApplication/Subscription/transformers/transform-resources-to-controls.js
@@ -201,15 +201,23 @@ export const shiftTemplateObject = (templateObject, selfLinksControl) => {
         // remove that placement rule too
         name = _.get(subscription, '$synced.spec.$v.placement.$v.placementRef.$v.name.$v')
         if (name) {
-            const rules = templateObject.PlacementRule || []
-            const inx = rules.findIndex((rule) => {
-                return name === _.get(rule, '$synced.metadata.$v.name.$v')
+            const remainingSubscriptions = _.get(templateObject, 'Subscription')
+            const isReused = remainingSubscriptions.some((resource) => {
+                return name === _.get(resource, '$synced.spec.$v.placement.$v.placementRef.$v.name.$v')
             })
-            if (inx !== -1) {
-                const rule = templateObject.PlacementRule.splice(inx, 1)[0]
-                if (selfLinksControl) {
-                    const ruleSelfLink = getResourceID(rule.$raw)
-                    _.set(selfLinksControl, 'active.PlacementRule', ruleSelfLink)
+
+            // unless it's used in another subscription
+            if (!isReused) {
+                const rules = templateObject.PlacementRule || []
+                const inx = rules.findIndex((rule) => {
+                    return name === _.get(rule, '$synced.metadata.$v.name.$v')
+                })
+                if (inx !== -1) {
+                    const rule = templateObject.PlacementRule.splice(inx, 1)[0]
+                    if (selfLinksControl) {
+                        const ruleSelfLink = getResourceID(rule.$raw)
+                        _.set(selfLinksControl, 'active.PlacementRule', ruleSelfLink)
+                    }
                 }
             }
         }

--- a/frontend/src/routes/Applications/CreateApplication/Subscription/transformers/transform-resources-to-controls.js
+++ b/frontend/src/routes/Applications/CreateApplication/Subscription/transformers/transform-resources-to-controls.js
@@ -200,12 +200,11 @@ export const shiftTemplateObject = (templateObject, selfLinksControl) => {
         // if this subscription pointed to a placement rule in this template
         // remove that placement rule too
         name = _.get(subscription, '$synced.spec.$v.placement.$v.placementRef.$v.name.$v')
+        const remainingSubscriptions = _.get(templateObject, 'Subscription')
+        const isReused = remainingSubscriptions.some((resource) => {
+            return name === _.get(resource, '$synced.spec.$v.placement.$v.placementRef.$v.name.$v')
+        })
         if (name) {
-            const remainingSubscriptions = _.get(templateObject, 'Subscription')
-            const isReused = remainingSubscriptions.some((resource) => {
-                return name === _.get(resource, '$synced.spec.$v.placement.$v.placementRef.$v.name.$v')
-            })
-
             // unless it's used in another subscription
             if (!isReused) {
                 const rules = templateObject.PlacementRule || []


### PR DESCRIPTION
stolostron/backlog#22431

tl:dr; there was a bug in how subscriptions in the yaml was stuffed into the form

1. when temptifly reverses yaml values into the form, it does a lodash get() of the parsed yaml with the control.reverse as a path
     **reverse: 'Application[0].metadata.namespace',**

2. there's only one Application but multiples of everything else:
![image](https://user-images.githubusercontent.com/60980397/168646901-970ae080-dfa6-4f31-9cc7-ba5e4d3ac667.png)

3. to process these arrays, shiftTemplateObject( ) does a shift on the subscription array to grab the first subscription

5. doing that allows the reverse on subscription controls to just specify the first value (iow [0] and not [1] etc)
![image](https://user-images.githubusercontent.com/60980397/168647315-9591bef9-7098-45db-b847-2196f7800830.png)

6. shiftTemplateObject( )  after subscription was shifted it also would remove its placement policy from the arrays to keep the arrays synced (does subscription 0 on array, then tries to remove placement rule 0 too so that Subscription[1] and PlacementRule[1] become Subscription[0] and PlacementRule[0]

7. so the bug was here-- when you set the first subscription to placement-2, it looked for that name in PLacementRule[ ], found the second one and deleted it thinking it belonged to only the first subscription and it was cleaning up the arrays

8. so the fix was to make sure that pr wasn't used by another subsciption before removing it:

![image](https://user-images.githubusercontent.com/60980397/168649325-73635f9b-7356-42c5-9583-a39042822395.png)




Signed-off-by: John Swanke <jswanke@redhat.com>