### PR TITLE
Change default to 4.11

### DIFF
--- a/start-ocp-console.sh
+++ b/start-ocp-console.sh
@@ -10,7 +10,7 @@ oc get oauthclient console-oauth-client -o jsonpath='{.secret}' > ocp-console/co
 oc get secrets -n default --field-selector type=kubernetes.io/service-account-token -o json | \
     jq '.items[0].data."ca.crt"' -r | python -m base64 -d > ocp-console/ca.crt
 
-CONSOLE_VERSION=${CONSOLE_VERSION:=4.10}
+CONSOLE_VERSION=${CONSOLE_VERSION:=4.11}
 CONSOLE_PORT=${CONSOLE_PORT:=9000}
 CONSOLE_IMAGE="quay.io/openshift/origin-console:${CONSOLE_VERSION}"
 


### PR DESCRIPTION
For 4.10, you cannot specify multiple plugins via the `BRIDGE_PLUGINS` environment variable. 

Support for that was added in https://github.com/openshift/console/pull/11531

Changing default to 4.11 for now.