### PR TITLE
Add isDesign field for cluster resources for 2.5

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologySubscription.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/topologySubscription.js
@@ -349,6 +349,7 @@ const addSubscriptionDeployedResource = (parentId, clustersNames, resource, link
         id: memberId,
         uid: memberId,
         specs: {
+            isDesign: false,
             parent: parentObject,
             clustersNames,
             template,

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/utils.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/utils.js
@@ -39,6 +39,7 @@ export const createChildNode = (parentObject, clustersNames, type, links, nodes,
         id: memberId,
         uid: memberId,
         specs: {
+            isDesign: false,
             resourceCount,
             resources,
             clustersNames,


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>
Issue: https://github.com/stolostron/backlog/issues/22657

Change:
- Add isDesign field for cluster resources so labels will be displayed for cluster resources