### PR TITLE
add 4.11 and remove 4.7 from discovery ocp versions

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryComponents/test-utils.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryComponents/test-utils.tsx
@@ -114,7 +114,7 @@ export const discoveryConfig: DiscoveryConfig = {
     spec: {
         filters: {
             lastActive: 14,
-            openShiftVersions: ['4.7'],
+            openShiftVersions: ['4.8'],
         },
         credential: mockRHOCMSecrets[0].metadata.name!,
     },
@@ -145,7 +145,7 @@ export const discoveryConfigUpdated: DiscoveryConfig = {
     spec: {
         filters: {
             lastActive: 30,
-            openShiftVersions: ['4.7', '4.8'],
+            openShiftVersions: ['4.8', '4.9'],
         },
         credential: mockRHOCMSecrets[0].metadata.name!,
     },

--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/DiscoveryConfig.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/DiscoveryConfig.test.tsx
@@ -115,7 +115,7 @@ describe('discovery config page', () => {
         // Select Version
         expect(container.querySelectorAll(`[aria-labelledby^="discoveryVersions-label"]`)).toHaveLength(1)
         container.querySelector<HTMLButtonElement>(`[aria-labelledby^="discoveryVersions-label"]`)!.click()
-        await clickByText('4.7')
+        await clickByText('4.8')
 
         // Submit form
         const createDiscoveryConfigNock = nockCreate(discoveryConfig, discoveryConfig)
@@ -154,7 +154,7 @@ describe('discovery config page', () => {
         await clickByText('30 days')
 
         container.querySelector<HTMLButtonElement>(`[aria-labelledby^="discoveryVersions-label"]`)!.click()
-        await clickByText('4.8')
+        await clickByText('4.9')
 
         const replaceNock = nockReplace(discoveryConfigUpdated)
         await clickByText('Save')

--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/DiscoveryConfig.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveryConfig/DiscoveryConfig.tsx
@@ -48,7 +48,7 @@ import {
     Provider,
 } from '../../../../../ui-components'
 
-const discoveryVersions = ['4.7', '4.8', '4.9', '4.10']
+const discoveryVersions = ['4.8', '4.9', '4.10', '4.11']
 
 export default function DiscoveryConfigPage() {
     const { t } = useTranslation()


### PR DESCRIPTION
Signed-off-by: Erin Murphy erinmurp@redhat.com

Issue: https://github.com/stolostron/backlog/issues/24549