### PR TITLE
Fix log viewer crash for 2.6

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/components/LogsContainer.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/components/LogsContainer.tsx
@@ -19,7 +19,7 @@ export function LogsContainer(props: ILogsContainerProps) {
     let resourceError = ''
     const t = props.t
     const podModel = _.get(props.node, 'specs.podModel')
-    const pods = podModel ? podModel[Object.keys(podModel)[0]] : []
+    const pods = podModel && Object.keys(podModel).length > 0 ? podModel[Object.keys(podModel)[0]] : []
 
     if (pods.length === 0) {
         resourceError = t('No pods found')


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/24370

- Add check for podModel length of 0

![image](https://user-images.githubusercontent.com/38960034/179599552-5de81776-9d99-45cb-a56a-0c85b5107e52.png)