### PR TITLE
Set subrow key to avoid crash

### DIFF
--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -517,6 +517,9 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
             const key = keyFn(item)
             const group = (groupFn && groupFn(item)) || undefined
             const subRows = addSubRows?.(item)
+            // Establish key for subrow based on parent row
+            subRows?.map((row, idx) => (row.props = { key: `${key}-subrow-${idx}` }))
+
             const tableItem: ITableItem<T> = { item, subRows, key, group }
             for (let i = 0; i < columns.length; i++) {
                 const column = columns[i]
@@ -673,12 +676,13 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                 })
             }
             if (allSubItems) {
-                allSubItems.forEach((item) => {
-                    const key = keyFn(item)
+                allSubItems.forEach((subItem, idx) => {
+                    // Establish key for subrow based on parent row
+                    const subKey = `${tableItem.key}-subrow-${idx}`
                     newRows.push({
                         parent: i + addedSubRowCount,
-                        props: { key },
-                        cells: itemToCells(item, key),
+                        props: { key: subKey },
+                        cells: itemToCells(subItem, subKey),
                     })
                 })
                 addedSubRowCount += allSubItems.length


### PR DESCRIPTION
Code in `react-core` using `UseMemo` to fetch an OUIA ID was causing the UI to crash. This uses the parent row to set the `key` (since the subrow wouldn't necessarily have the same data as its parent for the `keyfn` to return a value).

This PR is an alternative to the package update proposed here:
- https://github.com/stolostron/console/pull/1943

Addresses:
- https://github.com/stolostron/backlog/issues/24658

Closes #1943 