### PR TITLE
Updates to Helm chart repoository edit modal

### DIFF
--- a/frontend/src/routes/Infrastructure/ClusterTemplates/helpers/SelectField.tsx
+++ b/frontend/src/routes/Infrastructure/ClusterTemplates/helpers/SelectField.tsx
@@ -6,10 +6,9 @@ import {
   SelectVariant,
   SelectOption,
   SelectProps,
-  SelectOptionObject,
+  FormGroupProps,
 } from '@patternfly/react-core';
 import { useField } from 'formik';
-import { FormGroupProps } from '@patternfly/react-core';
 
 // https://github.com/patternfly-labs/formik-pf/blob/main/src/components/types.ts
 export type FieldProps = {
@@ -28,7 +27,6 @@ type SelectFieldProps = FieldProps & {
   placeholderText?: React.ReactNode;
   isCreatable?: boolean;
   hasOnCreateOption?: boolean;
-  onChange?: (value: string | SelectOptionObject) => void;
 };
 
 // https://github.com/patternfly-labs/formik-pf/blob/main/src/components/utils.ts
@@ -39,7 +37,6 @@ const SelectField: React.FC<SelectFieldProps> = ({
   name,
   label,
   options,
-  onChange,
   placeholderText,
   helperText,
   isRequired,
@@ -56,14 +53,12 @@ const SelectField: React.FC<SelectFieldProps> = ({
 
   const onSelect: SelectProps['onSelect'] = (_, value) => {
     setValue(value as string);
-    onChange && onChange(value);
     setTouched(true);
     setIsOpen(false);
   };
 
   const onClearSelection = () => {
     setValue('');
-    onChange && onChange('');
     setTouched(true);
   };
 


### PR DESCRIPTION
* Fix updating of default credentials secret and configMap when no existing secret/configMap is selected
* Handle updating helm repository credentials on selecting existing secret/configMap using useEffect instead of custom onChange prop on SelectField

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>