### PR TITLE
change violation filters to cluster level

### DIFF
--- a/frontend/src/routes/Governance/policies/Policies.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.tsx
@@ -598,18 +598,34 @@ export default function PoliciesPage() {
                 ],
                 tableFilterFn: (selectedValues, item) => {
                     if (selectedValues.includes('with-violations')) {
-                        if (item.policy.status?.compliant === 'NonCompliant') {
-                            return true
+                        if (item.policy.status?.status !== undefined) {
+                            for (let i = 0; i < item.policy.status?.status.length; i++) {
+                                const cl = item.policy.status?.status[i]
+                                if (cl.compliant !== undefined && cl.compliant == 'NonCompliant') {
+                                    return true
+                                }
+                            }
                         }
                     }
                     if (selectedValues.includes('without-violations')) {
-                        if (item.policy.status?.compliant === 'Compliant') {
-                            return true
+                        if (item.policy.status?.status !== undefined) {
+                            for (let i = 0; i < item.policy.status?.status.length; i++) {
+                                const cl = item.policy.status?.status[i]
+                                if (cl.compliant !== undefined && cl.compliant == 'Compliant') {
+                                    return true
+                                }
+                            }
                         }
                     }
                     if (selectedValues.includes('no-status')) {
-                        if (!item.policy.status?.compliant) {
+                        if (!item.policy.status?.status) {
                             return true
+                        }
+                        for (let i = 0; i < item.policy.status?.status.length; i++) {
+                            const cl = item.policy.status?.status[i]
+                            if (!cl.compliant) {
+                                return true
+                            }
                         }
                     }
                     return false


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

for https://github.com/stolostron/backlog/issues/24946

Previously, policies that were applied on multiple managed clusters could only be filtered by the overall compliance state, which seemed to conflict with the compliance status shown on the policies page. This PR changes the filters so that if a policy has different statuses on different managed clusters, it will show up in the filter for each cluster's compliance state.