### PR TITLE
Remove plural trimming logic

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.test.tsx
@@ -105,7 +105,7 @@ const getResourceResponse = {
                 relatedObjects: [
                     {
                         compliant: 'Compliant',
-                        object: { apiVersion: 'v1', kind: 'namespaces', metadata: { name: 'test' } },
+                        object: { apiVersion: 'v1', kind: 'namespace', metadata: { name: 'test' } },
                         reason: 'Resource found as expected',
                         cluster: 'test-cluster',
                     },
@@ -154,7 +154,7 @@ describe('Policy Template Details content', () => {
         // wait for related resources table to load correctly
         await waitForText('Related resources')
         await waitForText('test')
-        await waitForText('namespaces')
+        await waitForText('namespace')
         await waitForText('v1')
         await waitForText('No violations')
         await waitForText('Resource found as expected')

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
@@ -187,16 +187,12 @@ export function PolicyTemplateDetails(props: {
             {
                 header: '',
                 cell: (item: any) => {
-                    let {
-                        // eslint-disable-next-line prefer-const
+                    const {
                         cluster,
-                        // eslint-disable-next-line prefer-const
                         reason,
                         object: {
-                            // eslint-disable-next-line prefer-const
                             apiVersion,
                             kind,
-                            // eslint-disable-next-line prefer-const
                             metadata: { name, namespace = '' },
                         },
                     } = item
@@ -205,11 +201,6 @@ export function PolicyTemplateDetails(props: {
                         reason === 'Resource not found as expected'
                     ) {
                         return ''
-                    }
-                    if (kind.endsWith('ies')) {
-                        kind = kind.slice(0, -3)
-                    } else if (kind.endsWith('s')) {
-                        kind = kind.slice(0, -1)
                     }
                     if (cluster && kind && apiVersion && name) {
                         if (namespace !== '') {

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetailsPage.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetailsPage.test.tsx
@@ -39,6 +39,6 @@ describe('Policy Template Details Page', () => {
         // wait for page load - looking for breadcrumb items
         await waitForText('Policies')
         await waitForText('policy-set-with-1-placement-policy')
-        await waitForText('policy-set-with-1-placement-policy-1', true) // policy-set-with-1-placement-policy-1 is in breadcurmb and also the page header - so set multipleAllowed prop to true
+        await waitForText('policy-set-with-1-placement-policy-1', true) // policy-set-with-1-placement-policy-1 is in breadcrumb and also the page header - so set multipleAllowed prop to true
     })
 })


### PR DESCRIPTION
This interferes with Search successfully returning results on some clusters, I'm guessing the search interference may partially be because the CRD for `SecurityContextConstraints` looks like this:

```yaml
spec:
  group: security.openshift.io
  names:
    kind: SecurityContextConstraints
    listKind: SecurityContextConstraintsList
    plural: securitycontextconstraints
    singular: securitycontextconstraints
```

Addresses:
- https://github.com/stolostron/backlog/issues/25166