### PR TITLE
Prevent upgrading hypershift clusters

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -87,6 +87,7 @@ export type Cluster = {
     isHive: boolean
     isManaged: boolean
     isCurator: boolean
+    isHostedCluster: boolean
     clusterSet?: string
     owner: {
         createdBy?: string
@@ -236,6 +237,7 @@ export function getCluster(
         isHive: !!clusterDeployment,
         isManaged: !!managedCluster || !!managedClusterInfo,
         isCurator: !!clusterCurator,
+        isHostedCluster: getIsHostedCluster(managedCluster),
         isSNOCluster: getIsSNOCluster(agentClusterInstall),
         hive: getHiveConfig(clusterDeployment, clusterClaim),
         clusterSet:
@@ -959,5 +961,16 @@ export function getClusterStatus(
         return { status: cdStatus, statusMessage }
     } else {
         return { status: mcStatus, statusMessage }
+    }
+}
+
+export function getIsHostedCluster(managedCluster?: ManagedCluster) {
+    if (
+        managedCluster?.metadata.annotations &&
+        managedCluster?.metadata.annotations['cluster.open-cluster-management.io/hypershiftdeployment']
+    ) {
+        return true
+    } else {
+        return false
     }
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterMachinePools/ClusterMachinePools.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterMachinePools/ClusterMachinePools.test.tsx
@@ -37,6 +37,7 @@ const mockCluster: Cluster = {
     isHive: true,
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -229,7 +229,8 @@ export function ClustersTable(props: {
                 title: t('managed.upgrade.plural'),
                 click: (managedClusters: Array<Cluster>) => {
                     if (!managedClusters) return
-                    setUpgradeClusters(managedClusters)
+                    const managedClustersNoHypershift = managedClusters.filter((mc) => !mc.isHostedCluster)
+                    setUpgradeClusters(managedClustersNoHypershift)
                 },
                 variant: 'bulk-action',
             },

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchChannelSelectModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchChannelSelectModal.test.tsx
@@ -13,6 +13,7 @@ const mockClusterNoAvailable: Cluster = {
     status: ClusterStatus.ready,
     isHive: false,
     isCurator: false,
+    isHostedCluster: false,
     owner: {},
     distribution: {
         k8sVersion: '1.19',
@@ -84,6 +85,7 @@ const mockClusterReady1: Cluster = {
     },
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }
@@ -125,6 +127,7 @@ const mockClusterReady2: Cluster = {
     },
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }
@@ -166,6 +169,7 @@ const mockClusterOffline: Cluster = {
     },
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchUpgradeModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchUpgradeModal.test.tsx
@@ -42,6 +42,7 @@ const mockClusterNoAvailable: Cluster = {
     },
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }
@@ -81,6 +82,7 @@ const mockClusterReady1: Cluster = {
     },
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }
@@ -120,6 +122,7 @@ const mockClusterReady2: Cluster = {
     },
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }
@@ -159,6 +162,7 @@ const mockClusterOffline: Cluster = {
     },
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }
@@ -198,6 +202,7 @@ const mockClusterFailedUpgrade: Cluster = {
     },
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.test.tsx
@@ -55,6 +55,7 @@ const mockCluster: Cluster = {
     isHive: true,
     isManaged: true,
     isCurator: true,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterDestroy.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterDestroy.test.tsx
@@ -36,6 +36,7 @@ const mockDestroyCluster: Cluster = {
     },
     isHive: false,
     isManaged: true,
+    isHostedCluster: false,
     isSNOCluster: false,
 }
 
@@ -66,6 +67,7 @@ const mockDetachCluster: Cluster = {
     isHive: false,
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
@@ -354,6 +354,7 @@ describe('DistributionField', () => {
             isHive: false,
             isManaged: true,
             isCurator: true,
+            isHostedCluster: false,
             isSNOCluster: false,
             owner: {},
         }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -213,7 +213,7 @@ export function DistributionField(props: { cluster?: Cluster; clusterCurator?: C
                 />
             </>
         )
-    } else if (props.cluster?.distribution.upgradeInfo?.isReadyUpdates) {
+    } else if (props.cluster?.distribution.upgradeInfo?.isReadyUpdates && !props.cluster?.isHostedCluster) {
         // UPGRADE AVAILABLE
         return (
             <>

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DownloadConfigurationDropdown.old.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DownloadConfigurationDropdown.old.tsx
@@ -43,6 +43,7 @@ const mockCluster: Cluster = {
     isHive: true,
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HiveNotification.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HiveNotification.test.tsx
@@ -45,6 +45,7 @@ const mockCluster: Cluster = {
     isHive: false,
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ImportCommand.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ImportCommand.test.tsx
@@ -45,6 +45,7 @@ const mockCluster: Cluster = {
     isHive: false,
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/LoginCredentials.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/LoginCredentials.test.tsx
@@ -40,6 +40,7 @@ const mockCluster: Cluster = {
     isHive: true,
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.test.tsx
@@ -45,6 +45,7 @@ const mockCluster: Cluster = {
     isHive: false,
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.test.tsx
@@ -124,6 +124,7 @@ const mockCluster: Cluster = {
     isHive: false,
     isManaged: true,
     isCurator: false,
+    isHostedCluster: false,
     isSNOCluster: false,
     owner: {},
 }


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

For 2.6, we won't be able to add Hypershift cluster creation support to the UI but users can still create them from the CLI which will allow the clusters to show up in the cluster table. Upgrade is currently not supported for Hypershift clusters so we want to disable that option.

- Add isHostedCluster to cluster definition. HostedCluster is what we call Hypershift clusters
- Prevent the upgrade option from displaying for Hypershift clusters