### PR TITLE
extend wait for nocks timeout

### DIFF
--- a/frontend/src/lib/test-util.ts
+++ b/frontend/src/lib/test-util.ts
@@ -321,7 +321,13 @@ export function nocksAreDone(nocks: Scope[]) {
 }
 
 export async function waitForNocks(nocks: Scope[]) {
-    await waitFor(() => expect(nocksAreDone(nocks)).toBeTruthy())
+    const timeout = options.timeout * nocks.length * 3
+    const timeoutMsg = (error: Error) => {
+        error.message = `!!!!!!!!!!! Test timed out in waitForNocks()--waited ${timeout / 1000} seconds !!!!!!!!!!!!!`
+        error.stack = ''
+        return error
+    }
+    await waitFor(() => expect(nocksAreDone(nocks)).toBeTruthy(), { timeout, onTimeout: timeoutMsg })
 }
 
 export async function waitForNock(nock: Scope) {


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

Fixes test failure for some individually run test (DiscoveryConfig.test.tsx):

![Screen Shot 2022-11-07 at 1 05 18 PM](https://user-images.githubusercontent.com/21374229/200420758-f27add74-629b-4a32-80bc-d8068be09865.png)
