### PR TITLE
Update react-data-view to fix crash in MCE

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6422,9 +6422,9 @@
             }
         },
         "@stolostron/react-data-view": {
-            "version": "1.0.36",
-            "resolved": "https://registry.npmjs.org/@stolostron/react-data-view/-/react-data-view-1.0.36.tgz",
-            "integrity": "sha512-xdr/99bwx98ZEcAFFTLAstKGd4ksEd/aLQFcFdKzTHJ6Y83jokMtOuWC+nzMjm6ZzM4mHD8X2OTXMwRLBSW5UA==",
+            "version": "1.0.38",
+            "resolved": "https://registry.npmjs.org/@stolostron/react-data-view/-/react-data-view-1.0.38.tgz",
+            "integrity": "sha512-jCk+yEVNWyPVh1ZG5OKfmgZdWJa6biD8CRz2VrOlv8B4MX0W2WHOUSTBxZtgaDw3KgMqhIO5S178JXcDYed1pA==",
             "requires": {
                 "debounce": "1.2.1",
                 "fuse.js": "6.6.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,7 +48,7 @@
         "@react-hook/resize-observer": "1.2.5",
         "@redhat-cloud-services/rule-components": "3.2.5",
         "@reduxjs/toolkit": "1.8.x",
-        "@stolostron/react-data-view": "1.0.36",
+        "@stolostron/react-data-view": "^1.0.38",
         "ajv": "8.11.0",
         "axios": "0.27.2",
         "cidr-tools": "4.3.0",


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Bugzilla: https://github.com/stolostron/backlog/issues/24548

- Update react-data-view version with fix to not use PF Truncate, using a custom Truncate instead