### PR TITLE
Change path of locales for standalone app

### DIFF
--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -20,7 +20,7 @@ i18n
     // init i18next
     .init({
         backend: {
-            loadPath: '/multicloud/locales/{{lng}}/{{ns}}.json',
+            loadPath: '/standalone/locales/{{lng}}/{{ns}}.json',
         },
         compatibilityJSON: 'v3',
         fallbackLng: ['en'], // if language is not supported or string is missing, fallback to English

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -85,7 +85,7 @@ module.exports = function (_env: any, argv: { hot?: boolean; mode: string | unde
                         `./node_modules/openshift-assisted-ui-lib/dist/locales/${locale}/translation.json`
                       ],
                     output: {
-                        "fileName": `./multicloud/locales/${locale}/translation.json`
+                        "fileName": `./standalone/locales/${locale}/translation.json`
                     },
                     space: 4
                 })


### PR DESCRIPTION
The old 'multicloud' path clashes with backend logic which is removing 'multicloud' path from every request

Signed-off-by: Rastislav Wagner <rawagner@redhat.com>