### PR TITLE
Bump `react-core` version to include OUIA fix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5972,28 +5972,33 @@
             }
         },
         "@patternfly/react-core": {
-            "version": "4.221.11",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.221.11.tgz",
-            "integrity": "sha512-svaUdxJU2CdBnbhzq3FibFEBeeJXrfEW1+jWfEQdpgTBS9s/XLkDDOzfJ0zIkxHfUH91JvqryqlqmbcbnZUs4g==",
+            "version": "4.225.11",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.225.11.tgz",
+            "integrity": "sha512-2jbaryUwDrQdvrTi5NUDn/q8sYu6q81+bKHSNHTrk4DfBMewWR4ApszJnXD9hX9Wlx/MY9JJaQfom5VMT3jw7Q==",
             "requires": {
-                "@patternfly/react-icons": "^4.72.11",
-                "@patternfly/react-styles": "^4.71.11",
-                "@patternfly/react-tokens": "^4.73.11",
+                "@patternfly/react-icons": "^4.76.11",
+                "@patternfly/react-styles": "^4.75.11",
+                "@patternfly/react-tokens": "^4.77.11",
                 "focus-trap": "6.9.2",
                 "react-dropzone": "9.0.0",
                 "tippy.js": "5.1.2",
                 "tslib": "^2.0.0"
             },
             "dependencies": {
+                "@patternfly/react-icons": {
+                    "version": "4.82.2",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.82.2.tgz",
+                    "integrity": "sha512-4BzDstc/t+442cU1BJuSu3Y5ZmLa/DwtLKLYlp11yT20wLWTv9y+XSiZAD8LaWH12KDLTLDpjtFNRf22SpFWEg=="
+                },
                 "@patternfly/react-styles": {
-                    "version": "4.74.1",
-                    "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.74.1.tgz",
-                    "integrity": "sha512-9eWvKrjtrJ3qhJkhY2GQKyYA13u/J0mU1befH49SYbvxZtkbuHdpKmXBAeQoHmcx1hcOKtiYXeKb+dVoRRNx0A=="
+                    "version": "4.81.2",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.81.2.tgz",
+                    "integrity": "sha512-0WU6akUW2E7hpE+NROK9WaQxC9QbWUFlHOsveTV1W1NTuELBkw7jHqVp1Ma9N6ueeXkrrI+FaAIIbUpBSmEr8w=="
                 },
                 "@patternfly/react-tokens": {
-                    "version": "4.76.1",
-                    "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.76.1.tgz",
-                    "integrity": "sha512-gLEezRSzQeflaPu3SCgYmWtuiqDIRtxNNFP1+ES7P2o56YHXJ5o1Pki7LpNCPk/VOzHy2+vRFE/7l+hBEweugw=="
+                    "version": "4.83.2",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.83.2.tgz",
+                    "integrity": "sha512-fKRr3ztphxcfo4uzLDAyMivOlBLYYUWZFzGWb+PVusrglRIrlm9lKUwKJlTnQ1CTYDSUjm9nwo9qjZ3vzNa8hQ=="
                 },
                 "focus-trap": {
                     "version": "6.9.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
         "@patternfly/patternfly": "4.196.7",
         "@patternfly/react-charts": "6.74.3",
         "@patternfly/react-code-editor": "4.65.1",
-        "@patternfly/react-core": "4.221.11",
+        "@patternfly/react-core": "4.225.11",
         "@patternfly/react-icons": "4.75.1",
         "@patternfly/react-log-viewer": "4.66.3",
         "@patternfly/react-table": "4.90.3",


### PR DESCRIPTION
Bump to include:
- https://github.com/patternfly/patternfly-react/commit/d8f546344a8a361a73796096a1de7d4cd44fbcff

Addresses:
- https://github.com/stolostron/backlog/issues/24658