### PR TITLE
Add infrastructure and control plane data to review step

### DIFF
--- a/frontend/src/components/TemplateEditor/controls/ControlPanelFinish.js
+++ b/frontend/src/components/TemplateEditor/controls/ControlPanelFinish.js
@@ -183,6 +183,7 @@ class ControlPanelFinish extends React.Component {
         let desc
         let summaries
         switch (type) {
+            case 'reviewinfo':
             case 'text':
             case 'singleselect':
             case 'combobox':

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAI.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAI.js
@@ -12,6 +12,18 @@ export const getControlDataCIM = (includeKlusterletAddonConfig = true, warning) 
         title: 'Cluster details',
     },
     {
+        id: 'infrastructure',
+        name: 'Infrastructure',
+        active: 'Host inventory',
+        type: 'reviewinfo',
+    },
+    {
+        id: 'controlplane',
+        name: 'Control plane type',
+        active: 'Standalone',
+        type: 'reviewinfo',
+    },
+    {
         id: 'warning',
         type: 'custom',
         component: warning,
@@ -79,6 +91,18 @@ export const getControlDataAI = (includeKlusterletAddonConfig = true) => [
         id: 'aiDetailStep',
         type: 'step',
         title: 'Cluster details',
+    },
+    {
+        id: 'infrastructure',
+        name: 'Infrastructure',
+        active: 'Host inventory',
+        type: 'reviewinfo',
+    },
+    {
+        id: 'controlplane',
+        name: 'Control plane type',
+        active: 'Standalone',
+        type: 'reviewinfo',
     },
     /////////////////////// ACM Credentials  /////////////////////////////////////
     {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
@@ -680,6 +680,12 @@ const controlDataAWS = [
         title: 'Cluster details',
     },
     {
+        id: 'infrastructure',
+        name: 'Infrastructure',
+        active: 'AWS',
+        type: 'reviewinfo',
+    },
+    {
         name: 'creation.ocp.cloud.connection',
         tooltip: 'tooltip.creation.ocp.cloud.connection',
         id: 'connection',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.test.js
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+'use strict'
+
+import { getControlDataAWS } from './ControlDataAWS'
+
+describe('getControlDataAWS', () => {
+    it('get control data for AWS - default', () => {
+        getControlDataAWS()
+    })
+
+    it('get control data for AWS - no automation', () => {
+        getControlDataAWS(false, true, false, true)
+    })
+
+    it('get control data for AWS - include sno cluster', () => {
+        getControlDataAWS(true, true, true, true)
+    })
+
+    it('get control data for AWS - no klusterletaddon', () => {
+        getControlDataAWS(true, true, true, true)
+    })
+
+    it('get control data for AWS - no awsprivate', () => {
+        getControlDataAWS(true, false, true, true)
+    })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
@@ -476,6 +476,12 @@ const controlDataAZR = [
         title: 'Cluster details',
     },
     {
+        id: 'infrastructure',
+        name: 'Infrastructure',
+        active: 'Azure',
+        type: 'reviewinfo',
+    },
+    {
         name: 'creation.ocp.cloud.connection',
         tooltip: 'tooltip.creation.ocp.cloud.connection',
         id: 'connection',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.test.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+'use strict'
+
+import { getControlDataAZR } from './ControlDataAZR'
+
+describe('getControlDataAZR', () => {
+    it('get control data for Azure - default', () => {
+        getControlDataAZR()
+    })
+
+    it('get control data for Azure - no automation', () => {
+        getControlDataAZR(false, false, true)
+    })
+
+    it('get control data for Azure - include sno cluster', () => {
+        getControlDataAZR(true, true, true)
+    })
+
+    it('get control data for Azure - no klusterletaddon', () => {
+        getControlDataAZR(true, true, true)
+    })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.js
@@ -272,6 +272,12 @@ const controlDataGCP = [
         title: 'Cluster details',
     },
     {
+        id: 'infrastructure',
+        name: 'Infrastructure',
+        active: 'GCP',
+        type: 'reviewinfo',
+    },
+    {
         name: 'creation.ocp.cloud.connection',
         tooltip: 'tooltip.creation.ocp.cloud.connection',
         id: 'connection',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.test.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+'use strict'
+
+import { getControlDataGCP } from './ControlDataGCP'
+
+describe('getControlDataGCP', () => {
+    it('get control data for GCP - default', () => {
+        getControlDataGCP()
+    })
+
+    it('get control data for GCP - no automation', () => {
+        getControlDataGCP(false, false, true)
+    })
+
+    it('get control data for GCP - include sno cluster', () => {
+        getControlDataGCP(true, true, true)
+    })
+
+    it('get control data for GCP - no klusterletaddon', () => {
+        getControlDataGCP(true, true, true)
+    })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHypershift.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHypershift.js
@@ -14,6 +14,18 @@ export const getControlDataHypershift = (includeKlusterletAddonConfig = true, wa
         title: 'Cluster details',
     },
     {
+        id: 'infrastructure',
+        name: 'Infrastructure',
+        active: 'Host inventory',
+        type: 'reviewinfo',
+    },
+    {
+        id: 'controlplane',
+        name: 'Control plane type',
+        active: 'Hosted',
+        type: 'reviewinfo',
+    },
+    {
         id: 'warning',
         type: 'custom',
         component: warning,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHypershift.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHypershift.test.js
@@ -1,0 +1,16 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+'use strict'
+
+import { Warning } from '../Warning'
+import { getControlDataHypershift } from './ControlDataHypershift'
+
+describe('getControlDataHypershift', () => {
+    it('get control data for Hypershift - default', () => {
+        getControlDataHypershift()
+    })
+
+    it('get control data for RHV - no klusterletaddon', () => {
+        getControlDataHypershift(false, <Warning />)
+    })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.js
@@ -51,6 +51,12 @@ const controlDataOST = [
         title: 'Cluster details',
     },
     {
+        id: 'infrastructure',
+        name: 'Infrastructure',
+        active: 'OpenStack',
+        type: 'reviewinfo',
+    },
+    {
         name: 'creation.ocp.cloud.connection',
         tooltip: 'tooltip.creation.ocp.cloud.connection',
         id: 'connection',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.test.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+'use strict'
+
+import { getControlDataOST } from './ControlDataOST'
+
+describe('getControlDataOST', () => {
+    it('get control data for openstack - default', () => {
+        getControlDataOST()
+    })
+
+    it('get control data for openstack - no automation', () => {
+        getControlDataOST(false, false, true)
+    })
+
+    it('get control data for openstack - include sno cluster', () => {
+        getControlDataOST(true, true, true)
+    })
+
+    it('get control data for openstack - no klusterletaddon', () => {
+        getControlDataOST(true, true, true)
+    })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.js
@@ -37,6 +37,12 @@ const controlDataRHV = [
         title: 'Cluster details',
     },
     {
+        id: 'infrastructure',
+        name: 'Infrastructure',
+        active: 'RHV',
+        type: 'reviewinfo',
+    },
+    {
         name: 'creation.ocp.cloud.connection',
         tooltip: 'tooltip.creation.ocp.cloud.connection',
         id: 'connection',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.test.js
@@ -1,0 +1,19 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+'use strict'
+
+import { getControlDataRHV } from './ControlDataRHV'
+
+describe('getControlDataRHV', () => {
+    it('get control data for RHV - default', () => {
+        getControlDataRHV()
+    })
+
+    it('get control data for RHV - no automation', () => {
+        getControlDataRHV(false, true)
+    })
+
+    it('get control data for RHV - no klusterletaddon', () => {
+        getControlDataRHV(true, false)
+    })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.js
@@ -44,6 +44,12 @@ const controlDataVMW = [
         title: 'Cluster details',
     },
     {
+        id: 'infrastructure',
+        name: 'Infrastructure',
+        active: 'vSphere',
+        type: 'reviewinfo',
+    },
+    {
         name: 'creation.ocp.cloud.connection',
         tooltip: 'tooltip.creation.ocp.cloud.connection',
         id: 'connection',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.test.js
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+'use strict'
+
+import { getControlDataVMW } from './ControlDataVMW'
+
+describe('getControlDataVMW', () => {
+    it('get control data for vsphere - default', () => {
+        getControlDataVMW()
+    })
+
+    it('get control data for vsphere - no automation', () => {
+        getControlDataVMW(false, false, true)
+    })
+
+    it('get control data for vsphere - include sno cluster', () => {
+        getControlDataVMW(true, true, true)
+    })
+
+    it('get control data for vsphere - no klusterletaddon', () => {
+        getControlDataVMW(true, true, true)
+    })
+})


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/24789

- Add `reviewinfo` type to temptifly for data that we want to show in the review step but not in the generated YAML
- Add infrastructure and control plane type(if applicable) to all the different cluster creation flows