### PR TITLE
Fix pulse status not resetting to green when set to red or yellow for 2.5

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.js
@@ -37,6 +37,7 @@ export const warningCode = 2
 export const pendingCode = 1
 export const failureCode = 0
 //pod state contains any of these strings
+const resGreenStates = ['running']
 const resErrorStates = ['err', 'off', 'invalid', 'kill', 'propagationfailed', 'imagepullbackoff', 'crashloopbackoff']
 const resWarningStates = [pendingStatus, 'creating', 'terminating']
 const apiVersionPath = 'specs.raw.apiVersion'
@@ -408,6 +409,9 @@ const getPulseStatusForGenericNode = (node, t) => {
                     } else {
                         const resStatus = _.get(resourceItem, 'status', deployedStr).toLowerCase()
                         resourceItem.resStatus = resStatus
+                        if (_.includes(resGreenStates, resStatus)) {
+                            pulse = 'green'
+                        }
                         if (_.includes(resErrorStates, resStatus)) {
                             pulse = 'red'
                         }


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: 
- https://github.com/stolostron/backlog/issues/22639

Change:
- Fix the node details table pulse status not resetting to green when a red resource was processed