### PR TITLE
Add Submariner UI for Openstack cloud

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2759,6 +2759,7 @@
     "The name or names of security standards the policy is related to. For example, National Institute of Standards and Technology (NIST) and Payment Card Industry (PCI).": "The name or names of security standards the policy is related to. For example, National Institute of Standards and Technology (NIST) and Payment Card Industry (PCI).",
     "The namespace on the hub cluster where the policy resources will be created.": "The namespace on the hub cluster where the policy resources will be created.",
     "The OpenStack clouds.yaml file, including the password, to connect to the OpenStack server.": "The OpenStack clouds.yaml file, including the password, to connect to the OpenStack server.",
+    "The OpenStack instance type of the gateway node that will be created on the managed cluster (default PnTAE.CPU_4_Memory_8192_Disk_50).": "The OpenStack instance type of the gateway node that will be created on the managed cluster (default PnTAE.CPU_4_Memory_8192_Disk_50).",
     "The password associated with the vCenter username.": "The password associated with the vCenter username.",
     "The period in seconds.": "The period in seconds.",
     "The placement binding name must be unique to the namespace.": "The placement binding name must be unique to the namespace.",

--- a/frontend/src/resources/submariner-config.ts
+++ b/frontend/src/resources/submariner-config.ts
@@ -55,6 +55,7 @@ type SubmarinerConfigDefaults = {
     gateways: number
     awsInstanceType: string
     azureInstanceType: string
+    openStackInstanceType: string
 }
 
 export const submarinerConfigDefault: SubmarinerConfigDefaults = {
@@ -64,4 +65,5 @@ export const submarinerConfigDefault: SubmarinerConfigDefaults = {
     gateways: 1,
     awsInstanceType: 'c5d.large',
     azureInstanceType: 'Standard_F4s_v2',
+    openStackInstanceType: 'PnTAE.CPU_4_Memory_8192_Disk_50',
 }


### PR DESCRIPTION
 * Added text boxes to accept OpenStack credentials and instance type
 * The submariner config will be created with the values provided

Fixes: [backlog#19297](https://github.com/stolostron/backlog/issues/19297)

Signed-off-by: Aswin Suryanarayanan <aswinsuryan@gmail.com>