### PR TITLE
Fix issue unable to delete placementrule with same name in different namespaces 2.6

### DIFF
--- a/frontend/src/routes/Applications/helpers/resource-helper.tsx
+++ b/frontend/src/routes/Applications/helpers/resource-helper.tsx
@@ -467,7 +467,11 @@ export const getAppChildResources = (
         let subWithPR
         const referencedPR = currentSub ? (currentSub as Subscription).spec.placement?.placementRef : undefined
         placementRules.forEach((item) => {
-            if (referencedPR && referencedPR.name === item.metadata.name) {
+            if (
+                referencedPR &&
+                referencedPR.name === item.metadata.name &&
+                currentSub?.metadata?.namespace === item.metadata.namespace
+            ) {
                 subWithPR = { ...currentSub, rule: item }
             }
             const prHostingSubAnnotation = getAnnotation(item, hostingSubAnnotationStr)


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/24495

This issue is caused by using the same placementrule but in difference namespaces. The code is not checking the namepace so placementrules with the same name but different namespace will be associated with the wrong subscription

- Add a namespace check when search for placementrules

With the fix, the warning is now gone and users can delete the placementrule:
![image](https://user-images.githubusercontent.com/38960034/180570947-20c39add-7f4a-408e-93e6-11540f91cdeb.png)
