### PR TITLE
Change app name to label value and remove duplicate for subscription apps

### DIFF
--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -75,9 +75,9 @@ const fluxAnnotations = {
 }
 
 const labelArr: string[] = [
-    'app=',
     'kustomize.toolkit.fluxcd.io/name=',
     'helm.toolkit.fluxcd.io/name=',
+    'app=',
     'app.kubernetes.io/part-of=',
 ]
 


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/22974
https://github.com/stolostron/backlog/issues/23815

- Change app name to label value as we are passing that in the URL so topology can find the correct app
- Subscription apps are duplicated as an OCP app so that was fixed
- Argo apps are also duplicated but there's no good solution for this at the moment
