### PR TITLE
Cherry pick 2.6 Filter out HostedClusters in useClusters

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/useClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/useClusters.tsx
@@ -104,6 +104,8 @@ export function useClusters(
         clusterNames.includes(mca.metadata.namespace)
     )
 
+    const groupHostedClusters = hostedClusters.filter((hc) => clusterNames.includes(hc.metadata.namespace))
+
     const clusters: Cluster[] = mapClusters(
         groupClusterDeployments,
         groupManagedClusterInfos,
@@ -113,7 +115,7 @@ export function useClusters(
         clusterClaims,
         clusterCurators,
         agentClusterInstalls,
-        hostedClusters,
+        groupHostedClusters,
         nodePools
     )
 


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

Issue: https://github.com/stolostron/backlog/issues/25031

- Filter out HostedClusters in useClusters

![image](https://user-images.githubusercontent.com/38960034/184720276-39525b70-4b2d-4856-922c-2124d5e3cb15.png)