### PR TITLE
Fix the related objects view YAML link in hosted mode

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.test.tsx
@@ -6,6 +6,7 @@ import { managedClusterAddonsState } from '../../../../atoms'
 import { nockGet } from '../../../../lib/nock-util'
 import { waitForNocks, waitForText } from '../../../../lib/test-util'
 import { PolicyTemplateDetails } from './PolicyTemplateDetails'
+import { screen } from '@testing-library/react'
 import { ManagedClusterAddOn } from '../../../../resources'
 
 jest.mock('../../../../components/YamlEditor', () => {
@@ -240,6 +241,10 @@ describe('Policy Template Details content', () => {
         await waitForText('ConfigurationPolicy')
         await waitForText(
             '[{"Compliant":"Compliant","Validity":{},"conditions":[{"lastTransitionTime":"2022-02-22T13:32:41Z","message":"namespaces [test] found as specified, therefore this Object template is compliant","reason":"K8s `must have` object already exists","status":"True","type":"notification"}]}]'
+        )
+        const viewYamlLink = screen.getByText('View yaml')
+        expect(viewYamlLink.getAttribute('href')).toEqual(
+            `/multicloud/home/search/resources?cluster=${clusterName}&kind=namespace&apiversion=v1&name=test`
         )
     })
 })

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
@@ -65,10 +65,10 @@ export function PolicyTemplateDetails(props: {
         break
     }
 
-    function getRelatedObjects(resource: any) {
+    function getRelatedObjects(resource: any, clusterName: string) {
         return (
             resource?.status?.relatedObjects?.map((obj: any) => {
-                obj.cluster = resource.metadata.namespace
+                obj.cluster = clusterName
                 return obj
             }) ?? []
         )
@@ -82,14 +82,14 @@ export function PolicyTemplateDetails(props: {
                     setTemplateError(viewResponse.message)
                 } else {
                     setTemplate(viewResponse.result)
-                    setRelatedObjects(getRelatedObjects(viewResponse.result))
+                    setRelatedObjects(getRelatedObjects(viewResponse.result, clusterName))
                 }
             })
             .catch((err) => {
                 console.error('Error getting resource: ', err)
                 setTemplateError(err)
             })
-    }, [templateClusterName, templateNamespace, kind, apiGroup, apiVersion, templateName])
+    }, [templateClusterName, templateNamespace, clusterName, kind, apiGroup, apiVersion, templateName])
 
     const descriptionItems = [
         {


### PR DESCRIPTION
In hosted mode, the cluster where the policy templates exist is
different than the managed cluster that the policy templates apply to.
This commit accounts for this when the Policy addon is installed in
hosted mode.

Now the "View yaml" link will search for the related object on the
managed cluster instead of the hosting cluster.

Relates:
https://github.com/stolostron/backlog/issues/25103
https://bugzilla.redhat.com/show_bug.cgi?id=2118338

Signed-off-by: mprahl <mprahl@users.noreply.github.com>