### PR TITLE
Handle clusters with different name and namespace

### DIFF
--- a/frontend/src/NavigationPath.ts
+++ b/frontend/src/NavigationPath.ts
@@ -3,6 +3,19 @@
 import { LocationDescriptor } from 'history'
 import { useMemo } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
+import { generatePath } from 'react-router'
+import { Cluster } from './resources'
+
+export const getClusterNavPath = (
+    navPath:
+        | NavigationPath.editCluster
+        | NavigationPath.clusterDetails
+        | NavigationPath.clusterOverview
+        | NavigationPath.clusterSettings
+        | NavigationPath.clusterMachinePools
+        | NavigationPath.clusterNodes,
+    cluster: Cluster
+) => generatePath(navPath, { name: cluster.name, namespace: cluster.namespace || '~managed-cluster' })
 
 export enum NavigationPath {
     // Console
@@ -29,11 +42,11 @@ export enum NavigationPath {
     createDiscoverHost = '/multicloud/infrastructure/clusters/create/discover-host',
     createCluster = '/multicloud/infrastructure/clusters/create',
     editCluster = '/multicloud/infrastructure/clusters/edit/:namespace/:name',
-    clusterDetails = '/multicloud/infrastructure/clusters/details/:id',
-    clusterOverview = '/multicloud/infrastructure/clusters/details/:id/overview',
-    clusterSettings = '/multicloud/infrastructure/clusters/details/:id/settings',
-    clusterMachinePools = '/multicloud/infrastructure/clusters/details/:id/machinepools',
-    clusterNodes = '/multicloud/infrastructure/clusters/details/:id/nodes',
+    clusterDetails = '/multicloud/infrastructure/clusters/details/:namespace/:name',
+    clusterOverview = '/multicloud/infrastructure/clusters/details/:namespace/:name/overview',
+    clusterSettings = '/multicloud/infrastructure/clusters/details/:namespace/:name/settings',
+    clusterMachinePools = '/multicloud/infrastructure/clusters/details/:namespace/:name/machinepools',
+    clusterNodes = '/multicloud/infrastructure/clusters/details/:namespace/:name/nodes',
     importCluster = '/multicloud/infrastructure/clusters/import',
     importCommand = '/multicloud/infrastructure/clusters/import/:clusterName',
 

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -279,9 +279,9 @@ export function getCluster(
             hostedCluster?.metadata?.name ??
             selectedHostedCluster?.name,
         namespace:
-            managedCluster?.metadata.name ??
             clusterDeployment?.metadata.namespace ??
-            managedClusterInfo?.metadata.namespace,
+            managedClusterInfo?.metadata.namespace ??
+            hostedCluster?.metadata.namespace,
         uid:
             managedCluster?.metadata.uid ??
             clusterDeployment?.metadata.uid ??

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -4,8 +4,8 @@ import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from 
 import { AcmTable, AcmTablePaginationContextProvider, compareStrings } from '../../../../ui-components'
 import moment from 'moment'
 import { useEffect, useMemo, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { useRecoilState, useSharedAtoms } from '../../../../shared-recoil'
+import { generatePath, Link } from 'react-router-dom'
 import { useTranslation } from '../../../../lib/acm-i18next'
 import { checkPermission, rbacCreate } from '../../../../lib/rbac-util'
 import { transformBrowserUrlToFilterPresets } from '../../../../lib/urlQuery'
@@ -86,7 +86,10 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
                 cell: (item: resultsTableData) => (
                     <Link
                         to={{
-                            pathname: NavigationPath.clusterOverview.replace(':id', item.clusterNamespace),
+                            pathname: generatePath(NavigationPath.clusterOverview, {
+                                name: item.cluster,
+                                namespace: item.clusterNamespace || '~managed-cluster',
+                            }),
                         }}
                     >
                         {item.clusterNamespace}

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/components/ClusterClaimModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/components/ClusterClaimModal.tsx
@@ -28,7 +28,7 @@ import {
 } from '@patternfly/react-core'
 import { useEffect, useState } from 'react'
 import { Trans, useTranslation } from '../../../../../lib/acm-i18next'
-import { useHistory } from 'react-router-dom'
+import { generatePath, useHistory } from 'react-router-dom'
 import { NavigationPath } from '../../../../../NavigationPath'
 
 export type ClusterClaimModalProps = {
@@ -216,8 +216,15 @@ export function ClusterClaimModal(props: ClusterClaimModalProps) {
                         key="view-cluster"
                         variant="primary"
                         role="link"
+                        isDisabled={!clusterClaim?.spec?.namespace}
                         onClick={() =>
-                            history.push(NavigationPath.clusterOverview.replace(':id', clusterClaim!.spec!.namespace!))
+                            clusterClaim?.spec?.namespace &&
+                            history.push(
+                                generatePath(NavigationPath.clusterOverview, {
+                                    name: clusterClaim?.spec?.namespace,
+                                    namespace: clusterClaim?.spec?.namespace,
+                                })
+                            )
                         }
                     >
                         {t('clusterClaim.modal.viewCluster')}

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.test.tsx
@@ -971,7 +971,7 @@ describe('ClusterSetDetails page', () => {
         await waitForText('Details')
 
         await clickByText('Cluster list')
-        await waitForText(clusterSetCluster.metadata.name!)
+        await waitForText(clusterSetCluster.metadata.name!, true)
 
         await clickByText('Cluster pools')
     })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
@@ -253,9 +253,15 @@ export default function CreateCluster(props: { infrastructureType: ClusterInfras
                 if (status === 'DONE') {
                     const finishMessage = completedMsg ? [completedMsg] : []
                     setCreationStatus({ status, messages: finishMessage })
-                    if (!noRedirect) {
+                    const namespace = cluster?.metadata?.namespace
+                    if (!noRedirect && clusterName && namespace) {
                         setTimeout(() => {
-                            history.push(generatePath(NavigationPath.clusterDetails, { id: clusterName as string }))
+                            history.push(
+                                generatePath(NavigationPath.clusterDetails, {
+                                    name: clusterName,
+                                    namespace,
+                                })
+                            )
                         }, 2000)
                     }
                 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/utils.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/utils.ts
@@ -1,6 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useCallback, useMemo, useState, useEffect } from 'react'
+import { generatePath } from 'react-router'
 import { isEqual } from 'lodash'
 import { CIM } from 'openshift-assisted-ui-lib'
 
@@ -352,8 +353,8 @@ export const onApproveAgent = (agent: CIM.AgentK8sResource) =>
         },
     ]).promise
 
-export const getClusterDeploymentLink = ({ name }: { name: string }) =>
-    NavigationPath.clusterDetails.replace(':id', name)
+export const getClusterDeploymentLink = ({ name, namespace }: { name: string; namespace: string }) =>
+    generatePath(NavigationPath.clusterDetails, { name, namespace })
 
 export const fetchSecret = (namespace: string, name: string) =>
     getResource({ apiVersion: 'v1', kind: 'Secret', metadata: { namespace, name } }).promise

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -419,7 +419,12 @@ export default function ImportClusterPage() {
                                 autoClose: true,
                             })
                             setTimeout(() => {
-                                history.push(generatePath(NavigationPath.clusterDetails, { id: state.clusterName }))
+                                history.push(
+                                    generatePath(NavigationPath.clusterDetails, {
+                                        name: state.clusterName,
+                                        namespace: '~managed-cluster',
+                                    })
+                                )
                             }, 2000)
                         } catch (err) {
                             if (err instanceof Error) {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.test.tsx
@@ -426,7 +426,7 @@ describe('Clusters Page', () => {
                 </MemoryRouter>
             </RecoilRoot>
         )
-        await waitForText(mockManagedCluster0.metadata.name!)
+        await waitForText(mockManagedCluster0.metadata.name!, true)
     })
 
     test('should be able to delete cluster using row action', async () => {
@@ -539,7 +539,7 @@ describe('Clusters Page RBAC', () => {
                 </MemoryRouter>
             </RecoilRoot>
         )
-        await waitForText(mockManagedCluster0.metadata.name!)
+        await waitForText(mockManagedCluster0.metadata.name!, true)
         await waitForNock(rbacCreateManagedClusterNock)
         await waitForNocks(upgradeRBACNocks)
     })
@@ -569,7 +569,7 @@ describe('Clusters Page hypershift', () => {
                 </MemoryRouter>
             </RecoilRoot>
         )
-        await waitForText(mockManagedCluster6.metadata.name!)
+        await waitForText(mockManagedCluster6.metadata.name!, true)
     })
 })
 
@@ -593,7 +593,7 @@ describe('Clusters Page regional hub cluster', () => {
                 </MemoryRouter>
             </RecoilRoot>
         )
-        await waitForText(mockManagedCluster8.metadata.name!)
+        await waitForText(mockManagedCluster8.metadata.name!, true)
         await waitForText('Hub')
     })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -25,7 +25,7 @@ import { BulkActionModel, errorIsNot, IBulkActionModelProps } from '../../../../
 import { Trans, useTranslation } from '../../../../lib/acm-i18next'
 import { deleteCluster, detachCluster } from '../../../../lib/delete-cluster'
 import { canUser } from '../../../../lib/rbac-util'
-import { createBackCancelLocation, NavigationPath } from '../../../../NavigationPath'
+import { createBackCancelLocation, getClusterNavPath, NavigationPath } from '../../../../NavigationPath'
 import {
     addonPathKey,
     addonTextKey,
@@ -167,6 +167,7 @@ export function ClustersTable(props: {
     }, [])
 
     const clusterNameColumn = useClusterNameColumn()
+    const clusterNamespaceColumn = useClusterNamespaceColumn()
     const clusterStatusColumn = useClusterStatusColumn()
     const clusterProviderColumn = useClusterProviderColumn()
     const clusterControlPlaneColumn = useClusterControlPlaneColumn()
@@ -183,6 +184,7 @@ export function ClustersTable(props: {
     const columns = useMemo<IAcmTableColumn<Cluster>[]>(
         () => [
             clusterNameColumn,
+            clusterNamespaceColumn,
             clusterStatusColumn,
             clusterProviderColumn,
             clusterControlPlaneColumn,
@@ -200,6 +202,7 @@ export function ClustersTable(props: {
         ],
         [
             clusterNameColumn,
+            clusterNamespaceColumn,
             clusterStatusColumn,
             clusterProviderColumn,
             clusterControlPlaneColumn,
@@ -443,9 +446,7 @@ export function useClusterNameColumn(): IAcmTableColumn<Cluster> {
         cell: (cluster) => (
             <>
                 <span style={{ whiteSpace: 'nowrap' }}>
-                    <Link to={NavigationPath.clusterDetails.replace(':id', cluster.name as string)}>
-                        {cluster.displayName}
-                    </Link>
+                    <Link to={getClusterNavPath(NavigationPath.clusterDetails, cluster)}>{cluster.displayName}</Link>
                 </span>
                 {cluster.hive.clusterClaimName && (
                     <TextContent>
@@ -454,6 +455,15 @@ export function useClusterNameColumn(): IAcmTableColumn<Cluster> {
                 )}
             </>
         ),
+    }
+}
+
+export function useClusterNamespaceColumn(): IAcmTableColumn<Cluster> {
+    const { t } = useTranslation()
+    return {
+        header: t('table.namespace'),
+        sort: 'namespace',
+        cell: (cluster) => cluster.namespace || '-',
     }
 }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
@@ -4,7 +4,7 @@ import { AcmButton, AcmInlineStatus, StatusType, Provider } from '../../../../..
 import { ExternalLinkAltIcon, DownloadIcon } from '@patternfly/react-icons'
 import { Trans, useTranslation } from '../../../../../lib/acm-i18next'
 import { Link, useLocation } from 'react-router-dom'
-import { NavigationPath } from '../../../../../NavigationPath'
+import { getClusterNavPath, NavigationPath } from '../../../../../NavigationPath'
 import { ClusterStatusMessageAlert } from './ClusterStatusMessageAlert'
 import { launchLogs, launchToYaml } from './HiveNotification'
 import { CIM } from 'openshift-assisted-ui-lib'
@@ -169,9 +169,7 @@ export function StatusField(props: { cluster: Cluster }) {
         case ClusterStatus.degraded:
             hasAction = true
             Action = () => (
-                <Link to={`${NavigationPath.clusterSettings.replace(':id', props.cluster?.name!)}`}>
-                    {t('view.addons')}
-                </Link>
+                <Link to={getClusterNavPath(NavigationPath.clusterSettings, props.cluster)}>{t('view.addons')}</Link>
             )
             break
         case ClusterStatus.draft:

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from '../../../../../lib/acm-i18next'
 import { PluginContext } from '../../../../../lib/PluginContext'
 import { ISearchResult, queryStatusCount } from '../../../../../lib/search'
 import { useQuery } from '../../../../../lib/useQuery'
-import { NavigationPath } from '../../../../../NavigationPath'
+import { getClusterNavPath, NavigationPath } from '../../../../../NavigationPath'
 import { IRequestResult } from '../../../../../resources'
 import { useRecoilState, useSharedAtoms } from '../../../../../shared-recoil'
 import { AcmCountCardSection, AcmDrawerContext } from '../../../../../ui-components'
@@ -80,7 +80,8 @@ export function StatusSummaryCount() {
                     {
                         id: 'nodes',
                         count: /* istanbul ignore next */ (cluster?.nodes?.nodeList ?? []).length,
-                        countClick: () => push(NavigationPath.clusterNodes.replace(':id', cluster?.name!)),
+                        countClick: () =>
+                            cluster ? push(getClusterNavPath(NavigationPath.clusterNodes, cluster)) : undefined,
                         title: t('summary.nodes'),
                         description: (
                             <Trans

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.tsx
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 /* eslint-disable react-hooks/exhaustive-deps */
 import { useEffect, useState, useMemo } from 'react'
-import { RouteComponentProps, StaticContext, useHistory } from 'react-router'
+import { RouteComponentProps, StaticContext, useHistory, generatePath } from 'react-router'
 import { CIM } from 'openshift-assisted-ui-lib'
 import { ClusterDeploymentWizardStepsType } from 'openshift-assisted-ui-lib/cim'
 import { PageSection, Switch } from '@patternfly/react-core'
@@ -163,7 +163,7 @@ const EditAICluster: React.FC<EditAIClusterProps> = ({
             },
         ]).promise
 
-        history.push(NavigationPath.clusterDetails.replace(':id', agentClusterInstall.metadata.name))
+        history.push(generatePath(NavigationPath.clusterDetails, { name, namespace }))
     }
 
     return patchingHoldInstallation || !clusterDeployment || !agentClusterInstall ? (
@@ -177,7 +177,7 @@ const EditAICluster: React.FC<EditAIClusterProps> = ({
                         { text: t('Clusters'), to: NavigationPath.clusters },
                         {
                             text: clusterDeployment?.metadata?.name,
-                            to: NavigationPath.clusterDetails.replace(':id', name as string),
+                            to: generatePath(NavigationPath.clusterDetails, { name, namespace }),
                         },
                         {
                             text: t('managed.ai.editCluster.configurationBreadcrumb'),


### PR DESCRIPTION
This PR adds ability to handle clusters with different name to namespace. Until now such clusters were visible in clusters list, however it was not possible to access the cluster's details page (404) as the details page route had only `id` param which was used to match both cluster name and namespace.

I've changed the details routes to contain both name and namespace as params.

Signed-off-by: Rastislav Wagner <rawagner@redhat.com>