### PR TITLE
Update cluster templates page navigation + tweaks

### DIFF
--- a/frontend/plugins/mce/console-extensions.json
+++ b/frontend/plugins/mce/console-extensions.json
@@ -71,16 +71,6 @@
     {
         "type": "console.page/route",
         "properties": {
-            "path": "/k8s/cluster/clustertemplate.openshift.io~v1alpha1~ClusterTemplate/~tabs",
-            "component": { "$codeRef": "templates.default" }
-        },
-        "flags": {
-            "required": ["CLUSTER_TEMPLATES"]
-        }
-    },
-    {
-        "type": "console.page/route",
-        "properties": {
             "path": "/k8s/cluster/clustertemplate.openshift.io~v1alpha1~ClusterTemplate/~newRepository",
             "component": { "$codeRef": "helmRepositoryForm.default" }
         },

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplateDetails/ClusterTemplateDetailsPage.tsx
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplateDetails/ClusterTemplateDetailsPage.tsx
@@ -21,7 +21,7 @@ import { useClusterTemplate } from '../hooks/useClusterTemplates';
 import ClusterTemplateDetailsSections from './ClusterTemplateDetailsSections';
 
 export const getResourceListPageUrl = (resourceGVK: K8sGroupVersionKind) =>
-  `/k8s/cluster/${resourceGVK.group}~${resourceGVK.version}~${resourceGVK.kind}/~tabs`;
+  `/k8s/cluster/${resourceGVK.group}~${resourceGVK.version}~${resourceGVK.kind}`;
 
 const PageBreadcrumb: React.FC<{ clusterTemplateName: string }> = ({ clusterTemplateName }) => {
   const { t } = useTranslation();
@@ -64,7 +64,7 @@ const ClusterTemplateDetailsPage: React.FC<{ match: { params: { name: string } }
   const { name } = match.params;
   const [clusterTemplate, loaded, loadError] = useClusterTemplate(name);
   if (loadError) {
-    return <ErrorState error={loadError}></ErrorState>;
+    return <ErrorState />;
   }
   if (!loaded) {
     return <LoadingPage />;

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplatesPage/ClusterTemplatesPage.tsx
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/ClusterTemplatesPage/ClusterTemplatesPage.tsx
@@ -1,12 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import React from 'react';
-import {
-  HorizontalNav,
-  ListPageCreateDropdown,
-  ListPageHeader,
-  NavPage,
-} from '@openshift-console/dynamic-plugin-sdk';
-import { Redirect, Switch, useHistory } from 'react-router-dom';
+import { ListPageCreateDropdown, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
+import { useHistory, useLocation } from 'react-router-dom';
 import ClusterTemplatesTab from './ClusterTemplatesTab';
 import HelmRepositoriesTab from './HelmRepositoriesTab';
 import { useClusterTemplatesCount } from '../hooks/useClusterTemplates';
@@ -14,30 +9,26 @@ import { useHelmRepositoriesCount } from '../hooks/useHelmRepositories';
 import { useTranslation } from '../../../../lib/acm-i18next';
 import { clusterTemplateGVK } from '../constants';
 import { getNavLabelWithCount } from '../utils';
+import { Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 
 const clusterTemplateReference = `${clusterTemplateGVK.group}~${clusterTemplateGVK.version}~${clusterTemplateGVK.kind}`;
+
+const useActiveTab = () => {
+  const { search } = useLocation();
+  const activeTab = React.useMemo(() => {
+    const query = new URLSearchParams(search);
+    return query.get('tab') === 'repositories' ? 'repositories' : 'templates';
+  }, [search]);
+  return activeTab;
+};
 
 const ClusterTemplatesPage = () => {
   const { t } = useTranslation();
   const history = useHistory();
   const templatesCount = useClusterTemplatesCount();
   const helmRepositoriesCount = useHelmRepositoriesCount();
+  const activeTab = useActiveTab();
 
-  const pages: NavPage[] = React.useMemo(
-    () => [
-      {
-        href: '',
-        name: getNavLabelWithCount('Templates', templatesCount),
-        component: ClusterTemplatesTab,
-      },
-      {
-        href: 'repositories',
-        name: getNavLabelWithCount('HELM repositories', helmRepositoriesCount),
-        component: HelmRepositoriesTab,
-      },
-    ],
-    [templatesCount, helmRepositoriesCount],
-  );
   const actionItems = React.useMemo(
     () => ({
       NEW_CLUSTER_TEMPLATE: t('Cluster template'),
@@ -57,27 +48,53 @@ const ClusterTemplatesPage = () => {
     }
   };
 
-  return (
-    <Switch>
-      <Redirect
-        from={`/k8s/cluster/${clusterTemplateReference}`}
-        to={`/k8s/cluster/${clusterTemplateReference}/~tabs`}
-        exact
-      />
-      <>
-        <ListPageHeader title="Cluster templates">
-          <ListPageCreateDropdown
-            createAccessReview={{ groupVersionKind: clusterTemplateReference }}
-            items={actionItems}
-            onClick={handleCreateDropdownActionClick}
-          >
-            {t('Create')}
-          </ListPageCreateDropdown>
-        </ListPageHeader>
+  const handleTabSelect: React.ComponentProps<typeof Tabs>['onSelect'] = (_, eventKey) => {
+    switch (eventKey) {
+      case 'repositories':
+        history.push(`/k8s/cluster/${clusterTemplateReference}?tab=repositories`);
+        break;
+      default:
+        history.push(`/k8s/cluster/${clusterTemplateReference}`);
+    }
+  };
 
-        <HorizontalNav pages={pages} />
-      </>
-    </Switch>
+  return (
+    <>
+      <ListPageHeader title="Cluster templates">
+        <ListPageCreateDropdown
+          createAccessReview={{ groupVersionKind: clusterTemplateReference }}
+          items={actionItems}
+          onClick={handleCreateDropdownActionClick}
+        >
+          {t('Create')}
+        </ListPageCreateDropdown>
+      </ListPageHeader>
+      <div className="co-m-page__body">
+        <Tabs
+          activeKey={activeTab}
+          onSelect={handleTabSelect}
+          aria-label="Cluster templates page tabs"
+          role="resource-list-tabs"
+          usePageInsets
+        >
+          <Tab
+            eventKey="templates"
+            title={<TabTitleText>{getNavLabelWithCount('Templates', templatesCount)}</TabTitleText>}
+            aria-label="Cluster templates tab"
+          />
+          <Tab
+            eventKey="repositories"
+            title={
+              <TabTitleText>
+                {getNavLabelWithCount('HELM repositories', helmRepositoriesCount)}
+              </TabTitleText>
+            }
+            aria-label="HELM repositories tab"
+          />
+        </Tabs>
+        {activeTab === 'repositories' ? <HelmRepositoriesTab /> : <ClusterTemplatesTab />}
+      </div>
+    </>
   );
 };
 

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/helpers/ErrorState.tsx
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/helpers/ErrorState.tsx
@@ -4,7 +4,6 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { useTranslation } from '../../../../lib/acm-i18next';
 
 export type ErrorStateProps = {
-  error: unknown;
   errorId?: string;
   errorTitle?: string;
   errorMessage?: string;

--- a/frontend/src/routes/Infrastructure/ClusterTemplates/helpers/TableLoader.tsx
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/helpers/TableLoader.tsx
@@ -1,25 +1,15 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import React from 'react';
 import { Skeleton } from '@patternfly/react-core';
-import ErrorState from './ErrorState';
+import ErrorState, { ErrorStateProps } from './ErrorState';
 
 type TableLoaderProps = {
   children: React.ReactNode;
   loaded?: boolean;
   error?: unknown;
-  errorId?: string;
-  errorTitle?: string;
-  errorMessage?: string;
-};
+} & ErrorStateProps;
 
-function TableLoader({
-  loaded = false,
-  error,
-  errorId,
-  errorTitle,
-  errorMessage,
-  children,
-}: TableLoaderProps) {
+function TableLoader({ loaded = false, error, children, ...errorStateProps }: TableLoaderProps) {
   if (!loaded) {
     return (
       <div id="table-skeleton">
@@ -38,14 +28,7 @@ function TableLoader({
     );
   }
   if (error) {
-    return (
-      <ErrorState
-        error={error}
-        errorId={errorId}
-        errorTitle={errorTitle}
-        errorMessage={errorMessage}
-      ></ErrorState>
-    );
+    return <ErrorState {...errorStateProps} />;
   }
   return <>{children}</>;
 }


### PR DESCRIPTION
* Using redirect to `/~tabs` route to handle cluster templates page tabs collided with a resource detail route, resulting in first the detail page with error to get displayed and then getting replaced with actual cluster templates page. This change fixes it by using query params to manage active tab state.
* Use custom tabs implementation instead of HorizontalNav which does not work with query params
* Tweak TableLoader and ErrorState components
* Remove unused `/~tabs` plugin route

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>