### PR TITLE
Add resource counts to ClusterTemplatesPage tabs

### DIFF
--- a/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplatesPage/ClusterTemplatesPage.tsx
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplatesPage/ClusterTemplatesPage.tsx
@@ -1,29 +1,39 @@
 /* Copyright Contributors to the Open Cluster Management project */
+import React from 'react';
 import {
   HorizontalNav,
   ListPageCreate,
   ListPageCreateButton,
   ListPageHeader,
+  NavPage,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useHistory } from 'react-router-dom';
 import ClusterTemplatesTab from './ClusterTemplatesTab';
-import HelmRepositoriesPage from './HelmRepositoriesPage';
-
-const pages = [
-  {
-    href: '',
-    name: 'Templates',
-    component: ClusterTemplatesTab,
-  },
-  {
-    href: 'repositories',
-    name: 'HELM repositories',
-    component: HelmRepositoriesPage,
-  },
-];
+import HelmRepositoriesTab from './HelmRepositoriesTab';
+import { useClusterTemplatesCount } from '../hooks/useClusterTemplates';
+import { useHelmRepositoriesCount } from '../hooks/useHelmRepositories';
+import { getNavLabelWithCount } from '../utils';
 
 const ClusterTemplatesPage = () => {
   const history = useHistory();
+  const templatesCount = useClusterTemplatesCount();
+  const helmRepositoriesCount = useHelmRepositoriesCount();
+
+  const pages: NavPage[] = React.useMemo(
+    () => [
+      {
+        href: '',
+        name: getNavLabelWithCount('Templates', templatesCount),
+        component: ClusterTemplatesTab,
+      },
+      {
+        href: 'repositories',
+        name: getNavLabelWithCount('HELM repositories', helmRepositoriesCount),
+        component: HelmRepositoriesTab,
+      },
+    ],
+    [templatesCount, helmRepositoriesCount],
+  );
 
   const repositoriesPage = history.location.pathname.endsWith('/repositories');
   return (

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplatesPage/ClusterTemplatesTab.tsx
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplatesPage/ClusterTemplatesTab.tsx
@@ -6,7 +6,6 @@ import {
   RowProps,
   TableData,
   useK8sModel,
-  useK8sWatchResource,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -20,8 +19,10 @@ import {
   Skeleton,
 } from '@patternfly/react-core';
 import { sortable } from '@patternfly/react-table';
-import { clusterTemplateGVK, clusterTemplateInstanceGVK, helmRepoGVK } from '../constants';
-import { ClusterTemplate, ClusterTemplateInstance } from '../types';
+import { clusterTemplateGVK, helmRepoGVK } from '../constants';
+import { ClusterTemplate } from '../types';
+import { useClusterTemplates } from '../hooks/useClusterTemplates';
+import { useClusterTemplateInstances } from '../hooks/useClusterTemplateInstances';
 
 const columns = [
   {
@@ -57,11 +58,7 @@ const TemplateRow: React.FC<RowProps<ClusterTemplate>> = ({ obj, activeColumnIDs
   const [isOpen, setOpen] = React.useState(false);
   const [isDeleteOpen, setDeleteOpen] = React.useState(false);
   const [model] = useK8sModel(clusterTemplateGVK);
-
-  const [instances, loaded, loadError] = useK8sWatchResource<ClusterTemplateInstance[]>({
-    groupVersionKind: clusterTemplateInstanceGVK,
-    isList: true,
-  });
+  const [instances, loaded, loadError] = useClusterTemplateInstances();
 
   return (
     <>
@@ -144,10 +141,7 @@ const TemplateRow: React.FC<RowProps<ClusterTemplate>> = ({ obj, activeColumnIDs
 };
 
 const ClusterTemplatesTab = () => {
-  const [templates, loaded, loadError] = useK8sWatchResource<ClusterTemplate[]>({
-    groupVersionKind: clusterTemplateGVK,
-    isList: true,
-  });
+  const [templates, loaded, loadError] = useClusterTemplates();
 
   return (
     <PageSection>

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplatesPage/HelmRepositoriesTab.tsx
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplatesPage/HelmRepositoriesTab.tsx
@@ -6,7 +6,6 @@ import {
   RowProps,
   TableData,
   useK8sModel,
-  useK8sWatchResource,
   VirtualizedTable,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
@@ -23,10 +22,11 @@ import {
 import { CheckCircleIcon } from '@patternfly/react-icons';
 import { sortable } from '@patternfly/react-table';
 import { ExternalLink } from 'openshift-assisted-ui-lib/cim';
-import { clusterTemplateGVK, helmRepoGVK } from '../constants';
-import { ClusterTemplate, HelmChartRepository, HelmRepoIndex } from '../types';
+import { helmRepoGVK } from '../constants';
+import { HelmChartRepository, HelmRepoIndex } from '../types';
 import { useHelmRepositories } from '../hooks/useHelmRepositories';
 import { useHelmRepositoryIndex, getRepoCharts } from '../hooks/useHelmRepositoryIndex';
+import { useClusterTemplates } from '../hooks/useClusterTemplates';
 
 const columns = [
   {
@@ -65,10 +65,7 @@ const HelmRepoRow: React.FC<RowProps<HelmChartRepository>> = ({ obj, activeColum
   const [isDeleteOpen, setDeleteOpen] = React.useState(false);
   const [model] = useK8sModel(helmRepoGVK);
   const { indexFile, loaded, error } = React.useContext(RowContext);
-  const [templates, templatesLoaded, loadError] = useK8sWatchResource<ClusterTemplate[]>({
-    groupVersionKind: clusterTemplateGVK,
-    isList: true,
-  });
+  const [templates, templatesLoaded, loadError] = useClusterTemplates();
 
   const templatesFromRepo = templates.filter(
     (t) => t.spec.helmChartRef.repository === obj.metadata?.name,
@@ -167,7 +164,7 @@ const RowContext = React.createContext<{
   error: undefined,
 });
 
-const HelmRepositoriesPage = () => {
+const HelmRepositoriesTab = () => {
   const [repositories, loaded, loadError] = useHelmRepositories();
   const [repoIndex, repoLoaded, repoError] = useHelmRepositoryIndex();
 
@@ -193,4 +190,4 @@ const HelmRepositoriesPage = () => {
   );
 };
 
-export default HelmRepositoriesPage;
+export default HelmRepositoriesTab;

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/hooks/useClusterTemplateInstances.ts
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/hooks/useClusterTemplateInstances.ts
@@ -1,0 +1,10 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { clusterTemplateInstanceGVK } from '../constants';
+import { ClusterTemplateInstance } from '../types';
+
+export const useClusterTemplateInstances = (): [ClusterTemplateInstance[], boolean, unknown] =>
+  useK8sWatchResource<ClusterTemplateInstance[]>({
+    groupVersionKind: clusterTemplateInstanceGVK,
+    isList: true,
+  });

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/hooks/useClusterTemplates.ts
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/hooks/useClusterTemplates.ts
@@ -1,0 +1,15 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import { clusterTemplateGVK } from '../constants';
+import { ClusterTemplate } from '../types';
+
+export const useClusterTemplates = (): [ClusterTemplate[], boolean, unknown] =>
+  useK8sWatchResource<ClusterTemplate[]>({
+    groupVersionKind: clusterTemplateGVK,
+    isList: true,
+  });
+
+export const useClusterTemplatesCount = () => {
+  const [templates, loaded, error] = useClusterTemplates();
+  return loaded && !error ? templates.length : undefined;
+};

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/hooks/useHelmRepositories.ts
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/hooks/useHelmRepositories.ts
@@ -16,3 +16,8 @@ export const useHelmRepositories = (): [HelmChartRepository[], boolean, unknown]
   );
   return [templateRepositories, loaded, loadError];
 };
+
+export const useHelmRepositoriesCount = () => {
+  const [templates, loaded, error] = useHelmRepositories();
+  return loaded && !error ? templates.length : undefined;
+};

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/utils.ts
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/utils.ts
@@ -1,0 +1,7 @@
+/* Copyright Contributors to the Open Cluster Management project */
+export const getNavLabelWithCount = (label: string, count?: number) => {
+  if (count === undefined) {
+    return label;
+  }
+  return `${label} (${count})`;
+};


### PR DESCRIPTION
- Add hooks for watching ClusterTemplates resources
- Rename HelmChartRepositoriesPage to HelmChartRepositoriesTab

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>