### PR TITLE
Fix retrieving the policy template details in hosted mode

### DIFF
--- a/frontend/src/resources/managed-cluster-add-on.ts
+++ b/frontend/src/resources/managed-cluster-add-on.ts
@@ -17,7 +17,9 @@ export interface ManagedClusterAddOn extends IResource {
     apiVersion: ManagedClusterAddOnApiVersionType
     kind: ManagedClusterAddOnKindType
     metadata: Metadata
-    spec: {}
+    spec: {
+        installNamespace?: string
+    }
     status?: {
         conditions: {
             lastTransitionTime?: Date

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.test.tsx
@@ -2,9 +2,11 @@
 import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
+import { managedClusterAddonsState } from '../../../../atoms'
 import { nockGet } from '../../../../lib/nock-util'
 import { waitForNocks, waitForText } from '../../../../lib/test-util'
 import { PolicyTemplateDetails } from './PolicyTemplateDetails'
+import { ManagedClusterAddOn } from '../../../../resources'
 
 jest.mock('../../../../components/YamlEditor', () => {
     // TODO replace with actual YAML Page when Monaco editor is imported correctly
@@ -116,7 +118,11 @@ describe('Policy Template Details content', () => {
     test('Should render Policy Template Details Page content correctly', async () => {
         const getResourceNock = nockGet(getResourceRequest, getResourceResponse)
         render(
-            <RecoilRoot>
+            <RecoilRoot
+                initializeState={(snapshot) => {
+                    snapshot.set(managedClusterAddonsState, [])
+                }}
+            >
                 <MemoryRouter>
                     <PolicyTemplateDetails
                         clusterName={'test-cluster'}
@@ -151,5 +157,89 @@ describe('Policy Template Details content', () => {
         await waitForText('v1')
         await waitForText('No violations')
         await waitForText('Resource found as expected')
+    })
+
+    test('Should render Policy Template Details Page content correctly in hosted mode', async () => {
+        const clusterName = 'customer-cluster'
+        const hostingClusterName = 'hosting-cluster'
+        const installNamespace = `${clusterName}-hosted`
+
+        // Add one irrelevant addon not in hosted mode to ensure it gets ignored.
+        const mockManagedClusterAddOnWork: ManagedClusterAddOn = {
+            apiVersion: 'addon.open-cluster-management.io/v1alpha1',
+            kind: 'ManagedClusterAddOn',
+            metadata: {
+                name: 'work-manager',
+                namespace: clusterName,
+            },
+            spec: {},
+        }
+        const mockManagedClusterAddOnPolicy: ManagedClusterAddOn = {
+            apiVersion: 'addon.open-cluster-management.io/v1alpha1',
+            kind: 'ManagedClusterAddOn',
+            metadata: {
+                name: 'governance-policy-framework',
+                namespace: clusterName,
+                annotations: {
+                    'addon.open-cluster-management.io/hosting-cluster-name': hostingClusterName,
+                },
+            },
+            spec: {
+                installNamespace: installNamespace,
+            },
+        }
+
+        const getResourceRequestCopy = JSON.parse(JSON.stringify(getResourceRequest))
+        getResourceRequestCopy.metadata.namespace = hostingClusterName
+        getResourceRequestCopy.metadata.name = '99e5a663c0d087293127fd84856d50cf40595689'
+        getResourceRequestCopy.metadata.labels.viewName = '99e5a663c0d087293127fd84856d50cf40595689'
+
+        const getResourceResponseCopy = JSON.parse(JSON.stringify(getResourceResponse))
+        getResourceResponseCopy.metadata.namespace = hostingClusterName
+        getResourceResponseCopy.status.result.metadata.namespace = installNamespace
+        getResourceResponseCopy.metadata.name = '99e5a663c0d087293127fd84856d50cf40595689'
+        getResourceResponseCopy.metadata.labels.viewName = '99e5a663c0d087293127fd84856d50cf40595689'
+        getResourceResponseCopy.status.result.metadata.labels = {
+            'cluster-name': clusterName,
+            'cluster-namespace': installNamespace,
+            'policy.open-cluster-management.io/cluster-name': clusterName,
+            'policy.open-cluster-management.io/cluster-namespace': installNamespace,
+        }
+
+        const getResourceNock = nockGet(getResourceRequestCopy, getResourceResponseCopy)
+
+        render(
+            <RecoilRoot
+                initializeState={(snapshot) => {
+                    snapshot.set(managedClusterAddonsState, [
+                        mockManagedClusterAddOnWork,
+                        mockManagedClusterAddOnPolicy,
+                    ])
+                }}
+            >
+                <MemoryRouter>
+                    <PolicyTemplateDetails
+                        clusterName={clusterName}
+                        apiGroup={'policy.open-cluster-management.io'}
+                        apiVersion={'v1'}
+                        kind={'ConfigurationPolicy'}
+                        templateName={'policy-set-with-1-placement-policy-1'}
+                    />
+                </MemoryRouter>
+            </RecoilRoot>
+        )
+
+        // Wait for the get resource requests to finish
+        await waitForNocks([getResourceNock])
+
+        // Verify the template description section
+        await waitForText('Template details')
+        await waitForText('policy-set-with-1-placement-policy-1')
+        // Ensure the hosting cluster name isn't shown as the cluster name
+        await waitForText(clusterName)
+        await waitForText('ConfigurationPolicy')
+        await waitForText(
+            '[{"Compliant":"Compliant","Validity":{},"conditions":[{"lastTransitionTime":"2022-02-22T13:32:41Z","message":"namespaces [test] found as specified, therefore this Object template is compliant","reason":"K8s `must have` object already exists","status":"True","type":"notification"}]}]'
+        )
     })
 })

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetailsPage.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetailsPage.test.tsx
@@ -2,6 +2,7 @@
 import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
+import { managedClusterAddonsState } from '../../../../atoms'
 import { waitForText } from '../../../../lib/test-util'
 import { PolicyTemplateDetailsPage } from './PolicyTemplateDetailsPage'
 
@@ -24,7 +25,11 @@ jest.mock('react-router-dom', () => ({
 describe('Policy Template Details Page', () => {
     test('Should render Policy Template Details Page', async () => {
         render(
-            <RecoilRoot>
+            <RecoilRoot
+                initializeState={(snapshot) => {
+                    snapshot.set(managedClusterAddonsState, [])
+                }}
+            >
                 <MemoryRouter>
                     <PolicyTemplateDetailsPage />
                 </MemoryRouter>


### PR DESCRIPTION
In hosted mode, the cluster where the policy templates exist is
different than the managed cluster that the policy templates apply to.
This commit accounts for this when the Policy addon is installed in
hosted mode.

Relates:
https://github.com/stolostron/backlog/issues/24919
https://github.com/stolostron/backlog/issues/23723