### PR TITLE
Bug 2119334: ACM plugin extension for Application list page column

### DIFF
--- a/frontend/src/plugin-extensions/extensions/ApplicationListPageColumn.ts
+++ b/frontend/src/plugin-extensions/extensions/ApplicationListPageColumn.ts
@@ -1,0 +1,9 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { Extension, ExtensionDeclaration } from '@openshift-console/dynamic-plugin-sdk/lib/types'
+import { ApplicationListColumnProps } from '../properties'
+
+export type ApplicationListColumn = ExtensionDeclaration<'acm.application/list/column', ApplicationListColumnProps>
+
+// Type guards
+export const isApplicationListColumn = (e: Extension): e is ApplicationListColumn =>
+    e.type === 'acm.application/list/column'

--- a/frontend/src/plugin-extensions/extensions/index.ts
+++ b/frontend/src/plugin-extensions/extensions/index.ts
@@ -1,2 +1,3 @@
 /* Copyright Contributors to the Open Cluster Management project */
 export * from './ApplicationAction'
+export * from './ApplicationListPageColumn'

--- a/frontend/src/plugin-extensions/handler.ts
+++ b/frontend/src/plugin-extensions/handler.ts
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { useResolvedExtensions } from '@openshift-console/dynamic-plugin-sdk'
-import { isApplicationAction } from './extensions'
-import { ApplicationActionProps } from './properties'
+import { isApplicationAction, isApplicationListColumn } from './extensions'
+import { ApplicationActionProps, ApplicationListColumnProps } from './properties'
 import { AcmExtension } from './types'
 
 // Type guards
@@ -12,6 +12,14 @@ export function IsAcmExtensions() {
     const [applicationAction, reslovedApplicationAction] = useResolvedExtensions(isApplicationAction)
     if (reslovedApplicationAction) {
         acmExtension.applicationAction = applicationAction.map((action) => action.properties as ApplicationActionProps)
+    }
+
+    // Resolving application list column to acm compatible type
+    const [applicationListColumn, resolvedApplicationListColumn] = useResolvedExtensions(isApplicationListColumn)
+    if (resolvedApplicationListColumn) {
+        acmExtension.applicationListColumn = applicationListColumn.map(
+            (column) => column.properties as ApplicationListColumnProps
+        )
     }
 
     // list of all acm supported extensions

--- a/frontend/src/plugin-extensions/properties/addListColumnProps.ts
+++ b/frontend/src/plugin-extensions/properties/addListColumnProps.ts
@@ -1,0 +1,17 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { ITransform } from '@patternfly/react-table'
+
+export type ApplicationListColumnProps = {
+    /** the header of the column */
+    header: string
+
+    tooltip?: React.ReactNode
+
+    transforms?: ITransform[]
+
+    cellTransforms?: ITransform[]
+
+    /** component type*/
+    cell: React.ComponentType<{ resource?: any }>
+}

--- a/frontend/src/plugin-extensions/properties/index.ts
+++ b/frontend/src/plugin-extensions/properties/index.ts
@@ -1,2 +1,3 @@
 /* Copyright Contributors to the Open Cluster Management project */
 export * from './addActionProps'
+export * from './addListColumnProps'

--- a/frontend/src/plugin-extensions/types.ts
+++ b/frontend/src/plugin-extensions/types.ts
@@ -1,6 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { ApplicationActionProps } from './properties'
+import { ApplicationActionProps, ApplicationListColumnProps } from './properties'
 
 export type AcmExtension = Partial<{
     applicationAction: ApplicationActionProps[]
+    applicationListColumn: ApplicationListColumnProps[]
 }>

--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -529,6 +529,25 @@ export default function ApplicationsOverview() {
         (resource: IResource) => resource.metadata!.uid ?? `${resource.metadata!.namespace}/${resource.metadata!.name}`,
         []
     )
+    const extensionColumns: IAcmTableColumn<IApplicationResource>[] = useMemo(
+        () =>
+            acmExtensions?.applicationListColumn?.length
+                ? acmExtensions.applicationListColumn.map((appListColumn) => {
+                      const CellComp = appListColumn.cell
+                      return {
+                          header: appListColumn.header,
+                          transforms: appListColumn?.transforms,
+                          cellTransforms: appListColumn?.cellTransforms,
+                          tooltip: appListColumn?.tooltip,
+                          cell: (application) => {
+                              return <CellComp resource={application} />
+                          },
+                      }
+                  })
+                : [],
+        [acmExtensions]
+    )
+
     const columns = useMemo<IAcmTableColumn<IApplicationResource>[]>(
         () => [
             {
@@ -670,6 +689,7 @@ export default function ApplicationsOverview() {
                 sort: 'transformed.timeWindow',
                 search: 'transformed.timeWindow',
             },
+            ...extensionColumns,
             {
                 header: t('Created'),
                 cell: (resource) => {
@@ -679,7 +699,17 @@ export default function ApplicationsOverview() {
                 search: 'transformed.createdText',
             },
         ],
-        [argoApplications, channels, getTimeWindow, localCluster, placementRules, subscriptions, t, managedClusters]
+        [
+            argoApplications,
+            channels,
+            getTimeWindow,
+            localCluster,
+            placementRules,
+            subscriptions,
+            t,
+            managedClusters,
+            extensionColumns,
+        ]
     )
 
     const filters = useMemo(


### PR DESCRIPTION
**Goal:**
   Part DR + ODF plugin UI, The application user should be able to track their application DR status from the application list page itself. 
**How?**
   An OCP custom extension to inject the column into the ACM application list page from any other plugins. (This will be visible only on ACM plugin mode).
   For more OCP custom extension: [link](https://github.com/openshift/console/pull/11051 
**Where?**
   With this PR, ACM will expose the custom extension to other plugins, ODF  plugin will inject the column using this newly exposed plugin into the application list page.
**Tested?**
  I tested this on ACM plugin mode and ACM standalone mode.
   
 ```
 To invoke ACM acm.application/list/column from other plugin console-extensions.json

{
    "type": "acm.application/list/column",
    "properties": {
      "header": "Column header",
      "tooltip": "Displaying via ACM custom plugin",
      "cell": {
        "$codeRef": "your component ref"
      }
    }
  }
 ```
[For more info](https://github.com/stolostron/console/pull/2017/files#diff-39badbec5c8b3b8f37b0f9961cadc0a6dcb0ae3e6cdad8312b0f153c2625c9d4R1-R17 )

ODF issue: https://issues.redhat.com/browse/RHSTOR-3737
   
Signed-off-by: Gowtham Shanmugasundaram <gshanmug@redhat.com>