### PR TITLE
Conditionally display template details link

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -167,21 +167,25 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
                             .replace(':apiVersion', version)
                             .replace(':kind', kind)
                             .replace(':templateName', templateName)
+                        const templateLink = canCreatePolicy ? (
+                            templateDetailURL && (
+                                <span>
+                                    -<Link to={templateDetailURL}>{` ${t('View details')}`}</Link>
+                                </span>
+                            )
+                        ) : (
+                            <Tooltip content={t('rbac.unauthorized')}>
+                                <span className="link-disabled">{`- ${t('View details')}`}</span>
+                            </Tooltip>
+                        )
+                        const templateExists = !(
+                            prunedMessage.includes('Failed to create policy template') ||
+                            prunedMessage.includes('check if you have CRD deployed')
+                        )
                         return (
                             <div>
                                 {/* message may need to be limited to 300 chars? */}
-                                {prunedMessage}{' '}
-                                {canCreatePolicy ? (
-                                    templateDetailURL && (
-                                        <span>
-                                            -<Link to={templateDetailURL}>{` ${t('View details')}`}</Link>
-                                        </span>
-                                    )
-                                ) : (
-                                    <Tooltip content={t('rbac.unauthorized')}>
-                                        <span className="link-disabled">{`- ${t('View details')}`}</span>
-                                    </Tooltip>
-                                )}
+                                {prunedMessage} {templateExists && templateLink}
                             </div>
                         )
                     }


### PR DESCRIPTION
If the policy framework can not create the policy template (because the
CRD does not exist, or if the template is invalid), then the link that
was previously added would go to a page with a not found error. This
change detects most situations where that would occur, and skips adding
the link.

Refs:
 - https://github.com/stolostron/backlog/issues/24746

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>