### PR TITLE
Ansible operator install alert

### DIFF
--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -102,6 +102,7 @@ export interface AcmDataFormProps {
     mode?: 'form' | 'wizard' | 'details'
     isHorizontal?: boolean
     edit?: () => void
+    operatorError?: ReactNode
 }
 
 function generalValidationMessage() {
@@ -120,7 +121,7 @@ const EDITOR_CHANGES = 'Other YAML changes'
 export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
     const pageRef = useRef(null)
 
-    const { editorTitle, schema, secrets, immutables, formData } = props
+    const { editorTitle, schema, secrets, immutables, formData, operatorError } = props
     const [stateChanges, setStateChanges] = useState<any | undefined>([])
     const [showFormErrors, setShowFormErrors] = useState(false)
     const mode = props.mode ?? 'form'
@@ -267,6 +268,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                                         showFormErrors={showFormErrors}
                                         setShowFormErrors={setShowFormErrors}
                                         isHorizontal={isHorizontal}
+                                        operatorError={operatorError}
                                     />
                                 </PageSection>
                             ) : (
@@ -294,9 +296,10 @@ export function AcmDataForm(
         stateChanges: SyncDiffType
         showFormErrors: boolean
         setShowFormErrors: (showFormErrors: boolean) => void
+        operatorError?: ReactNode
     }
 ): JSX.Element {
-    const { formData, stateChanges, isHorizontal, showFormErrors, setShowFormErrors } = props
+    const { formData, stateChanges, isHorizontal, operatorError, showFormErrors, setShowFormErrors } = props
     switch (props.mode) {
         case 'wizard':
             return (
@@ -306,6 +309,7 @@ export function AcmDataForm(
                     isHorizontal={isHorizontal ?? false}
                     showFormErrors={showFormErrors}
                     setShowFormErrors={setShowFormErrors}
+                    operatorError={operatorError}
                 />
             )
 
@@ -441,11 +445,12 @@ export function AcmDataFormWizard(props: {
     formData: FormData
     stateChanges: SyncDiffType
     isHorizontal: boolean
+    operatorError?: ReactNode
     showFormErrors: boolean
     setShowFormErrors: (showFormErrors: boolean) => void
 }): JSX.Element {
     const { t } = useTranslation()
-    const { formData, stateChanges, isHorizontal, showFormErrors, setShowFormErrors } = props
+    const { formData, stateChanges, isHorizontal, operatorError, showFormErrors, setShowFormErrors } = props
     const [showSectionErrors, setShowSectionErrors] = useState<Record<string, boolean>>({})
     const [submitText, setSubmitText] = useState(formData.submitText)
     const [submitError, setSubmitError] = useState('')
@@ -469,6 +474,11 @@ export function AcmDataFormWizard(props: {
             ),
             component: section.type === 'Section' && (
                 <Form isHorizontal={isHorizontal}>
+                    {operatorError && (
+                        <AlertGroup>
+                            <Alert isInline variant="danger" title={operatorError} />
+                        </AlertGroup>
+                    )}
                     {(showFormErrors || showSectionErrors[section.title]) && hasError && (
                         <AlertGroup>
                             {sectionHasRequiredErrors(section) ? (

--- a/frontend/src/resources/ansible-job.ts
+++ b/frontend/src/resources/ansible-job.ts
@@ -2,6 +2,7 @@
 import { Metadata } from './metadata'
 import { IResourceDefinition } from './resource'
 import { getLatest } from './utils/utils'
+import { SubscriptionOperator } from '.'
 
 export const AnsibleJobApiVersion = 'tower.ansible.com/v1alpha1'
 export type AnsibleJobApiVersionType = 'tower.ansible.com/v1alpha1'
@@ -65,6 +66,17 @@ export function getLatestAnsibleJob(ansibleJobs: AnsibleJob[], namespace: string
         prehook: prehookJobs,
         posthook: posthookJobs,
     }
+}
+
+export function isAnsibleOperatorInstalled(subscriptionOperators: SubscriptionOperator[]) {
+    const ansibleOp = subscriptionOperators.filter((op: SubscriptionOperator) => {
+        const conditions = op.status?.conditions[0]
+        return (
+            op.metadata.name === 'ansible-automation-platform-operator' &&
+            conditions?.reason === 'AllCatalogSourcesHealthy'
+        )
+    })
+    return ansibleOp.length > 0
 }
 
 export interface AnsibleTowerJobTemplateList {

--- a/frontend/src/routes/Governance/components/AutomationDetailsSidebar.tsx
+++ b/frontend/src/routes/Governance/components/AutomationDetailsSidebar.tsx
@@ -26,7 +26,15 @@ import { ansibleJobState, configMapsState, secretsState, subscriptionOperatorsSt
 import { BulkActionModel, IBulkActionModelProps } from '../../../components/BulkActionModel'
 import { Trans, useTranslation } from '../../../lib/acm-i18next'
 import { NavigationPath } from '../../../NavigationPath'
-import { AnsibleJob, deleteResource, Policy, PolicyAutomation, Secret, SubscriptionOperator } from '../../../resources'
+import {
+    AnsibleJob,
+    deleteResource,
+    isAnsibleOperatorInstalled,
+    Policy,
+    PolicyAutomation,
+    Secret,
+    SubscriptionOperator,
+} from '../../../resources'
 import { ClusterPolicyViolationIcons } from '../components/ClusterPolicyViolations'
 import { useGovernanceData } from '../useGovernanceData'
 
@@ -63,16 +71,10 @@ export function AutomationDetailsSidebar(props: {
         open: false,
     })
 
-    const isOperatorInstalled = useMemo(() => {
-        const ansibleOp = subscriptionOperators.filter((op: SubscriptionOperator) => {
-            const conditions = op.status?.conditions[0]
-            return (
-                op.metadata.name === 'ansible-automation-platform-operator' &&
-                conditions?.reason === 'AllCatalogSourcesHealthy'
-            )
-        })
-        return ansibleOp.length > 0
-    }, [subscriptionOperators])
+    const isOperatorInstalled = useMemo(
+        () => isAnsibleOperatorInstalled(subscriptionOperators),
+        [subscriptionOperators]
+    )
 
     const credential = useMemo(
         () =>

--- a/frontend/src/routes/Governance/components/AutomationDetailsSidebar.tsx
+++ b/frontend/src/routes/Governance/components/AutomationDetailsSidebar.tsx
@@ -33,7 +33,6 @@ import {
     Policy,
     PolicyAutomation,
     Secret,
-    SubscriptionOperator,
 } from '../../../resources'
 import { ClusterPolicyViolationIcons } from '../components/ClusterPolicyViolations'
 import { useGovernanceData } from '../useGovernanceData'

--- a/frontend/src/routes/Governance/components/AutomationDetailsSidebar.tsx
+++ b/frontend/src/routes/Governance/components/AutomationDetailsSidebar.tsx
@@ -215,7 +215,7 @@ export function AutomationDetailsSidebar(props: {
                                 )
                             }
                         >
-                            {'Operator'}
+                            OperatorHub
                             <ExternalLinkAltIcon style={{ marginLeft: '4px', verticalAlign: 'middle' }} />
                         </Button>
                     </div>

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomations.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomations.tsx
@@ -16,7 +16,7 @@ import {
 import { Fragment, useContext, useEffect, useMemo, useState } from 'react'
 import { Link, useHistory } from 'react-router-dom'
 import { useRecoilState } from 'recoil'
-import { clusterCuratorsState, configMapsState, secretsState } from '../../../atoms'
+import { clusterCuratorsState, configMapsState, secretsState, subscriptionOperatorsState } from '../../../atoms'
 import { BulkActionModel, IBulkActionModelProps } from '../../../components/BulkActionModel'
 import { DropdownActionModal, IDropdownActionModalProps } from '../../../components/DropdownActionModal'
 import { RbacDropdown } from '../../../components/Rbac'
@@ -31,11 +31,18 @@ import {
     getTemplateJobsNum,
     LinkAnsibleCredential,
     unpackProviderConnection,
+    isAnsibleOperatorInstalled,
 } from '../../../resources'
 
 export default function AnsibleAutomationsPage() {
     const [configMaps] = useRecoilState(configMapsState)
     const alertContext = useContext(AcmAlertContext)
+    const [subscriptionOperators] = useRecoilState(subscriptionOperatorsState)
+
+    const isOperatorInstalled = useMemo(
+        () => isAnsibleOperatorInstalled(subscriptionOperators),
+        [subscriptionOperators]
+    )
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     useEffect(() => alertContext.clearAlerts, [])
@@ -68,27 +75,29 @@ export default function AnsibleAutomationsPage() {
         <AcmPage hasDrawer header={<AcmPageHeader title={t('template.title')} />}>
             <AcmPageContent id="clusters">
                 <PageSection>
-                    <Hint className={classes.hint}>
-                        <div>
-                            {t('template.hint')}{' '}
-                            <AcmButton
-                                onClick={() =>
-                                    window.open(
-                                        openShiftConsoleUrl +
-                                            '/operatorhub/all-namespaces?keyword=ansible+automation+platform'
-                                    )
-                                }
-                                variant={ButtonVariant.link}
-                                role="link"
-                                id="view-logs"
-                                isInline
-                                isSmall
-                            >
-                                {t('template.operator.link')}
-                                <ExternalLinkAltIcon style={{ marginLeft: '4px', verticalAlign: 'middle' }} />
-                            </AcmButton>
-                        </div>
-                    </Hint>
+                    {!isOperatorInstalled && (
+                        <Hint className={classes.hint}>
+                            <div>
+                                {t('template.hint')}{' '}
+                                <AcmButton
+                                    onClick={() =>
+                                        window.open(
+                                            openShiftConsoleUrl +
+                                                '/operatorhub/all-namespaces?keyword=ansible+automation+platform'
+                                        )
+                                    }
+                                    variant={ButtonVariant.link}
+                                    role="link"
+                                    id="view-logs"
+                                    isInline
+                                    isSmall
+                                >
+                                    {t('template.operator.link')}
+                                    <ExternalLinkAltIcon style={{ marginLeft: '4px', verticalAlign: 'middle' }} />
+                                </AcmButton>
+                            </div>
+                        </Hint>
+                    )}
                     <AnsibleJobTemplateTable />
                 </PageSection>
             </AcmPageContent>

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
@@ -10,14 +10,24 @@ import {
     Secret,
     SecretApiVersion,
     SecretKind,
+    SubscriptionOperator,
+    SubscriptionOperatorApiVersion,
+    SubscriptionOperatorKind,
 } from '../../../resources'
 import { Provider } from '@stolostron/ui-components/lib/AcmProvider'
 import { render } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
-import { clusterCuratorsState, namespacesState, secretsState } from '../../../atoms'
+import { clusterCuratorsState, namespacesState, secretsState, subscriptionOperatorsState } from '../../../atoms'
 import { nockAnsibleTower, nockCreate, nockIgnoreRBAC } from '../../../lib/nock-util'
-import { clickByPlaceholderText, clickByText, typeByPlaceholderText, waitForNock } from '../../../lib/test-util'
+import {
+    clickByPlaceholderText,
+    clickByText,
+    typeByPlaceholderText,
+    waitForNock,
+    waitForNotText,
+    waitForText,
+} from '../../../lib/test-util'
 import { NavigationPath } from '../../../NavigationPath'
 import { AnsibleTowerJobTemplateList } from '../../../resources'
 import AnsibleAutomationsFormPage from './AnsibleAutomationsForm'
@@ -47,13 +57,14 @@ const mockSecret: Secret = {
     },
 }
 
-function AddAnsibleTemplateTest() {
+function AddAnsibleTemplateTest(props: { subscriptions?: SubscriptionOperator[] }) {
     return (
         <RecoilRoot
             initializeState={(snapshot) => {
                 snapshot.set(namespacesState, mockNamespaces)
                 snapshot.set(secretsState, [mockSecret])
                 snapshot.set(clusterCuratorsState, [mockClusterCurator])
+                snapshot.set(subscriptionOperatorsState, props.subscriptions || [])
             }}
         >
             <MemoryRouter initialEntries={[NavigationPath.addAnsibleAutomation]}>
@@ -107,6 +118,27 @@ const mockTemplateList: AnsibleTowerJobTemplateList = {
     ],
 }
 
+const mockSubscriptionOperator: SubscriptionOperator = {
+    apiVersion: SubscriptionOperatorApiVersion,
+    kind: SubscriptionOperatorKind,
+    metadata: {
+        name: 'ansible-automation-platform-operator',
+        namespace: 'ansible-automation-platform-operator',
+    },
+    status: {
+        conditions: [
+            {
+                reason: 'AllCatalogSourcesHealthy',
+                lastTransitionTime: '',
+                message: '',
+                type: '',
+                status: '',
+            },
+        ],
+    },
+    spec: {},
+}
+
 describe('add ansible job template page', () => {
     beforeEach(() => {
         nockIgnoreRBAC()
@@ -149,5 +181,16 @@ describe('add ansible job template page', () => {
         nockAnsibleTower(mockAnsibleCredential, mockTemplateList)
         await clickByText('Add')
         await waitForNock(createNock)
+    })
+
+    it('should render warning when Ansible operator is not installed', async () => {
+        // mockSubscriptionOperator
+        render(<AddAnsibleTemplateTest />)
+        waitForText('The Ansible Automation Platform Resource Operator is required to create an Ansible job. ')
+    })
+
+    it('should not render warning when Ansible operator is installed', async () => {
+        render(<AddAnsibleTemplateTest subscriptions={[mockSubscriptionOperator]} />)
+        waitForNotText('The Ansible Automation Platform Resource Operator is required to create an Ansible job. ')
     })
 })

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
@@ -184,7 +184,6 @@ describe('add ansible job template page', () => {
     })
 
     it('should render warning when Ansible operator is not installed', async () => {
-        // mockSubscriptionOperator
         render(<AddAnsibleTemplateTest />)
         waitForText('The Ansible Automation Platform Resource Operator is required to create an Ansible job. ')
     })

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -163,10 +163,10 @@ export function AnsibleAutomationsForm(props: {
         if (!isOperatorInstalled)
             return (
                 <div>
-                    {'The Ansible Automation Platform Resource Operator is required to create an Ansible job. '}
+                    {t('The Ansible Automation Platform Resource Operator is required to create an Ansible job. ')}
                     {openShiftConsoleUrl && openShiftConsoleUrl !== '' ? (
                         <div>
-                            {'Install the Operator through the following link: '}
+                            {t('Install the Operator through the following link: ')}
                             <Button
                                 isInline
                                 variant={ButtonVariant.link}
@@ -182,7 +182,7 @@ export function AnsibleAutomationsForm(props: {
                             </Button>
                         </div>
                     ) : (
-                        'Install the Operator through operator hub.'
+                        t('Install the Operator through operator hub.')
                     )}
                 </div>
             )

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -177,7 +177,7 @@ export function AnsibleAutomationsForm(props: {
                                     )
                                 }
                             >
-                                {'Operator'}
+                                OperatorHub
                                 <ExternalLinkAltIcon style={{ marginLeft: '4px', verticalAlign: 'middle' }} />
                             </Button>
                         </div>

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -2,6 +2,7 @@
 import {
     ActionGroup,
     Button,
+    ButtonVariant,
     Chip,
     ChipGroup,
     Flex,
@@ -10,12 +11,13 @@ import {
     SelectOption,
     SelectVariant,
 } from '@patternfly/react-core'
+import { ExternalLinkAltIcon } from '@patternfly/react-icons'
 import { AcmForm, AcmLabelsInput, AcmModal, AcmSelect, AcmSubmit } from '@stolostron/ui-components'
 import _ from 'lodash'
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useEffect, useMemo, useState } from 'react'
 import { RouteComponentProps, useHistory } from 'react-router-dom'
 import { useRecoilState } from 'recoil'
-import { secretsState, settingsState } from '../../../atoms'
+import { configMapsState, secretsState, settingsState, subscriptionOperatorsState } from '../../../atoms'
 import { AcmDataFormPage } from '../../../components/AcmDataForm'
 import { FormData, LinkType, Section } from '../../../components/AcmFormData'
 import { ErrorPage } from '../../../components/ErrorPage'
@@ -31,6 +33,7 @@ import {
     createResource,
     getClusterCurator,
     IResource,
+    isAnsibleOperatorInstalled,
     listAnsibleTowerJobs,
     ProviderConnection,
     replaceResource,
@@ -146,6 +149,44 @@ export function AnsibleAutomationsForm(props: {
     const [destroyPostJobs, setDestroyPostJobs] = useState<ClusterCuratorAnsibleJob[]>(
         clusterCurator?.spec?.destroy?.posthook ?? []
     )
+    const [configMaps] = useRecoilState(configMapsState)
+    const [subscriptionOperators] = useRecoilState(subscriptionOperatorsState)
+
+    const isOperatorInstalled = useMemo(
+        () => isAnsibleOperatorInstalled(subscriptionOperators),
+        [subscriptionOperators]
+    )
+
+    function getOperatorError() {
+        const openShiftConsoleConfig = configMaps?.find((configmap) => configmap.metadata?.name === 'console-public')
+        const openShiftConsoleUrl: string = openShiftConsoleConfig?.data?.consoleURL
+        if (!isOperatorInstalled)
+            return (
+                <div>
+                    {'The Ansible Automation Platform Resource Operator is required to create an Ansible job. '}
+                    {openShiftConsoleUrl && openShiftConsoleUrl !== '' ? (
+                        <div>
+                            {'Install the Operator through the following link: '}
+                            <Button
+                                isInline
+                                variant={ButtonVariant.link}
+                                onClick={() =>
+                                    window.open(
+                                        openShiftConsoleUrl +
+                                            '/operatorhub/all-namespaces?keyword=ansible+automation+platform'
+                                    )
+                                }
+                            >
+                                {'Operator'}
+                                <ExternalLinkAltIcon style={{ marginLeft: '4px', verticalAlign: 'middle' }} />
+                            </Button>
+                        </div>
+                    ) : (
+                        'Install the Operator through operator hub.'
+                    )}
+                </div>
+            )
+    }
 
     const resourceVersion: string | undefined = clusterCurator?.metadata.resourceVersion ?? undefined
 
@@ -524,6 +565,7 @@ export function AnsibleAutomationsForm(props: {
                 schema={schema}
                 immutables={isEditing ? ['ClusterCurator.0.metadata.name', 'ClusterCurator.0.metadata.namespace'] : []}
                 mode={isViewing ? 'details' : isEditing ? 'form' : 'wizard'}
+                operatorError={getOperatorError()}
             />
             <EditAnsibleJobModal
                 ansibleJob={editAnsibleJob}


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/13951

- Ansible operator installation warning now appears in the creation wizard (styled to resemble the same alert in the policy automation wizard).
- The hint rendered on the Automations page now only renders when the operator is not installed. 
- Unit testing has also been added for each case.

![Screen Shot 2022-06-13 at 11 41 15 AM](https://user-images.githubusercontent.com/21374229/173423113-f37a0378-ba38-4828-a66d-eed93a5c0a65.png)

![Screen Shot 2022-06-13 at 11 45 03 AM](https://user-images.githubusercontent.com/21374229/173423191-b227c80a-92aa-4125-88a1-dba2274987ad.png)

