### PR TITLE
GRC tables don't expand full width of screen like the rest of ACM tables

### DIFF
--- a/frontend/src/routes/Governance/overview/Overview.tsx
+++ b/frontend/src/routes/Governance/overview/Overview.tsx
@@ -43,7 +43,7 @@ export default function GovernanceOverview() {
         )
     }
     return (
-        <PageSection isWidthLimited>
+        <PageSection>
             <Stack hasGutter>
                 <AcmMasonry minSize={415} maxColumns={3}>
                     <PolicySetViolationsCard />

--- a/frontend/src/routes/Governance/policies/Policies.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.tsx
@@ -704,7 +704,7 @@ export default function PoliciesPage() {
     }
 
     return (
-        <PageSection isWidthLimited>
+        <PageSection>
             {modal !== undefined && modal}
             <BulkActionModel<PolicyTableItem> {...modalProps} />
             <AcmTable<PolicyTableItem>


### PR DESCRIPTION
Signed-off-by: Chunxi Luo <chuluo@redhat.com>

https://github.com/stolostron/backlog/issues/25597

`isWidthLimited` is introduced in https://github.com/stolostron/console/pull/1112

@jamestalton @KevinFCormier @RobDolares  let me know if removing `isWidthLimited` will cause any potential issue.