### PR TITLE
Fix catalog routes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7171,14 +7171,14 @@
             }
         },
         "@stolostron/react-data-view": {
-            "version": "1.0.38",
-            "resolved": "https://registry.npmjs.org/@stolostron/react-data-view/-/react-data-view-1.0.38.tgz",
-            "integrity": "sha512-jCk+yEVNWyPVh1ZG5OKfmgZdWJa6biD8CRz2VrOlv8B4MX0W2WHOUSTBxZtgaDw3KgMqhIO5S178JXcDYed1pA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@stolostron/react-data-view/-/react-data-view-1.2.0.tgz",
+            "integrity": "sha512-tg9KGLoW/y4XBmR2xTym68cx3hdI3W63J+Av3RNWlnUp6uL9D2uAnaSDYQnV0RGxY7dG0W5XbMLd2fnZApHuYA==",
             "requires": {
                 "debounce": "1.2.1",
                 "fuse.js": "6.6.2",
                 "get-value": "3.0.1",
-                "luxon": "^3.0.1"
+                "luxon": "^3.0.4"
             }
         },
         "@storybook/addon-a11y": {
@@ -26445,9 +26445,9 @@
             "dev": true
         },
         "luxon": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.1.tgz",
-            "integrity": "sha512-hF3kv0e5gwHQZKz4wtm4c+inDtyc7elkanAsBq+fundaCdUBNJB1dHEGUZIM6SfSBUlbVFduPwEtNjFK8wLtcw=="
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.0.4.tgz",
+            "integrity": "sha512-aV48rGUwP/Vydn8HT+5cdr26YYQiUZ42NM6ToMoaGKwYfWbfLeRkEu1wXWMHBZT6+KyLfcbbtVcoQFCbbPjKlw=="
         },
         "lz-string": {
             "version": "1.4.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
         "@react-hook/resize-observer": "1.2.5",
         "@redhat-cloud-services/rule-components": "^3.2.5",
         "@reduxjs/toolkit": "1.8.x",
-        "@stolostron/react-data-view": "^1.0.38",
+        "@stolostron/react-data-view": "^1.2.0",
         "ajv": "8.11.0",
         "axios": "0.27.2",
         "cidr-tools": "4.3.0",

--- a/frontend/src/NavigationPath.ts
+++ b/frontend/src/NavigationPath.ts
@@ -22,9 +22,8 @@ export enum NavigationPath {
     // Infrastructure - Clusters - Managed Clusters
     clusters = '/multicloud/infrastructure/clusters',
     managedClusters = '/multicloud/infrastructure/clusters/managed',
-    createInfrastructure = '/multicloud/infrastructure/clusters/create/infrastructure',
     createControlPlane = '/multicloud/infrastructure/clusters/create/control-plane',
-    createDicoverHost = '/multicloud/infrastructure/clusters/create/discover-host',
+    createDiscoverHost = '/multicloud/infrastructure/clusters/create/discover-host',
     createCluster = '/multicloud/infrastructure/clusters/create',
     editCluster = '/multicloud/infrastructure/clusters/edit/:namespace/:name',
     clusterDetails = '/multicloud/infrastructure/clusters/details/:id',

--- a/frontend/src/NavigationPath.ts
+++ b/frontend/src/NavigationPath.ts
@@ -49,7 +49,6 @@ export enum NavigationPath {
     // Infrastructure - Clusters - Cluster Pools
     clusterPools = '/multicloud/infrastructure/clusters/pools',
     createClusterPool = '/multicloud/infrastructure/clusters/pools/create',
-    createClusterPoolInfrastructure = '/multicloud/infrastructure/clusters/pools/create/infrastructure',
 
     // Infrastructure - Clusters - Discovery
     discoveredClusters = '/multicloud/infrastructure/clusters/discovered',

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
@@ -33,7 +33,7 @@ import { TechPreviewAlert } from '../../../../components/TechPreviewAlert'
 import { Trans, useTranslation } from '../../../../lib/acm-i18next'
 import { DOC_LINKS, viewDocumentation } from '../../../../lib/doc-util'
 import { rbacCreate, rbacDelete, rbacPatch } from '../../../../lib/rbac-util'
-import { NavigationPath } from '../../../../NavigationPath'
+import { createBackCancelLocation, NavigationPath } from '../../../../NavigationPath'
 import {
     Cluster,
     ClusterClaim,
@@ -115,7 +115,8 @@ export default function ClusterPoolsPage() {
                                 {
                                     id: 'createClusterPool',
                                     title: t('managed.createClusterPool'),
-                                    click: () => history.push(NavigationPath.createClusterPool),
+                                    click: () =>
+                                        history.push(createBackCancelLocation(NavigationPath.createClusterPool)),
                                     variant: ButtonVariant.primary,
                                 },
                             ]}
@@ -133,7 +134,11 @@ export default function ClusterPoolsPage() {
                                         <div>
                                             <AcmButton
                                                 role="link"
-                                                onClick={() => history.push(NavigationPath.createClusterPool)}
+                                                onClick={() =>
+                                                    history.push(
+                                                        createBackCancelLocation(NavigationPath.createClusterPool)
+                                                    )
+                                                }
                                             >
                                                 {t('managed.createClusterPool')}
                                             </AcmButton>

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
@@ -115,7 +115,7 @@ export default function ClusterPoolsPage() {
                                 {
                                     id: 'createClusterPool',
                                     title: t('managed.createClusterPool'),
-                                    click: () => history.push(NavigationPath.createClusterPoolInfrastructure),
+                                    click: () => history.push(NavigationPath.createClusterPool),
                                     variant: ButtonVariant.primary,
                                 },
                             ]}
@@ -133,9 +133,7 @@ export default function ClusterPoolsPage() {
                                         <div>
                                             <AcmButton
                                                 role="link"
-                                                onClick={() =>
-                                                    history.push(NavigationPath.createClusterPoolInfrastructure)
-                                                }
+                                                onClick={() => history.push(NavigationPath.createClusterPool)}
                                             >
                                                 {t('managed.createClusterPool')}
                                             </AcmButton>

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.test.tsx
@@ -35,8 +35,8 @@ import {
     waitForText,
 } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
-import CreateClusterPoolPage from './CreateClusterPool'
 import { createProviderConnection } from '../../../../Credentials/CredentialsForm.test'
+import { CreateClusterPoolPage } from '../CreateClusterPoolPage'
 
 const clusterName = 'test'
 

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPool.tsx
@@ -7,7 +7,7 @@ import { Modal, ModalVariant, PageSection } from '@patternfly/react-core'
 import { createCluster } from '../../../../../lib/create-cluster'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { useHistory, useLocation } from 'react-router-dom'
-import { CancelBackState, cancelNavigation, NavigationPath } from '../../../../../NavigationPath'
+import { NavigationPath, useBackCancelNavigation } from '../../../../../NavigationPath'
 import Handlebars from 'handlebars'
 import { DOC_LINKS } from '../../../../../lib/doc-util'
 import { useCanJoinClusterSets, useMustJoinClusterSet } from '../../ClusterSets/components/useCanJoinClusterSets'
@@ -113,8 +113,8 @@ export default function CreateClusterPool(props: { infrastructureType: CreateClu
 function CreateClusterPoolWizard(props: { infrastructureType: CreateClusterPoolInfrastructureType }) {
     const { infrastructureType } = props
     const history = useHistory()
-    const location = useLocation<CancelBackState>()
-    const { search } = location
+    const { search } = useLocation()
+    const { back, cancel } = useBackCancelNavigation()
     const { namespacesState, settingsState, clusterPoolsState, secretsState } = useSharedAtoms()
     const [namespaces] = useRecoilState(namespacesState)
     const [secrets] = useRecoilState(secretsState)
@@ -172,14 +172,8 @@ function CreateClusterPoolWizard(props: { infrastructureType: CreateClusterPoolI
         setIsModalOpen(!isModalOpen)
     }
 
-    function backButtonOverrideFunc() {
-        history.goBack()
-    }
-
-    // cancel button
-    const cancelCreate = () => {
-        cancelNavigation(location, history, NavigationPath.clusterPools)
-    }
+    const backButtonOverride = back(NavigationPath.createClusterPool)
+    const cancelCreate = cancel(NavigationPath.clusterPools)
 
     // setup translation
     const { t } = useTranslation()
@@ -301,7 +295,7 @@ function CreateClusterPoolWizard(props: { infrastructureType: CreateClusterPoolI
                     pauseCreate: () => {},
                     creationStatus: creationStatus?.status,
                     creationMsg: creationStatus?.messages,
-                    backButtonOverride: backButtonOverrideFunc,
+                    backButtonOverride,
                 }}
                 logging={process.env.NODE_ENV !== 'production'}
                 onControlChange={onControlChange}

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPoolInfrastructure.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPoolInfrastructure.test.tsx
@@ -6,7 +6,7 @@ import { secretsState } from '../../../../../atoms'
 import { clickByTestId } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { ProviderConnectionApiVersion, ProviderConnectionKind, Secret } from '../../../../../resources'
-import { CreateInfrastructureClusterpool } from './CreateIntrastructureClusterpool'
+import { CreateClusterPoolInfrastructure } from './CreateClusterPoolInfrastructure'
 
 const providerConnectionAws: Secret = {
     apiVersion: ProviderConnectionApiVersion,
@@ -29,9 +29,9 @@ describe('CreateInfrastructure clusterpool', () => {
                     snapshot.set(secretsState, [providerConnectionAws])
                 }}
             >
-                <MemoryRouter initialEntries={[NavigationPath.createClusterPoolInfrastructure]}>
-                    <Route path={NavigationPath.createClusterPoolInfrastructure}>
-                        <CreateInfrastructureClusterpool />
+                <MemoryRouter initialEntries={[NavigationPath.createClusterPool]}>
+                    <Route path={NavigationPath.createClusterPool}>
+                        <CreateClusterPoolInfrastructure />
                     </Route>
                 </MemoryRouter>
             </RecoilRoot>

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPoolInfrastructure.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPoolInfrastructure.tsx
@@ -1,17 +1,17 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { CatalogCardItemType, CatalogColor, ICatalogCard, ItemView, PageHeader } from '@stolostron/react-data-view'
 import { Fragment, useCallback, useMemo } from 'react'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import { useRecoilState, useSharedAtoms } from '../../../../../shared-recoil'
 import { useTranslation } from '../../../../../lib/acm-i18next'
-import { NavigationPath } from '../../../../../NavigationPath'
+import { NavigationPath, useBackCancelNavigation } from '../../../../../NavigationPath'
 import { AcmIcon, AcmIconVariant, Provider } from '../../../../../ui-components'
 import { CreateClusterPoolInfrastructureType } from './CreateClusterPool'
 
 export function CreateClusterPoolInfrastructure() {
     const [t] = useTranslation()
-    const history = useHistory()
     const { search } = useLocation()
+    const { nextStep, back, cancel } = useBackCancelNavigation()
     const { secretsState } = useSharedAtoms()
     const [secrets] = useRecoilState(secretsState)
     const credentials = useMemo(
@@ -52,11 +52,10 @@ export function CreateClusterPoolInfrastructure() {
                     },
                 ],
                 labels: getCredentialLabels(Provider.aws),
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createClusterPool,
-                        search: getSearchWithInfrastructureType(CreateClusterPoolInfrastructureType.AWS),
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createClusterPool,
+                    search: getSearchWithInfrastructureType(CreateClusterPoolInfrastructureType.AWS),
+                }),
             },
             {
                 id: 'google',
@@ -71,11 +70,10 @@ export function CreateClusterPoolInfrastructure() {
                     },
                 ],
                 labels: getCredentialLabels(Provider.gcp),
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createClusterPool,
-                        search: getSearchWithInfrastructureType(CreateClusterPoolInfrastructureType.GCP),
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createClusterPool,
+                    search: getSearchWithInfrastructureType(CreateClusterPoolInfrastructureType.GCP),
+                }),
             },
             {
                 id: 'azure',
@@ -88,15 +86,14 @@ export function CreateClusterPoolInfrastructure() {
                     },
                 ],
                 labels: getCredentialLabels(Provider.azure),
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createClusterPool,
-                        search: getSearchWithInfrastructureType(CreateClusterPoolInfrastructureType.Azure),
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createClusterPool,
+                    search: getSearchWithInfrastructureType(CreateClusterPoolInfrastructureType.Azure),
+                }),
             },
         ]
         return newCards
