### PR TITLE
[release-2.6] Update react-form-wizard to 1.8.6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5866,9 +5866,9 @@
             }
         },
         "@patternfly-labs/react-form-wizard": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.8.5.tgz",
-            "integrity": "sha512-1Ut0m4Gl3ptwbg2RePmoaqzL/yvkUjP8mPM/o1aunC/mJGQZamcnl9DXRRnUr6AHiW+AEtWJ8Vs3wBU+t/RBQw==",
+            "version": "1.8.6",
+            "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.8.6.tgz",
+            "integrity": "sha512-QyjMhRYRiW9SrdzSUq0FSoUMaukhEGetdgpnZYfEOrKTJFA83eEsfmSQK897TtVcJVWVyUZd1bcq7oDTYNKtdw==",
             "requires": {
                 "get-value": "3.0.1",
                 "klona": "2.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,7 +37,7 @@
         "@material-ui/styles": "4.11.5",
         "@octokit/rest": "19.0.3",
         "@octokit/types": "6.40.0",
-        "@patternfly-labs/react-form-wizard": "1.8.5",
+        "@patternfly-labs/react-form-wizard": "1.8.6",
         "@patternfly/patternfly": "4.196.7",
         "@patternfly/react-charts": "6.74.3",
         "@patternfly/react-code-editor": "4.65.1",


### PR DESCRIPTION
Includes a fix for radio labels not always corresponding to the correct
radio input.

Refs:
 - https://github.com/stolostron/backlog/issues/25009

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>