### PR TITLE
Include custom styles in Clusters plugin entry component (#1891)

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClustersPlugin.css
+++ b/frontend/src/routes/Infrastructure/Clusters/ClustersPlugin.css
@@ -1,0 +1,1 @@
+@import '~openshift-assisted-ui-lib/index.css';

--- a/frontend/src/routes/Infrastructure/Clusters/ClustersPlugin.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClustersPlugin.tsx
@@ -4,6 +4,8 @@ import { PluginData } from '../../../components/PluginData'
 import { PluginContextProvider } from '../../../components/PluginContextProvider'
 import Clusters from './Clusters'
 
+import './ClustersPlugin.css'
+
 export default function ClustersPlugin() {
     return (
         <PluginContextProvider>


### PR DESCRIPTION
This change includes custom application styles (mostly from openshift-assisted-ui-lib)
in ClustersPlugin entry to ensure correct styles for assisted parts of the plugins.

Fixes BZ2053000

Cherry-picked from 89bcc97e
Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>