### PR TITLE
Added support for deploy local MCE builds for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "podman:build:mce": "podman build --file Dockerfile.mce.prow --tag console-mce .",
         "podman:run": "npm run podman:build && podman run --rm --name console -p 3000:3000 -e PORT=3000 -v $PWD/backend/certs:/app/certs -v $PWD/backend/config:/app/config --env-file=backend/.env console | ./backend/node_modules/.bin/pino-zen -i time && podman rm -f console",
         "podman:deploy": "npm run podman:build && podman tag console quay.io/$USER/console:latest && podman push quay.io/$USER/console:latest && ./scripts/patch-deployment.sh latest quay.io/$USER/console",
+        "podman:deploy:mce": "npm run podman:build:mce && podman tag console-mce quay.io/$USER/console-mce:latest && podman push quay.io/$USER/console-mce:latest && ./scripts/patch-deployment.sh latest quay.io/$USER/console-mce",
         "setup": "./setup.sh",
         "prepare": "husky install"
     },

--- a/scripts/patch-deployment.sh
+++ b/scripts/patch-deployment.sh
@@ -13,16 +13,24 @@ IMAGE=${2:-quay.io/stolostron/console}
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 cd $DIR
 
-DEPLOYMENT=`oc get deployment -n open-cluster-management --selector=app=console-chart-v2,component=console -o="jsonpath={.items[0].metadata.name}"`
+# default to MCE since it does not need any calculation
+NS='multicluster-engine'
+DEPLOYMENT='console-mce-console'
 
-kubectl scale deployment.v1.apps/$DEPLOYMENT -n open-cluster-management --replicas=0
+if [[ "$IMAGE" != *"console-mce" ]]; then
+    # if its not MCE than its ACM
+    NS='open-cluster-management'
+    DEPLOYMENT=`oc get deployment -n $NS --selector=app=console-chart-v2,component=console -o="jsonpath={.items[0].metadata.name}"`
+fi
+
+kubectl scale deployment.v1.apps/$DEPLOYMENT -n $NS --replicas=0
 
 PATCH='[{"op":"replace","path":"/spec/template/spec/containers/0/imagePullPolicy","value":"Always"}]'
-oc patch deployment $DEPLOYMENT -n open-cluster-management --type='json' -p $PATCH
+oc patch deployment $DEPLOYMENT -n $NS --type='json' -p $PATCH
 
 PATCH='[{"op":"replace","path":"/spec/template/spec/containers/0/image","value":"'${IMAGE}':'$1'"}]'
-oc patch deployment $DEPLOYMENT -n open-cluster-management --type='json' -p $PATCH
+oc patch deployment $DEPLOYMENT -n $NS --type='json' -p $PATCH
 
-kubectl scale deployment.v1.apps/$DEPLOYMENT -n open-cluster-management --replicas=1
+kubectl scale deployment.v1.apps/$DEPLOYMENT -n $NS --replicas=1
 
-oc get deployment $DEPLOYMENT -n open-cluster-management -o="jsonpath={.spec.template.spec.containers[0].image}"
+oc get deployment $DEPLOYMENT -n $NS -o="jsonpath={.spec.template.spec.containers[0].image}"


### PR DESCRIPTION
The support for deploying ACM was there for some time, but the MCE was
missing.

This patch adds MCE support in a way that the API does not change, so if
someone uses the current solution in scripts, it will keep working.

Signed-off-by: Tomas Jelinek <tjelinek@redhat.com>