### PR TITLE
Disable bulk actions for unauthorized users

### DIFF
--- a/frontend/src/routes/Governance/policies/Policies.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.tsx
@@ -47,7 +47,7 @@ import {
 import { BulkActionModel, IBulkActionModelProps } from '../../../components/BulkActionModel'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { deletePolicy } from '../../../lib/delete-policy'
-import { checkPermission, rbacCreate, rbacUpdate } from '../../../lib/rbac-util'
+import { checkPermission, rbacCreate, rbacUpdate, rbacPatch } from '../../../lib/rbac-util'
 import { transformBrowserUrlToFilterPresets } from '../../../lib/urlQuery'
 import { NavigationPath } from '../../../NavigationPath'
 import {
@@ -119,11 +119,13 @@ export default function PoliciesPage() {
     const policyClusterViolationsColumn = usePolicyViolationsColumn(policyClusterViolationSummaryMap)
     const [modal, setModal] = useState<ReactNode | undefined>()
     const [canCreatePolicy, setCanCreatePolicy] = useState<boolean>(false)
+    const [canPatchPolicy, setCanPatchPolicy] = useState<boolean>(false)
     const [canCreatePolicyAutomation, setCanCreatePolicyAutomation] = useState<boolean>(false)
     const [canUpdatePolicyAutomation, setCanUpdatePolicyAutomation] = useState<boolean>(false)
 
     useEffect(() => {
         checkPermission(rbacCreate(PolicyDefinition), setCanCreatePolicy, namespaces)
+        checkPermission(rbacPatch(PolicyDefinition), setCanPatchPolicy, namespaces)
         checkPermission(rbacCreate(PolicyAutomationDefinition), setCanCreatePolicyAutomation, namespaces)
         checkPermission(rbacUpdate(PolicyAutomationDefinition), setCanUpdatePolicyAutomation, namespaces)
     }, [namespaces])
@@ -373,6 +375,7 @@ export default function PoliciesPage() {
                     setModal(<AddToPolicySetModal policyTableItems={...item} onClose={() => setModal(undefined)} />)
                 },
                 tooltip: t('Add to policy set'),
+                isDisabled: !canPatchPolicy,
             },
             {
                 id: 'seperator-1',
@@ -420,6 +423,7 @@ export default function PoliciesPage() {
                                     }).length > 0,
                             })
                         },
+                        isDisabled: !canPatchPolicy,
                     },
                     {
                         variant: 'bulk-action',
@@ -458,6 +462,7 @@ export default function PoliciesPage() {
                                     }).length > 0,
                             })
                         },
+                        isDisabled: !canPatchPolicy,
                     },
                 ],
             },
@@ -507,6 +512,7 @@ export default function PoliciesPage() {
                                     }).length > 0,
                             })
                         },
+                        isDisabled: !canPatchPolicy,
                     },
                     {
                         variant: 'bulk-action',
@@ -545,11 +551,12 @@ export default function PoliciesPage() {
                                     }).length > 0,
                             })
                         },
+                        isDisabled: !canPatchPolicy,
                     },
                 ],
             },
         ],
-        [t, bulkModalStatusColumns, bulkModalRemediationColumns]
+        [t, bulkModalStatusColumns, bulkModalRemediationColumns, canPatchPolicy]
     )
 
     const getSourceOptions = useCallback(() => {


### PR DESCRIPTION
For individual policies, the actions dropdown disables actions which the
user is not authorized to perform. This adds a similar thing to the bulk
action dropdown.

Refs:
 - https://github.com/stolostron/backlog/issues/24445

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>