### PR TITLE
Add action to set installation disk to AI cluster wizard

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.tsx
@@ -115,6 +115,15 @@ const EditAICluster: React.FC<EditAIClusterProps> = ({
             ]).promise
         },
         onDeleteHost,
+        onSetInstallationDiskId: (agent: CIM.AgentK8sResource, diskId: string) => {
+            return patchResource(agent, [
+                {
+                    op: 'replace',
+                    path: '/spec/installation_disk_id',
+                    value: diskId,
+                },
+            ]).promise
+        },
     }
 
     useEffect(() => {


### PR DESCRIPTION
Depends on https://github.com/openshift-assisted/assisted-ui-lib/pull/1554

Fixes BZ2081597

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>