### PR TITLE
Update API version for CertificateSigningRequest

### DIFF
--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -74,7 +74,7 @@ const definitions: IWatchOptions[] = [
     { kind: 'Infrastructure', apiVersion: 'config.openshift.io/v1' },
     {
         kind: 'CertificateSigningRequest',
-        apiVersion: 'certificates.k8s.io/v1beta1',
+        apiVersion: 'certificates.k8s.io/v1',
         labelSelector: { 'open-cluster-management.io/cluster-name': '' },
     },
     { kind: 'ManagedCluster', apiVersion: 'cluster.open-cluster-management.io/v1' },

--- a/frontend/src/resources/certificate-signing-requests.ts
+++ b/frontend/src/resources/certificate-signing-requests.ts
@@ -3,8 +3,8 @@
 import { V1ObjectMeta } from '@kubernetes/client-node/dist/gen/model/v1ObjectMeta'
 import { IResource, IResourceDefinition } from './resource'
 
-export const CertificateSigningRequestApiVersion = 'certificates.k8s.io/v1beta1'
-export type CertificateSigningRequestApiVersionType = 'certificates.k8s.io/v1beta1'
+export const CertificateSigningRequestApiVersion = 'certificates.k8s.io/v1'
+export type CertificateSigningRequestApiVersionType = 'certificates.k8s.io/v1'
 
 export const CertificateSigningRequestKind = 'CertificateSigningRequest'
 export type CertificateSigningRequestKindType = 'CertificateSigningRequest'
@@ -23,8 +23,8 @@ export interface CertificateSigningRequest extends IResource {
     }
 }
 
-export const CertificateSigningRequestListApiVersion = 'certificates.k8s.io/v1beta1'
-export type CertificateSigningRequestListApiVersionType = 'certificates.k8s.io/v1beta1'
+export const CertificateSigningRequestListApiVersion = 'certificates.k8s.io/v1'
+export type CertificateSigningRequestListApiVersionType = 'certificates.k8s.io/v1'
 
 export const CertificateSigningRequestListKind = 'CertificateSigningRequestList'
 export type CertificateSigningRequestListKindType = 'CertificateSigningRequestList'


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/19175

Confirmed we are encountering an error on OCP 4.9:
```
{"level":"warn","time":1654182459774,"msg":"watch","kind":"CertificateSigningRequest","apiVersion":"certificates.k8s.io/v1beta1","labelSelector":{"open-cluster-management.io/cluster-name":""},"error":"Response code 404 (Not Found)","name":"HTTPError"}
```

RHACM 2.4 supports back to OCP 4.6, and the `certificates.k8s.io/v1` version of CertificateSigningRequest is available in that release:

https://docs.openshift.com/container-platform/4.6/rest_api/security_apis/certificatesigningrequest-certificates-k8s-io-v1.html#certificatesigningrequest-certificates-k8s-io-v1