-    }, [getCredentialLabels, history, t])
+    }, [nextStep, getCredentialLabels, search, t])
 
     const keyFn = useCallback((card: ICatalogCard) => card.id, [])
 
@@ -116,8 +113,8 @@ export function CreateClusterPoolInfrastructure() {
                 items={cards}
                 itemKeyFn={keyFn}
                 itemToCardFn={(card) => card}
-                onBack={() => history.push(NavigationPath.clusterPools)}
-                onCancel={() => history.push(NavigationPath.clusterPools)}
+                onBack={back(NavigationPath.clusterPools)}
+                onCancel={cancel(NavigationPath.clusterPools)}
             />
         </Fragment>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPoolInfrastructure.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPoolInfrastructure.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from '../../../../../lib/acm-i18next'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { AcmIcon, AcmIconVariant, Provider } from '../../../../../ui-components'
 
-export function CreateInfrastructureClusterpool() {
+export function CreateClusterPoolInfrastructure() {
     const [t] = useTranslation()
     const history = useHistory()
     const { secretsState } = useSharedAtoms()

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPoolInfrastructure.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/CreateClusterPoolInfrastructure.tsx
@@ -1,15 +1,17 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { CatalogCardItemType, CatalogColor, ICatalogCard, ItemView, PageHeader } from '@stolostron/react-data-view'
 import { Fragment, useCallback, useMemo } from 'react'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { useRecoilState, useSharedAtoms } from '../../../../../shared-recoil'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { AcmIcon, AcmIconVariant, Provider } from '../../../../../ui-components'
+import { CreateClusterPoolInfrastructureType } from './CreateClusterPool'
 
 export function CreateClusterPoolInfrastructure() {
     const [t] = useTranslation()
     const history = useHistory()
+    const { search } = useLocation()
     const { secretsState } = useSharedAtoms()
     const [secrets] = useRecoilState(secretsState)
     const credentials = useMemo(
@@ -32,6 +34,12 @@ export function CreateClusterPoolInfrastructure() {
     )
 
     const cards = useMemo(() => {
+        const getSearchWithInfrastructureType = (infrastructureType: CreateClusterPoolInfrastructureType) => {
+            const urlParams = new URLSearchParams(search)
+            urlParams.append('infrastructureType', infrastructureType)
+            return urlParams.toString()
+        }
+
         const newCards: ICatalogCard[] = [
             {
                 id: 'aws',
@@ -47,7 +55,7 @@ export function CreateClusterPoolInfrastructure() {
                 onClick: () =>
                     history.push({
                         pathname: NavigationPath.createClusterPool,
-                        search: '?infrastructureType=AWS',
+                        search: getSearchWithInfrastructureType(CreateClusterPoolInfrastructureType.AWS),
                     }),
             },
             {
@@ -66,7 +74,7 @@ export function CreateClusterPoolInfrastructure() {
                 onClick: () =>
                     history.push({
                         pathname: NavigationPath.createClusterPool,
-                        search: '?infrastructureType=GCP',
+                        search: getSearchWithInfrastructureType(CreateClusterPoolInfrastructureType.GCP),
                     }),
             },
             {
@@ -83,7 +91,7 @@ export function CreateClusterPoolInfrastructure() {
                 onClick: () =>
                     history.push({
                         pathname: NavigationPath.createClusterPool,
-                        search: '?infrastructureType=Azure',
+                        search: getSearchWithInfrastructureType(CreateClusterPoolInfrastructureType.Azure),
                     }),
             },
         ]

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAWS.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAWS.js
@@ -122,8 +122,8 @@ export const getControlDataAWS = (
     includeAwsPrivate = true,
     includeSno = false
 ) => {
-    if (includeSno) addSnoText(controlDataAWS)
-    let controlData = [...controlDataAWS]
+    const controlData = [...controlDataAWS]
+    if (includeSno) addSnoText(controlData)
     if (includeAwsPrivate) {
         controlData.push(...awsPrivateControlData)
         const regionObject = controlData.find((object) => object.id === 'region')

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAWS.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAWS.js
@@ -123,7 +123,9 @@ export const getControlDataAWS = (
     includeSno = false
 ) => {
     const controlData = [...controlDataAWS]
-    if (includeSno) addSnoText(controlData)
+    if (includeSno) {
+        addSnoText(controlData)
+    }
     if (includeAwsPrivate) {
         controlData.push(...awsPrivateControlData)
         const regionObject = controlData.find((object) => object.id === 'region')

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAZR.js
@@ -439,12 +439,13 @@ const ApplicationCreationPage = [
 ]
 
 export const getControlDataAZR = (handleModalToggle, includeAutomation = true, includeSno = false) => {
-    if (includeSno) addSnoText(controlDataAZR)
-    if (includeAutomation) return [...controlDataAZR, ...automationControlData]
+    const controlData = [...controlDataAZR]
+    if (includeSno) addSnoText(controlData)
+    if (includeAutomation) return [...controlData, ...automationControlData]
     if (handleModalToggle) {
-        insertToggleModalFunction(handleModalToggle, controlDataAZR)
+        insertToggleModalFunction(handleModalToggle, controlData)
     }
-    return [...controlDataAZR]
+    return controlData
 }
 
 const setRegions = (control, controlData) => {

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAZR.js
@@ -440,8 +440,12 @@ const ApplicationCreationPage = [
 
 export const getControlDataAZR = (handleModalToggle, includeAutomation = true, includeSno = false) => {
     const controlData = [...controlDataAZR]
-    if (includeSno) addSnoText(controlData)
-    if (includeAutomation) return [...controlData, ...automationControlData]
+    if (includeSno) {
+        addSnoText(controlData)
+    }
+    if (includeAutomation) {
+        return [...controlData, ...automationControlData]
+    }
     if (handleModalToggle) {
         insertToggleModalFunction(handleModalToggle, controlData)
     }

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataGCP.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataGCP.js
@@ -254,8 +254,12 @@ const GCPworkerInstanceTypes = [
 
 export const getControlDataGCP = (handleModalToggle, includeAutomation = true, includeSno = false) => {
     const controlData = [...controlDataGCP]
-    if (includeSno) addSnoText(controlData)
-    if (includeAutomation) return [...controlData, ...automationControlData]
+    if (includeSno) {
+        addSnoText(controlData)
+    }
+    if (includeAutomation) {
+        return [...controlData, ...automationControlData]
+    }
     if (handleModalToggle) {
         insertToggleModalFunction(handleModalToggle, controlData)
     }

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataGCP.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataGCP.js
@@ -253,12 +253,13 @@ const GCPworkerInstanceTypes = [
 ]
 
 export const getControlDataGCP = (handleModalToggle, includeAutomation = true, includeSno = false) => {
-    if (includeSno) addSnoText(controlDataGCP)
-    if (includeAutomation) return [...controlDataGCP, ...automationControlData]
+    const controlData = [...controlDataGCP]
+    if (includeSno) addSnoText(controlData)
+    if (includeAutomation) return [...controlData, ...automationControlData]
     if (handleModalToggle) {
-        insertToggleModalFunction(handleModalToggle, controlDataGCP)
+        insertToggleModalFunction(handleModalToggle, controlData)
     }
-    return [...controlDataGCP]
+    return controlData
 }
 
 const controlDataGCP = [

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPoolPage.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPoolPage.tsx
@@ -1,0 +1,17 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
+import CreateClusterPool, { isCreateClusterPoolInfrastructureType } from './CreateClusterPool/CreateClusterPool'
+import { CreateClusterPoolInfrastructure } from './CreateClusterPool/CreateClusterPoolInfrastructure'
+
+export function CreateClusterPoolPage() {
+    const { search } = useLocation()
+    const searchParams = useMemo(() => new URLSearchParams(search), [search])
+    const infrastructureType = searchParams.get('infrastructureType') || ''
+    return isCreateClusterPoolInfrastructureType(infrastructureType) ? (
+        <CreateClusterPool infrastructureType={infrastructureType} />
+    ) : (
+        <CreateClusterPoolInfrastructure />
+    )
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetClusterPools/ClusterSetClusterPools.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetClusterPools/ClusterSetClusterPools.tsx
@@ -8,7 +8,7 @@ import { Trans, useTranslation } from '../../../../../../lib/acm-i18next'
 import { Link } from 'react-router-dom'
 import { RbacButton } from '../../../../../../components/Rbac'
 import { rbacCreate } from '../../../../../../lib/rbac-util'
-import { locationWithCancelBack, NavigationPath } from '../../../../../../NavigationPath'
+import { createBackCancelLocation, NavigationPath } from '../../../../../../NavigationPath'
 import { ClusterPoolsTable } from '../../../ClusterPools/ClusterPools'
 import { ClusterSetContext } from '../ClusterSetDetails'
 
@@ -33,10 +33,10 @@ export function ClusterSetClusterPoolsPageContent() {
                             action={
                                 <RbacButton
                                     component={Link}
-                                    to={locationWithCancelBack(
-                                        NavigationPath.createClusterPool,
-                                        `?clusterSet=${clusterSet!.metadata.name}`
-                                    )}
+                                    to={createBackCancelLocation({
+                                        pathname: NavigationPath.createClusterPool,
+                                        search: `?clusterSet=${clusterSet!.metadata.name}`,
+                                    })}
                                     variant="primary"
                                     rbac={[
                                         rbacCreate(

--- a/frontend/src/routes/Infrastructure/Clusters/Clusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/Clusters.tsx
@@ -2,34 +2,26 @@
 /* istanbul ignore file */
 import { Redirect, Route, Switch } from 'react-router-dom'
 import { NavigationPath } from '../../../NavigationPath'
-import CreateClusterPoolPage from './ClusterPools/CreateClusterPool/CreateClusterPool'
-import { CreateInfrastructureClusterpool } from './ClusterPools/CreateClusterPool/CreateIntrastructureClusterpool'
+import { CreateClusterPoolPage } from './ClusterPools/CreateClusterPoolPage'
 import ClusterSetDetailsPage from './ClusterSets/ClusterSetDetails/ClusterSetDetails'
 import { ClustersPage } from './ClustersPage'
 import DiscoveryConfigPage from './DiscoveredClusters/DiscoveryConfig/DiscoveryConfig'
 import ClusterDetailsPage from './ManagedClusters/ClusterDetails/ClusterDetails'
 import EditAICluster from './ManagedClusters/components/cim/EditAICluster'
-import CreateClusterPage from './ManagedClusters/CreateCluster/CreateCluster'
+import { CreateClusterPage } from './ManagedClusters/CreateClusterPage'
 import { CreateControlPlane } from './ManagedClusters/CreateInfrastructure/CreateControlPlane'
 import { CreateDiscoverHost } from './ManagedClusters/CreateInfrastructure/CreateDiscoverHost'
-import { CreateInfrastructure } from './ManagedClusters/CreateInfrastructure/CreateInfrastructure'
 import ImportClusterPage from './ManagedClusters/ImportCluster/ImportCluster'
 
 export default function Clusters() {
     return (
         <Switch>
-            <Route exact path={NavigationPath.createInfrastructure} component={CreateInfrastructure} />
             <Route exact path={NavigationPath.createControlPlane} component={CreateControlPlane} />
-            <Route exact path={NavigationPath.createDicoverHost} component={CreateDiscoverHost} />
+            <Route exact path={NavigationPath.createDiscoverHost} component={CreateDiscoverHost} />
             <Route exact path={NavigationPath.createCluster} component={CreateClusterPage} />
             <Route exact path={NavigationPath.importCluster} component={ImportClusterPage} />
             <Route path={NavigationPath.clusterDetails} component={ClusterDetailsPage} />
             <Route path={NavigationPath.clusterSetDetails} component={ClusterSetDetailsPage} />
-            <Route
-                exact
-                path={NavigationPath.createClusterPoolInfrastructure}
-                component={CreateInfrastructureClusterpool}
-            />
             <Route exact path={NavigationPath.createClusterPool} component={CreateClusterPoolPage} />
             <Route exact path={NavigationPath.editCluster} component={EditAICluster} />
             <Route exact path={NavigationPath.configureDiscovery} component={DiscoveryConfigPage} />

--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
@@ -19,7 +19,7 @@ import { Fragment, useEffect, useState } from 'react'
 import { Trans, useTranslation } from '../../../../lib/acm-i18next'
 import { Link, useHistory } from 'react-router-dom'
 import { DOC_LINKS, viewDocumentation } from '../../../../lib/doc-util'
-import { locationWithCancelBack, NavigationPath } from '../../../../NavigationPath'
+import { createBackCancelLocation, NavigationPath } from '../../../../NavigationPath'
 import { DiscoveredCluster, DiscoveryConfig, ProviderConnection, unpackProviderConnection } from '../../../../resources'
 import { useRecoilState, useSharedAtoms } from '../../../../shared-recoil'
 
@@ -380,7 +380,7 @@ export function DiscoveredClustersTable(props: {
                             sessionStorage.setItem('DiscoveredClusterDisplayName', item.spec.displayName)
                             sessionStorage.setItem('DiscoveredClusterConsoleURL', item.spec.console)
                             sessionStorage.setItem('DiscoveredClusterApiURL', item.spec?.apiUrl || '')
-                            history.push(locationWithCancelBack(NavigationPath.importCluster))
+                            history.push(createBackCancelLocation(NavigationPath.importCluster))
                         },
                     },
                 ]}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
@@ -52,7 +52,6 @@ import {
     waitForText,
 } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
-import CreateClusterPage from './CreateCluster'
 import { Scope } from 'nock/types'
 import {
     clusterName,
@@ -63,6 +62,7 @@ import {
     mockClusterImageSet,
 } from './CreateCluster.sharedmocks'
 import { PluginContext } from '../../../../../lib/PluginContext'
+import { CreateClusterPage } from '../CreateClusterPage'
 import { PluginDataContext } from '../../../../../lib/PluginDataContext'
 
 //const awsProjectNamespace = 'test-aws-namespace'

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
@@ -10,7 +10,7 @@ import { CIM } from 'openshift-assisted-ui-lib'
 import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 // include monaco editor
 import MonacoEditor from 'react-monaco-editor'
-import { useHistory, useLocation } from 'react-router-dom'
+import { useHistory } from 'react-router-dom'
 import TemplateEditor from '../../../../../components/TemplateEditor'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { createCluster } from '../../../../../lib/create-cluster'
@@ -74,9 +74,25 @@ const useStyles = makeStyles({
     },
 })
 
-export default function CreateClusterPage() {
+export enum CreateClusterInfrastructureType {
+    AWS = 'AWS',
+    GCP = 'GCP',
+    Azure = 'Azure',
+    vSphere = 'vSphere',
+    OpenStack = 'OpenStack',
+    RHV = 'RHV',
+    CIMHypershift = 'CIMHypershift',
+    CIM = 'CIM',
+    AI = 'AI',
+}
+
+export const isCreateClusterInfrastructureType = (
+    infrastructureType: string
+): infrastructureType is CreateClusterInfrastructureType => infrastructureType in CreateClusterInfrastructureType
+
+export default function CreateCluster(props: { infrastructureType: CreateClusterInfrastructureType }) {
+    const { infrastructureType } = props
     const history = useHistory()
-    const location = useLocation()
     const { agentClusterInstallsState, infraEnvironmentsState, managedClustersState, secretsState, settingsState } =
         useSharedAtoms()
     const {
@@ -101,7 +117,7 @@ export default function CreateClusterPage() {
         return t(key, arg)
     }
     const controlPlaneBreadCrumb = { text: t('Control plane type'), to: NavigationPath.createControlPlane }
-    const hostsBreadCrumb = { text: t('Hosts'), to: NavigationPath.createDicoverHost }
+    const hostsBreadCrumb = { text: t('Hosts'), to: NavigationPath.createDiscoverHost }
 
     const settings = useRecoilValue(settingsState)
     const supportedCurations = useRecoilValue(clusterCuratorSupportedCurationsValue)
@@ -270,17 +286,6 @@ export default function CreateClusterPage() {
     Handlebars.registerHelper('arrayItemHasKey', arrayItemHasKey)
     Handlebars.registerHelper('append', append)
 
-    // if opened from bma page, pass selected bma's to editor
-    const urlParams = new URLSearchParams(location.search.substring(1))
-    const bmasParam = urlParams.get('bmas')
-    const requestedUIDs = bmasParam ? bmasParam.split(',') : []
-    const fetchControl = bmasParam
-        ? {
-              isLoaded: true,
-              fetchData: { requestedUIDs },
-          }
-        : null
-
     const { canJoinClusterSets } = useCanJoinClusterSets()
     const mustJoinClusterSet = useMustJoinClusterSet()
     function onControlInitialize(control: any) {
@@ -354,9 +359,12 @@ export default function CreateClusterPage() {
         }
     }
 
-    const infrastructureType = urlParams.get('infrastructureType') || ''
     useEffect(() => {
-        if ((infrastructureType === 'CIM' || infrastructureType === 'CIMHypershift') && !isInfraEnvAvailable) {
+        if (
+            (infrastructureType === CreateClusterInfrastructureType.CIM ||
+                infrastructureType === CreateClusterInfrastructureType.CIMHypershift) &&
+            !isInfraEnvAvailable
+        ) {
             setWarning({
                 title: t('cim.infra.missing.warning.title'),
                 text: t('cim.infra.missing.warning.text'),
@@ -376,7 +384,7 @@ export default function CreateClusterPage() {
     let controlData: any[]
     const breadcrumbs = [
         { text: t('Clusters'), to: NavigationPath.clusters },
-        { text: t('Infrastructure'), to: NavigationPath.createInfrastructure },
+        { text: t('Infrastructure'), to: NavigationPath.createCluster },
     ]
 
     function backButtonOverrideFunc() {
@@ -388,7 +396,7 @@ export default function CreateClusterPage() {
     }
 
     switch (infrastructureType) {
-        case 'AWS':
+        case CreateClusterInfrastructureType.AWS:
             controlData = getControlDataAWS(
                 handleModalToggle,
                 true,
@@ -397,7 +405,7 @@ export default function CreateClusterPage() {
                 isACMAvailable
             )
             break
-        case 'GCP':
+        case CreateClusterInfrastructureType.GCP:
             controlData = getControlDataGCP(
                 handleModalToggle,
                 true,
@@ -405,7 +413,7 @@ export default function CreateClusterPage() {
                 isACMAvailable
             )
             break
-        case 'Azure':
+        case CreateClusterInfrastructureType.Azure:
             controlData = getControlDataAZR(
                 handleModalToggle,
                 true,
@@ -413,7 +421,7 @@ export default function CreateClusterPage() {
                 isACMAvailable
             )
             break
-        case 'vSphere':
+        case CreateClusterInfrastructureType.vSphere:
             controlData = getControlDataVMW(
                 handleModalToggle,
                 true,
@@ -421,7 +429,7 @@ export default function CreateClusterPage() {
                 isACMAvailable
             )
             break
-        case 'OpenStack':
+        case CreateClusterInfrastructureType.OpenStack:
             controlData = getControlDataOST(
                 handleModalToggle,
                 true,
@@ -429,26 +437,24 @@ export default function CreateClusterPage() {
                 isACMAvailable
             )
             break
-        case 'RHV':
+        case CreateClusterInfrastructureType.RHV:
             controlData = getControlDataRHV(handleModalToggle, true, isACMAvailable)
             break
-        case 'CIMHypershift':
+        case CreateClusterInfrastructureType.CIMHypershift:
             template = Handlebars.compile(hypershiftTemplate)
             controlData = getControlDataHypershift(handleModalToggle, <Warning />, true, isACMAvailable)
             breadcrumbs.push(controlPlaneBreadCrumb)
             break
-        case 'CIM':
+        case CreateClusterInfrastructureType.CIM:
             template = Handlebars.compile(cimTemplate)
             controlData = getControlDataCIM(handleModalToggle, <Warning />, isACMAvailable)
             breadcrumbs.push(controlPlaneBreadCrumb)
             break
-        case 'AI':
+        case CreateClusterInfrastructureType.AI:
             template = Handlebars.compile(aiTemplate)
             controlData = getControlDataAI(handleModalToggle, isACMAvailable)
             breadcrumbs.push(controlPlaneBreadCrumb, hostsBreadCrumb)
             break
-        default:
-            controlData = []
     }
 
     breadcrumbs.push({ text: t('page.header.create-cluster'), to: NavigationPath.emptyPath })
@@ -509,7 +515,6 @@ export default function CreateClusterPage() {
                                     controlData={controlData}
                                     template={template}
                                     portals={Portals}
-                                    fetchControl={fetchControl}
                                     createControl={{
                                         createResource,
                                         cancelCreate,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
@@ -10,13 +10,13 @@ import { CIM } from 'openshift-assisted-ui-lib'
 import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 // include monaco editor
 import MonacoEditor from 'react-monaco-editor'
-import { useHistory } from 'react-router-dom'
+import { generatePath, useHistory } from 'react-router-dom'
 import TemplateEditor from '../../../../../components/TemplateEditor'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { createCluster } from '../../../../../lib/create-cluster'
 import { DOC_LINKS } from '../../../../../lib/doc-util'
 import { PluginContext } from '../../../../../lib/PluginContext'
-import { NavigationPath } from '../../../../../NavigationPath'
+import { NavigationPath, useBackCancelNavigation } from '../../../../../NavigationPath'
 import {
     ClusterCurator,
     createClusterCurator,
@@ -93,6 +93,7 @@ export const isCreateClusterInfrastructureType = (
 export default function CreateCluster(props: { infrastructureType: CreateClusterInfrastructureType }) {
     const { infrastructureType } = props
     const history = useHistory()
+    const { back, cancel } = useBackCancelNavigation()
     const { agentClusterInstallsState, infraEnvironmentsState, managedClustersState, secretsState, settingsState } =
         useSharedAtoms()
     const {
@@ -265,7 +266,7 @@ export default function CreateCluster(props: { infrastructureType: CreateCluster
                     setCreationStatus({ status, messages: finishMessage })
                     if (!noRedirect) {
                         setTimeout(() => {
-                            history.push(NavigationPath.clusterDetails.replace(':id', clusterName as string))
+                            history.push(generatePath(NavigationPath.clusterDetails, { id: clusterName as string }))
                         }, 2000)
                     }
                 }
@@ -276,9 +277,7 @@ export default function CreateCluster(props: { infrastructureType: CreateCluster
     }
 
     // cancel button
-    const cancelCreate = () => {
-        history.push(NavigationPath.clusters)
-    }
+    const cancelCreate = cancel(NavigationPath.clusters)
 
     //compile templates
     let template = Handlebars.compile(hiveTemplate)
@@ -387,9 +386,7 @@ export default function CreateCluster(props: { infrastructureType: CreateCluster
         { text: t('Infrastructure'), to: NavigationPath.createCluster },
     ]
 
-    function backButtonOverrideFunc() {
-        history.goBack()
-    }
+    const backButtonOverride = back(NavigationPath.clusters)
 
     const handleModalToggle = () => {
         setIsModalOpen(!isModalOpen)
@@ -524,7 +521,7 @@ export default function CreateCluster(props: { infrastructureType: CreateCluster
                                         resetStatus: () => {
                                             setCreationStatus(undefined)
                                         },
-                                        backButtonOverride: backButtonOverrideFunc,
+                                        backButtonOverride,
                                     }}
                                     logging={process.env.NODE_ENV !== 'production'}
                                     i18n={i18n}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAI.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAI.js
@@ -5,9 +5,10 @@ import { automationControlData, appendKlusterletAddonConfig, insertToggleModalFu
 import { CreateCredentialModal } from '../../../../../../components/CreateCredentialModal'
 
 export const getControlDataAI = (handleModalToggle, includeKlusterletAddonConfig = true) => {
-    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlDataAI)
-    insertToggleModalFunction(handleModalToggle, controlDataAI)
-    return [...controlDataAI]
+    const controlData = [...controlDataAI]
+    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
+    insertToggleModalFunction(handleModalToggle, controlData)
+    return controlData
 }
 
 export const controlDataAI = [

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
@@ -124,8 +124,8 @@ export const getControlDataAWS = (
     includeSno = false,
     includeKlusterletAddonConfig = true
 ) => {
-    if (includeSno) addSnoText(controlDataAWS)
-    let controlData = [...controlDataAWS]
+    const controlData = [...controlDataAWS]
+    if (includeSno) addSnoText(controlData)
     if (includeAwsPrivate) {
         controlData.push(...awsPrivateControlData)
         const regionObject = controlData.find((object) => object.id === 'region')

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
@@ -125,7 +125,9 @@ export const getControlDataAWS = (
     includeKlusterletAddonConfig = true
 ) => {
     const controlData = [...controlDataAWS]
-    if (includeSno) addSnoText(controlData)
+    if (includeSno) {
+        addSnoText(controlData)
+    }
     if (includeAwsPrivate) {
         controlData.push(...awsPrivateControlData)
         const regionObject = controlData.find((object) => object.id === 'region')
@@ -134,7 +136,9 @@ export const getControlDataAWS = (
             regionObject.available = regionObject.available.concat(Object.keys(awsRegions))
         }
     }
-    if (includeAutomation) controlData.push(...automationControlData)
+    if (includeAutomation) {
+        controlData.push(...automationControlData)
+    }
     appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
     insertToggleModalFunction(handleModalToggle, controlData)
     return controlData

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
@@ -445,11 +445,12 @@ export const getControlDataAZR = (
     includeSno = false,
     includeKlusterletAddonConfig = true
 ) => {
-    if (includeSno) addSnoText(controlDataAZR)
-    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlDataAZR)
-    insertToggleModalFunction(handleModalToggle, controlDataAZR)
-    if (includeAutomation) return [...controlDataAZR, ...automationControlData]
-    return [...controlDataAZR]
+    const controlData = [...controlDataAZR]
+    if (includeSno) addSnoText(controlData)
+    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
+    insertToggleModalFunction(handleModalToggle, controlData)
+    if (includeAutomation) return [...controlData, ...automationControlData]
+    return controlData
 }
 
 const setRegions = (control, controlData) => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
@@ -446,10 +446,14 @@ export const getControlDataAZR = (
     includeKlusterletAddonConfig = true
 ) => {
     const controlData = [...controlDataAZR]
-    if (includeSno) addSnoText(controlData)
+    if (includeSno) {
+        addSnoText(controlData)
+    }
     appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
     insertToggleModalFunction(handleModalToggle, controlData)
-    if (includeAutomation) return [...controlData, ...automationControlData]
+    if (includeAutomation) {
+        return [...controlData, ...automationControlData]
+    }
     return controlData
 }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataCIM.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataCIM.js
@@ -10,12 +10,13 @@ import {
 import { CreateCredentialModal } from '../../../../../../components/CreateCredentialModal'
 
 export const getControlDataCIM = (handleModalToggle, warning, includeKlusterletAddonConfig = true) => {
-    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlDataCIM)
-    insertToggleModalFunction(handleModalToggle, controlDataCIM)
+    const controlData = [...controlDataCIM]
+    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
+    insertToggleModalFunction(handleModalToggle, controlData)
     if (warning) {
-        appendWarning(warning, controlDataCIM)
+        appendWarning(warning, controlData)
     }
-    return [...controlDataCIM]
+    return controlData
 }
 
 const controlDataCIM = [

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.js
@@ -260,10 +260,14 @@ export const getControlDataGCP = (
     includeKlusterletAddonConfig = true
 ) => {
     const controlData = [...controlDataGCP]
-    if (includeSno) addSnoText(controlData)
+    if (includeSno) {
+        addSnoText(controlData)
+    }
     appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
     insertToggleModalFunction(handleModalToggle, controlData)
-    if (includeAutomation) return [...controlData, ...automationControlData]
+    if (includeAutomation) {
+        return [...controlData, ...automationControlData]
+    }
     return controlData
 }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.js
@@ -259,11 +259,12 @@ export const getControlDataGCP = (
     includeSno = false,
     includeKlusterletAddonConfig = true
 ) => {
-    if (includeSno) addSnoText(controlDataGCP)
-    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlDataGCP)
-    insertToggleModalFunction(handleModalToggle, controlDataGCP)
-    if (includeAutomation) return [...controlDataGCP, ...automationControlData]
-    return [...controlDataGCP]
+    const controlData = [...controlDataGCP]
+    if (includeSno) addSnoText(controlData)
+    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
+    insertToggleModalFunction(handleModalToggle, controlData)
+    if (includeAutomation) return [...controlData, ...automationControlData]
+    return controlData
 }
 
 const controlDataGCP = [

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHypershift.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHypershift.js
@@ -17,15 +17,16 @@ export const getControlDataHypershift = (
     includeAutomation = true,
     includeKlusterletAddonConfig = true
 ) => {
-    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlDataHypershift)
-    insertToggleModalFunction(handleModalToggle, controlDataHypershift)
+    const controlData = [...controlDataHypershift]
+    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
+    insertToggleModalFunction(handleModalToggle, controlData)
     if (warning) {
-        appendWarning(warning, controlDataHypershift)
+        appendWarning(warning, controlData)
     }
     if (includeAutomation) {
-        return [...controlDataHypershift, ...automationControlData]
+        return [...controlData, ...automationControlData]
     }
-    return [...controlDataHypershift]
+    return controlData
 }
 
 const controlDataHypershift = [

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.js
@@ -38,11 +38,12 @@ export const getControlDataOST = (
     includeSno = false,
     includeKlusterletAddonConfig = true
 ) => {
-    if (includeSno) addSnoText(controlDataOST)
-    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlDataOST)
-    insertToggleModalFunction(handleModalToggle, controlDataOST)
-    if (includeAutomation) return [...controlDataOST, ...automationControlData]
-    return [...controlDataOST]
+    const controlData = [...controlDataOST]
+    if (includeSno) addSnoText(controlData)
+    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
+    insertToggleModalFunction(handleModalToggle, controlData)
+    if (includeAutomation) return [...controlData, ...automationControlData]
+    return controlData
 }
 
 const controlDataOST = [

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.js
@@ -39,10 +39,14 @@ export const getControlDataOST = (
     includeKlusterletAddonConfig = true
 ) => {
     const controlData = [...controlDataOST]
-    if (includeSno) addSnoText(controlData)
+    if (includeSno) {
+        addSnoText(controlData)
+    }
     appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
     insertToggleModalFunction(handleModalToggle, controlData)
-    if (includeAutomation) return [...controlData, ...automationControlData]
+    if (includeAutomation) {
+        return [...controlData, ...automationControlData]
+    }
     return controlData
 }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.js
@@ -27,7 +27,9 @@ export const getControlDataRHV = (handleModalToggle, includeAutomation = true, i
     const controlData = [...controlDataRHV]
     appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
     insertToggleModalFunction(handleModalToggle, controlData)
-    if (includeAutomation) return [...controlData, ...automationControlData]
+    if (includeAutomation) {
+        return [...controlData, ...automationControlData]
+    }
     return controlData
 }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.js
@@ -24,10 +24,11 @@ import { CreateCredentialModal } from '../../../../../../components/CreateCreden
 const installConfig = Handlebars.compile(installConfigHbs)
 
 export const getControlDataRHV = (handleModalToggle, includeAutomation = true, includeKlusterletAddonConfig = true) => {
-    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlDataRHV)
-    insertToggleModalFunction(handleModalToggle, controlDataRHV)
-    if (includeAutomation) return [...controlDataRHV, ...automationControlData]
-    return [...controlDataRHV]
+    const controlData = [...controlDataRHV]
+    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
+    insertToggleModalFunction(handleModalToggle, controlData)
+    if (includeAutomation) return [...controlData, ...automationControlData]
+    return controlData
 }
 
 const controlDataRHV = [

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.js
@@ -31,11 +31,12 @@ export const getControlDataVMW = (
     includeSno = false,
     includeKlusterletAddonConfig = true
 ) => {
-    if (includeSno) addSnoText(controlDataVMW)
-    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlDataVMW)
-    insertToggleModalFunction(handleModalToggle, controlDataVMW)
-    if (includeAutomation) return [...controlDataVMW, ...automationControlData]
-    return [...controlDataVMW]
+    const controlData = [...controlDataVMW]
+    if (includeSno) addSnoText(controlData)
+    appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
+    insertToggleModalFunction(handleModalToggle, controlData)
+    if (includeAutomation) return [...controlData, ...automationControlData]
+    return controlData
 }
 
 const controlDataVMW = [

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.js
@@ -32,10 +32,14 @@ export const getControlDataVMW = (
     includeKlusterletAddonConfig = true
 ) => {
     const controlData = [...controlDataVMW]
-    if (includeSno) addSnoText(controlData)
+    if (includeSno) {
+        addSnoText(controlData)
+    }
     appendKlusterletAddonConfig(includeKlusterletAddonConfig, controlData)
     insertToggleModalFunction(handleModalToggle, controlData)
-    if (includeAutomation) return [...controlData, ...automationControlData]
+    if (includeAutomation) {
+        return [...controlData, ...automationControlData]
+    }
     return controlData
 }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterPage.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterPage.tsx
@@ -1,0 +1,17 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
+import CreateCluster, { isCreateClusterInfrastructureType } from './CreateCluster/CreateCluster'
+import { CreateInfrastructure } from './CreateInfrastructure/CreateInfrastructure'
+
+export function CreateClusterPage() {
+    const { search } = useLocation()
+    const searchParams = useMemo(() => new URLSearchParams(search), [search])
+    const infrastructureType = searchParams.get('infrastructureType') || ''
+    return isCreateClusterInfrastructureType(infrastructureType) ? (
+        <CreateCluster infrastructureType={infrastructureType} />
+    ) : (
+        <CreateInfrastructure />
+    )
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateControlPlane.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateControlPlane.tsx
@@ -11,16 +11,17 @@ import {
     PatternFlyColor,
 } from '@stolostron/react-data-view'
 import { Fragment, useCallback, useMemo } from 'react'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { DOC_LINKS } from '../../../../../lib/doc-util'
-import { NavigationPath } from '../../../../../NavigationPath'
+import { CancelBackState, cancelNavigation, NavigationPath } from '../../../../../NavigationPath'
 import { useSharedAtoms, useRecoilState } from '../../../../../shared-recoil'
 
 const clusterTypeTooltips = 'Required operator: Red Hat Advanced Cluster Management or multicluster engine'
 
 export function CreateControlPlane() {
     const [t] = useTranslation()
+    const location = useLocation<CancelBackState>()
     const history = useHistory()
     const { customResourceDefinitionsState } = useSharedAtoms()
     const [crds] = useRecoilState(customResourceDefinitionsState)
@@ -110,7 +111,7 @@ export function CreateControlPlane() {
                         ],
                     },
                 ],
-                onClick: () => history.push(NavigationPath.createDicoverHost),
+                onClick: () => history.push(NavigationPath.createDiscoverHost),
                 badge: t('Classic'),
                 badgeColor: CatalogColor.purple,
             },
@@ -123,7 +124,7 @@ export function CreateControlPlane() {
     const breadcrumbs = useMemo(() => {
         const newBreadcrumbs: ICatalogBreadcrumb[] = [
             { label: t('Clusters'), to: NavigationPath.clusters },
-            { label: t('Infrastructure'), to: NavigationPath.createInfrastructure },
+            { label: t('Infrastructure'), to: NavigationPath.createCluster },
             { label: t('Control plane type') },
         ]
         return newBreadcrumbs
@@ -140,8 +141,8 @@ export function CreateControlPlane() {
                 items={cards}
                 itemKeyFn={keyFn}
                 itemToCardFn={(card) => card}
-                onBack={() => history.push(NavigationPath.createInfrastructure)}
-                onCancel={() => history.push(NavigationPath.clusters)}
+                onBack={() => history.push(NavigationPath.createCluster)}
+                onCancel={() => cancelNavigation(location, history, NavigationPath.clusters)}
             />
         </Fragment>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateControlPlane.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateControlPlane.tsx
@@ -11,18 +11,16 @@ import {
     PatternFlyColor,
 } from '@stolostron/react-data-view'
 import { Fragment, useCallback, useMemo } from 'react'
-import { useHistory, useLocation } from 'react-router-dom'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { DOC_LINKS } from '../../../../../lib/doc-util'
-import { CancelBackState, cancelNavigation, NavigationPath } from '../../../../../NavigationPath'
+import { NavigationPath, useBackCancelNavigation } from '../../../../../NavigationPath'
 import { useSharedAtoms, useRecoilState } from '../../../../../shared-recoil'
 
 const clusterTypeTooltips = 'Required operator: Red Hat Advanced Cluster Management or multicluster engine'
 
 export function CreateControlPlane() {
     const [t] = useTranslation()
-    const location = useLocation<CancelBackState>()
-    const history = useHistory()
+    const { nextStep, back, cancel } = useBackCancelNavigation()
     const { customResourceDefinitionsState } = useSharedAtoms()
     const [crds] = useRecoilState(customResourceDefinitionsState)
 
@@ -58,11 +56,10 @@ export function CreateControlPlane() {
                     },
                 ],
                 onClick: isHypershiftEnabled
-                    ? () =>
-                          history.push({
-                              pathname: NavigationPath.createCluster,
-                              search: '?infrastructureType=CIMHypershift',
-                          })
+                    ? nextStep({
+                          pathname: NavigationPath.createCluster,
+                          search: '?infrastructureType=CIMHypershift',
+                      })
                     : undefined,
                 alertTitle: isHypershiftEnabled
                     ? undefined
@@ -111,13 +108,13 @@ export function CreateControlPlane() {
                         ],
                     },
                 ],
-                onClick: () => history.push(NavigationPath.createDiscoverHost),
+                onClick: nextStep(NavigationPath.createDiscoverHost),
                 badge: t('Classic'),
                 badgeColor: CatalogColor.purple,
             },
         ]
         return newCards
-    }, [history, t, isHypershiftEnabled])
+    }, [nextStep, t, isHypershiftEnabled])
 
     const keyFn = useCallback((card: ICatalogCard) => card.id, [])
 
@@ -141,8 +138,8 @@ export function CreateControlPlane() {
                 items={cards}
                 itemKeyFn={keyFn}
                 itemToCardFn={(card) => card}
-                onBack={() => history.push(NavigationPath.createCluster)}
-                onCancel={() => cancelNavigation(location, history, NavigationPath.clusters)}
+                onBack={back(NavigationPath.createCluster)}
+                onCancel={cancel(NavigationPath.clusters)}
             />
         </Fragment>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateDiscoverHost.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateDiscoverHost.test.tsx
@@ -10,8 +10,8 @@ describe('CreateDiscoverHost', () => {
     const Component = () => {
         return (
             <RecoilRoot>
-                <MemoryRouter initialEntries={[NavigationPath.createDicoverHost]}>
-                    <Route path={NavigationPath.createDicoverHost}>
+                <MemoryRouter initialEntries={[NavigationPath.createDiscoverHost]}>
+                    <Route path={NavigationPath.createDiscoverHost}>
                         <CreateDiscoverHost />
                     </Route>
                 </MemoryRouter>

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateDiscoverHost.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateDiscoverHost.tsx
@@ -1,14 +1,12 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { CatalogCardItemType, ItemView, ICatalogCard, PageHeader } from '@stolostron/react-data-view'
 import { Fragment, useCallback, useMemo } from 'react'
-import { useHistory, useLocation } from 'react-router-dom'
 import { useTranslation } from '../../../../../lib/acm-i18next'
-import { CancelBackState, cancelNavigation, NavigationPath } from '../../../../../NavigationPath'
+import { NavigationPath, useBackCancelNavigation } from '../../../../../NavigationPath'
 
 export function CreateDiscoverHost() {
     const [t] = useTranslation()
-    const location = useLocation<CancelBackState>()
-    const history = useHistory()
+    const { nextStep, back, cancel } = useBackCancelNavigation()
 
     const cards = useMemo(() => {
         const newCards: ICatalogCard[] = [
@@ -25,11 +23,10 @@ export function CreateDiscoverHost() {
                         ),
                     },
                 ],
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createCluster,
-                        search: '?infrastructureType=CIM',
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createCluster,
+                    search: '?infrastructureType=CIM',
+                }),
             },
             {
                 id: 'discover',
@@ -42,15 +39,14 @@ export function CreateDiscoverHost() {
                         ),
                     },
                 ],
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createCluster,
-                        search: '?infrastructureType=AI',
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createCluster,
+                    search: '?infrastructureType=AI',
+                }),
             },
         ]
         return newCards
-    }, [history, t])
+    }, [nextStep, t])
 
     const keyFn = useCallback((card: ICatalogCard) => card.id, [])
 
@@ -60,8 +56,6 @@ export function CreateDiscoverHost() {
         { label: t('Control plane type'), to: NavigationPath.createControlPlane },
         { label: t('Hosts') },
     ]
-
-    const onBack = useCallback(() => history.push(NavigationPath.createControlPlane), [history])
 
     return (
         <Fragment>
@@ -74,8 +68,8 @@ export function CreateDiscoverHost() {
                 items={cards}
                 itemKeyFn={keyFn}
                 itemToCardFn={(card) => card}
-                onBack={onBack}
-                onCancel={() => cancelNavigation(location, history, NavigationPath.clusters)}
+                onBack={back(NavigationPath.createControlPlane)}
+                onCancel={cancel(NavigationPath.clusters)}
             />
         </Fragment>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateDiscoverHost.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateDiscoverHost.tsx
@@ -1,12 +1,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { CatalogCardItemType, ItemView, ICatalogCard, PageHeader } from '@stolostron/react-data-view'
 import { Fragment, useCallback, useMemo } from 'react'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { useTranslation } from '../../../../../lib/acm-i18next'
-import { NavigationPath } from '../../../../../NavigationPath'
+import { CancelBackState, cancelNavigation, NavigationPath } from '../../../../../NavigationPath'
 
 export function CreateDiscoverHost() {
     const [t] = useTranslation()
+    const location = useLocation<CancelBackState>()
     const history = useHistory()
 
     const cards = useMemo(() => {
@@ -55,7 +56,7 @@ export function CreateDiscoverHost() {
 
     const breadcrumbs = [
         { label: t('Clusters'), to: NavigationPath.clusters },
-        { label: t('Infrastructure'), to: NavigationPath.createInfrastructure },
+        { label: t('Infrastructure'), to: NavigationPath.createCluster },
         { label: t('Control plane type'), to: NavigationPath.createControlPlane },
         { label: t('Hosts') },
     ]
@@ -74,7 +75,7 @@ export function CreateDiscoverHost() {
                 itemKeyFn={keyFn}
                 itemToCardFn={(card) => card}
                 onBack={onBack}
-                onCancel={() => history.push(NavigationPath.clusters)}
+                onCancel={() => cancelNavigation(location, history, NavigationPath.clusters)}
             />
         </Fragment>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateInfrastructure.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateInfrastructure.test.tsx
@@ -30,8 +30,8 @@ describe('CreateInfrastructure', () => {
                     snapshot.set(secretsState, [providerConnectionAws])
                 }}
             >
-                <MemoryRouter initialEntries={[NavigationPath.createInfrastructure]}>
-                    <Route path={NavigationPath.createInfrastructure}>
+                <MemoryRouter initialEntries={[NavigationPath.createCluster]}>
+                    <Route path={NavigationPath.createCluster}>
                         <CreateInfrastructure />
                     </Route>
                 </MemoryRouter>

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateInfrastructure.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateInfrastructure.tsx
@@ -1,9 +1,8 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { CatalogCardItemType, CatalogColor, ICatalogCard, ItemView, PageHeader } from '@stolostron/react-data-view'
 import { Fragment, useCallback, useMemo } from 'react'
-import { useHistory, useLocation } from 'react-router-dom'
 import { useTranslation } from '../../../../../lib/acm-i18next'
-import { CancelBackState, cancelNavigation, NavigationPath } from '../../../../../NavigationPath'
+import { NavigationPath, useBackCancelNavigation } from '../../../../../NavigationPath'
 import { AcmIcon, AcmIconVariant, Provider } from '../../../../../ui-components'
 import { DOC_LINKS } from '../../../../../lib/doc-util'
 import { ExternalLinkAltIcon } from '@patternfly/react-icons'
@@ -11,8 +10,7 @@ import { useSharedAtoms, useRecoilState } from '../../../../../shared-recoil'
 
 export function CreateInfrastructure() {
     const [t] = useTranslation()
-    const location = useLocation<CancelBackState>()
-    const history = useHistory()
+    const { nextStep, back, cancel } = useBackCancelNavigation()
     const { clusterImageSetsState, secretsState } = useSharedAtoms()
     const [secrets] = useRecoilState(secretsState)
     const [clusterImageSets] = useRecoilState(clusterImageSetsState)
@@ -48,11 +46,10 @@ export function CreateInfrastructure() {
                     },
                 ],
                 labels: getCredentialLabels(Provider.aws),
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createCluster,
-                        search: '?infrastructureType=AWS',
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createCluster,
+                    search: '?infrastructureType=AWS',
+                }),
             },
             // {
             //     id: 'alibaba',
@@ -67,7 +64,7 @@ export function CreateInfrastructure() {
             //         },
             //     ],
             //     labels: getCredentialLabels(Provider.alibaba),
-            //     // onClick: () => history.push(NavigationPath.clusters),
+            //     // onClick: () => nextStep(NavigationPath.clusters),
             // },
             {
                 id: 'google',
@@ -82,11 +79,10 @@ export function CreateInfrastructure() {
                     },
                 ],
                 labels: getCredentialLabels(Provider.gcp),
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createCluster,
-                        search: '?infrastructureType=GCP',
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createCluster,
+                    search: '?infrastructureType=GCP',
+                }),
             },
             {
                 id: 'hostinventory',
@@ -100,7 +96,7 @@ export function CreateInfrastructure() {
                         ),
                     },
                 ],
-                onClick: clusterImageSets.length ? () => history.push(NavigationPath.createControlPlane) : undefined,
+                onClick: clusterImageSets.length ? nextStep(NavigationPath.createControlPlane) : undefined,
                 alertTitle: clusterImageSets.length ? undefined : t('OpenShift release images unavailable'),
                 alertVariant: 'info',
                 alertContent: (
@@ -127,11 +123,10 @@ export function CreateInfrastructure() {
                     },
                 ],
                 labels: getCredentialLabels(Provider.azure),
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createCluster,
-                        search: '?infrastructureType=Azure',
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createCluster,
+                    search: '?infrastructureType=Azure',
+                }),
             },
             {
                 id: 'openstack',
@@ -146,11 +141,10 @@ export function CreateInfrastructure() {
                     },
                 ],
                 labels: getCredentialLabels(Provider.openstack),
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createCluster,
-                        search: '?infrastructureType=OpenStack',
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createCluster,
+                    search: '?infrastructureType=OpenStack',
+                }),
             },
             {
                 id: 'rhv',
@@ -165,11 +159,10 @@ export function CreateInfrastructure() {
                     },
                 ],
                 labels: getCredentialLabels(Provider.redhatvirtualization),
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createCluster,
-                        search: '?infrastructureType=RHV',
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createCluster,
+                    search: '?infrastructureType=RHV',
+                }),
             },
             {
                 id: 'vsphere',
@@ -184,15 +177,14 @@ export function CreateInfrastructure() {
                     },
                 ],
                 labels: getCredentialLabels(Provider.vmware),
-                onClick: () =>
-                    history.push({
-                        pathname: NavigationPath.createCluster,
-                        search: '?infrastructureType=vSphere',
-                    }),
+                onClick: nextStep({
+                    pathname: NavigationPath.createCluster,
+                    search: '?infrastructureType=vSphere',
+                }),
             },
         ]
         return newCards
-    }, [getCredentialLabels, clusterImageSets.length, history, t])
+    }, [nextStep, getCredentialLabels, clusterImageSets.length, t])
 
     const keyFn = useCallback((card: ICatalogCard) => card.id, [])
 
@@ -212,8 +204,8 @@ export function CreateInfrastructure() {
                 items={cards}
                 itemKeyFn={keyFn}
                 itemToCardFn={(card) => card}
-                onBack={() => history.push(NavigationPath.clusters)}
-                onCancel={() => cancelNavigation(location, history, NavigationPath.clusters)}
+                onBack={back(NavigationPath.clusters)}
+                onCancel={cancel(NavigationPath.clusters)}
             />
         </Fragment>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateInfrastructure.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateInfrastructure/CreateInfrastructure.tsx
@@ -1,9 +1,9 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { CatalogCardItemType, CatalogColor, ICatalogCard, ItemView, PageHeader } from '@stolostron/react-data-view'
 import { Fragment, useCallback, useMemo } from 'react'
-import { useHistory } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { useTranslation } from '../../../../../lib/acm-i18next'
-import { NavigationPath } from '../../../../../NavigationPath'
+import { CancelBackState, cancelNavigation, NavigationPath } from '../../../../../NavigationPath'
 import { AcmIcon, AcmIconVariant, Provider } from '../../../../../ui-components'
 import { DOC_LINKS } from '../../../../../lib/doc-util'
 import { ExternalLinkAltIcon } from '@patternfly/react-icons'
@@ -11,6 +11,7 @@ import { useSharedAtoms, useRecoilState } from '../../../../../shared-recoil'
 
 export function CreateInfrastructure() {
     const [t] = useTranslation()
+    const location = useLocation<CancelBackState>()
     const history = useHistory()
     const { clusterImageSetsState, secretsState } = useSharedAtoms()
     const [secrets] = useRecoilState(secretsState)
@@ -212,7 +213,7 @@ export function CreateInfrastructure() {
                 itemKeyFn={keyFn}
                 itemToCardFn={(card) => card}
                 onBack={() => history.push(NavigationPath.clusters)}
-                onCancel={() => history.push(NavigationPath.clusters)}
+                onCancel={() => cancelNavigation(location, history, NavigationPath.clusters)}
             />
         </Fragment>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -21,12 +21,12 @@ import {
 } from '../../../../../ui-components'
 import { cloneDeep, groupBy, pick } from 'lodash'
 import { Dispatch, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useReducer, useState } from 'react'
-import { Link, useHistory, useLocation } from 'react-router-dom'
+import { generatePath, Link, useHistory } from 'react-router-dom'
 import { SyncEditor } from '../../../../../components/SyncEditor/SyncEditor'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { DOC_LINKS } from '../../../../../lib/doc-util'
 import { PluginContext } from '../../../../../lib/PluginContext'
-import { CancelBackState, cancelNavigation, NavigationPath } from '../../../../../NavigationPath'
+import { NavigationPath, useBackCancelNavigation } from '../../../../../NavigationPath'
 import {
     ClusterCurator,
     ClusterCuratorDefinition,
@@ -206,7 +206,7 @@ export default function ImportClusterPage() {
     const toastContext = useContext(AcmToastContext)
     const { isACMAvailable } = useContext(PluginContext)
     const history = useHistory()
-    const location = useLocation<CancelBackState>()
+    const { cancel } = useBackCancelNavigation()
     const { canJoinClusterSets } = useCanJoinClusterSets()
     const mustJoinClusterSet = useMustJoinClusterSet()
     const initialClusterName = sessionStorage.getItem('DiscoveredClusterDisplayName') ?? ''
@@ -419,7 +419,7 @@ export default function ImportClusterPage() {
                                 autoClose: true,
                             })
                             setTimeout(() => {
-                                history.push(NavigationPath.clusterDetails.replace(':id', state.clusterName))
+                                history.push(generatePath(NavigationPath.clusterDetails, { id: state.clusterName }))
                             }, 2000)
                         } catch (err) {
                             if (err instanceof Error) {
@@ -436,9 +436,7 @@ export default function ImportClusterPage() {
                         }
                     })
                 }}
-                onCancel={function (): void {
-                    cancelNavigation(location, history, NavigationPath.clusters)
-                }}
+                onCancel={cancel(NavigationPath.clusters)}
                 submitButtonText={submitButtonText}
                 submittingButtonText={submittingButtonText}
             >

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -89,7 +89,7 @@ export default function ManagedClusters() {
                                 {
                                     id: 'createCluster',
                                     title: t('managed.createCluster'),
-                                    click: () => history.push(NavigationPath.createInfrastructure),
+                                    click: () => history.push(locationWithCancelBack(NavigationPath.createCluster)),
                                     isDisabled: !canCreateCluster,
                                     tooltip: t('rbac.unauthorized'),
                                     variant: ButtonVariant.primary,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -25,7 +25,7 @@ import { BulkActionModel, errorIsNot, IBulkActionModelProps } from '../../../../
 import { Trans, useTranslation } from '../../../../lib/acm-i18next'
 import { deleteCluster, detachCluster } from '../../../../lib/delete-cluster'
 import { canUser } from '../../../../lib/rbac-util'
-import { locationWithCancelBack, NavigationPath } from '../../../../NavigationPath'
+import { createBackCancelLocation, NavigationPath } from '../../../../NavigationPath'
 import {
     addonPathKey,
     addonTextKey,
@@ -89,7 +89,7 @@ export default function ManagedClusters() {
                                 {
                                     id: 'createCluster',
                                     title: t('managed.createCluster'),
-                                    click: () => history.push(locationWithCancelBack(NavigationPath.createCluster)),
+                                    click: () => history.push(createBackCancelLocation(NavigationPath.createCluster)),
                                     isDisabled: !canCreateCluster,
                                     tooltip: t('rbac.unauthorized'),
                                     variant: ButtonVariant.primary,
@@ -97,7 +97,7 @@ export default function ManagedClusters() {
                                 {
                                     id: 'importCluster',
                                     title: t('managed.importCluster'),
-                                    click: () => history.push(locationWithCancelBack(NavigationPath.importCluster)),
+                                    click: () => history.push(createBackCancelLocation(NavigationPath.importCluster)),
                                     isDisabled: !canCreateCluster,
                                     tooltip: t('rbac.unauthorized'),
                                     variant: ButtonVariant.secondary,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/AddCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/AddCluster.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { Link, useHistory } from 'react-router-dom'
 import { canUser } from '../../../../../lib/rbac-util'
-import { locationWithCancelBack, NavigationPath } from '../../../../../NavigationPath'
+import { createBackCancelLocation, NavigationPath } from '../../../../../NavigationPath'
 import { ManagedClusterDefinition } from '../../../../../resources'
 import { DOC_LINKS, viewDocumentation } from '../../../../../lib/doc-util'
 
@@ -33,7 +33,7 @@ export function AddCluster(props: { type: 'button' | 'dropdown'; buttonType?: 'p
                                 isDisabled={!canCreateCluster}
                                 tooltip={t('rbac.unauthorized')}
                                 variant={props.buttonType ?? 'primary'}
-                                to={locationWithCancelBack(NavigationPath.createCluster)}
+                                to={createBackCancelLocation(NavigationPath.createCluster)}
                             >
                                 {t('managed.createCluster')}
                             </AcmButton>
@@ -44,7 +44,7 @@ export function AddCluster(props: { type: 'button' | 'dropdown'; buttonType?: 'p
                                 isDisabled={!canCreateCluster}
                                 tooltip={t('rbac.unauthorized')}
                                 variant={props.buttonType ?? 'primary'}
-                                to={locationWithCancelBack(NavigationPath.importCluster)}
+                                to={createBackCancelLocation(NavigationPath.importCluster)}
                             >
                                 {t('managed.importCluster')}
                             </AcmButton>
@@ -58,10 +58,10 @@ export function AddCluster(props: { type: 'button' | 'dropdown'; buttonType?: 'p
         const onSelect = (id: string) => {
             switch (id) {
                 case 'create-cluster':
-                    history.push(locationWithCancelBack(NavigationPath.createCluster))
+                    history.push(createBackCancelLocation(NavigationPath.createCluster))
                     break
                 case 'import-cluster':
-                    history.push(locationWithCancelBack(NavigationPath.importCluster))
+                    history.push(createBackCancelLocation(NavigationPath.importCluster))
                     break
             }
         }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/AddCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/AddCluster.tsx
@@ -33,7 +33,7 @@ export function AddCluster(props: { type: 'button' | 'dropdown'; buttonType?: 'p
                                 isDisabled={!canCreateCluster}
                                 tooltip={t('rbac.unauthorized')}
                                 variant={props.buttonType ?? 'primary'}
-                                to={NavigationPath.createInfrastructure}
+                                to={locationWithCancelBack(NavigationPath.createCluster)}
                             >
                                 {t('managed.createCluster')}
                             </AcmButton>
@@ -58,7 +58,7 @@ export function AddCluster(props: { type: 'button' | 'dropdown'; buttonType?: 'p
         const onSelect = (id: string) => {
             switch (id) {
                 case 'create-cluster':
-                    history.push(NavigationPath.createCluster)
+                    history.push(locationWithCancelBack(NavigationPath.createCluster))
                     break
                 case 'import-cluster':
                     history.push(locationWithCancelBack(NavigationPath.importCluster))


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/26405

**Note:** This PR removes the `/multicloud/infrastructure/clusters/create/infrastructure` and `/multicloud/infrastructure/clusters/pools/create/infrastructure` routes.

Instead, if the `/multicloud/infrastructure/clusters/create` or `/multicloud/infrastructure/clusters/pools/create` routes are accessed without or with an invalid `infrastructureType` search param, instead of displaying an empty form or crashing, the catalog is displayed.

The `useBackCancelNavigation()` hook is used to remember in [History.state](https://developer.mozilla.org/en-US/docs/Web/API/History/state) whether back navigation can be used for a **Back** button (and how many steps maximum) and whether back navigation can be used for a **Cancel** button (and how many steps it takes). Using back keeps the browser history cleaner and supports different entry points to a flow.

First navigations into a catalog or wizard are done using the `createBackCancelLocation()` function. Then the hook provides callbacks `nextStep` (to add another catalog page or wizard in the flow), and `back` and `cancel` which take default locations for when a user navigates directly to these pages and using the back action is not available, so that a sensible location can be used.

Cluster pool creation has 2 entry points - from the main cluster pools page, and from the cluster pools tab of the cluster sets page. So using `useBackCancelNavigation()` allows the Back and Cancel buttons to return to where the user started these actions.

When coming from the cluster sets page, the cluster set is supposed to be pre-selected. This PR also restores that behaviour.