### PR TITLE
testing debug flag --foreground-scripts

### DIFF
--- a/Dockerfile.mce.prow
+++ b/Dockerfile.mce.prow
@@ -3,7 +3,7 @@
 FROM registry.ci.openshift.org/stolostron/builder:nodejs14-linux as dynamic-plugin
 WORKDIR /app/frontend
 COPY ./frontend .
-RUN npm ci --no-optional || npm ci --no-optional
+RUN npm ci --no-optional --foreground-scripts || npm ci --no-optional --foreground-scripts
 RUN npm run build:plugin:mce
 
 FROM registry.ci.openshift.org/stolostron/builder:nodejs14-linux as backend

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -5,7 +5,7 @@ WORKDIR /app/frontend
 # Copy only package.json and package-lock.json so that the docker cache hash only changes if those change
 # This will cause the npm ci to only rerun if the package.json or package-lock.json changes
 COPY ./frontend/package.json ./frontend/package-lock.json ./
-RUN npm ci --no-optional || npm ci --no-optional
+RUN npm ci --no-optional --foreground-scripts || npm ci --no-optional --foreground-scripts
 COPY ./frontend .
 
 FROM frontend-packages as frontend


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

Testing install flag on npm ci to reveal error causing failure from cb() never called 
`npm ci --no-optional --foreground-scripts`

source - https://github.com/npm/statusboard/issues/395#issuecomment-1003256492