### PR TITLE
Default networking type

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAWS.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAWS.js
@@ -20,6 +20,7 @@ import {
     addSnoText,
     architectureData,
     insertToggleModalFunction,
+    onImageChange,
 } from '../../../ManagedClusters/CreateCluster/controlData/ControlDataHelpers'
 import { getControlByID } from '../../../../../../lib/temptifly-utils'
 import { DevPreviewLabel } from '../../../../../../components/TechPreviewAlert'
@@ -721,6 +722,7 @@ const controlDataAWS = [
             notification: 'creation.ocp.cluster.must.select.ocp.image',
             required: true,
         },
+        onSelect: onImageChange,
     },
     //Always Hidden
     {

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataAZR.js
@@ -16,6 +16,7 @@ import {
     addSnoText,
     architectureData,
     insertToggleModalFunction,
+    onImageChange,
 } from '../../../ManagedClusters/CreateCluster/controlData/ControlDataHelpers'
 import { DevPreviewLabel } from '../../../../../../components/TechPreviewAlert'
 import { CreateCredentialModal } from '../../../../../../components/CreateCredentialModal'
@@ -513,6 +514,7 @@ const controlDataAZR = [
             notification: 'creation.ocp.cluster.must.select.ocp.image',
             required: true,
         },
+        onSelect: onImageChange,
     },
     //Always Hidden
     {

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataGCP.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/CreateClusterPool/controlData/ControlDataGCP.js
@@ -16,6 +16,7 @@ import {
     addSnoText,
     architectureData,
     insertToggleModalFunction,
+    onImageChange,
 } from '../../../ManagedClusters/CreateCluster/controlData/ControlDataHelpers'
 import { DevPreviewLabel } from '../../../../../../components/TechPreviewAlert'
 import { CreateCredentialModal } from '../../../../../../components/CreateCredentialModal'
@@ -310,6 +311,7 @@ const controlDataGCP = [
             notification: 'creation.ocp.cluster.must.select.ocp.image',
             required: true,
         },
+        onSelect: onImageChange,
     },
     //Always Hidden
     {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.js
@@ -21,6 +21,7 @@ import {
     architectureData,
     appendKlusterletAddonConfig,
     insertToggleModalFunction,
+    onImageChange,
 } from './ControlDataHelpers'
 import { getControlByID } from '../../../../../../lib/temptifly-utils'
 import { DevPreviewLabel } from '../../../../../../components/TechPreviewAlert'
@@ -722,6 +723,7 @@ const controlDataAWS = [
             notification: 'creation.ocp.cluster.must.select.ocp.image',
             required: true,
         },
+        onSelect: onImageChange,
     },
     //Always Hidden
     {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.js
@@ -17,6 +17,7 @@ import {
     architectureData,
     appendKlusterletAddonConfig,
     insertToggleModalFunction,
+    onImageChange,
 } from './ControlDataHelpers'
 import { DevPreviewLabel } from '../../../../../../components/TechPreviewAlert'
 import installConfigHbs from '../templates/install-config.hbs'
@@ -518,6 +519,7 @@ const controlDataAZR = [
             notification: 'creation.ocp.cluster.must.select.ocp.image',
             required: true,
         },
+        onSelect: onImageChange,
     },
     //Always Hidden
     {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.js
@@ -17,6 +17,7 @@ import {
     architectureData,
     appendKlusterletAddonConfig,
     insertToggleModalFunction,
+    onImageChange,
 } from './ControlDataHelpers'
 import { DevPreviewLabel } from '../../../../../../components/TechPreviewAlert'
 import installConfigHbs from '../templates/install-config.hbs'
@@ -316,6 +317,7 @@ const controlDataGCP = [
             notification: 'creation.ocp.cluster.must.select.ocp.image',
             required: true,
         },
+        onSelect: onImageChange,
     },
     //Always Hidden
     {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -414,7 +414,7 @@ export const networkingControlData = [
         name: 'creation.ocp.cluster.network.type',
         tooltip: 'tooltip.creation.ocp.cluster.network.type',
         type: 'singleselect',
-        active: 'OpenShiftSDN',
+        active: 'OVNKubernetes',
         available: ['OpenShiftSDN', 'OVNKubernetes'],
         validation: {
             notification: 'creation.ocp.cluster.valid.key',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -198,12 +198,6 @@ export const setAvailableTemplates = (control, templates) => {
     control.available = templates.map((template) => template.metadata.name)
 }
 
-export const onChangeImage = (control, controlData) => {
-    const networkDefault = getControlByID(controlData, 'networkType')
-    const { active, saveActive } = infrastructure
-    active = 'OVNKubernetes'
-}
-
 const onChangeProxy = (control, controlData) => {
     const infrastructure = getControlByID(controlData, 'connection')
     const { active, availableMap = {} } = infrastructure
@@ -298,6 +292,18 @@ export function getOSTNetworkingControlData() {
     const modifiedData = networkData.find((object) => object.id == 'networkType')
     modifiedData.available.push('Kuryr')
     return networkData
+}
+
+export const onImageChange = (control, controlData) => {
+    const networkDefault = getControlByID(controlData, 'networkType')
+    const { setActive } = networkDefault
+    const { active: version } = control
+
+    if (versionGreater(version, 4, 11)) {
+        setActive('OVNKubernetes')
+    } else {
+        setActive('OpenShiftSDN')
+    }
 }
 
 export const clusterDetailsControlData = [

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -198,6 +198,12 @@ export const setAvailableTemplates = (control, templates) => {
     control.available = templates.map((template) => template.metadata.name)
 }
 
+export const onChangeImage = (control, controlData) => {
+    const networkDefault = getControlByID(controlData, 'networkType')
+    const { active, saveActive } = infrastructure
+    active = 'OVNKubernetes'
+}
+
 const onChangeProxy = (control, controlData) => {
     const infrastructure = getControlByID(controlData, 'connection')
     const { active, availableMap = {} } = infrastructure

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.js
@@ -24,6 +24,7 @@ import {
     architectureData,
     appendKlusterletAddonConfig,
     insertToggleModalFunction,
+    onImageChange,
 } from './ControlDataHelpers'
 import { DevPreviewLabel } from '../../../../../../components/TechPreviewAlert'
 import installConfigHbs from '../templates/install-config.hbs'
@@ -94,6 +95,7 @@ const controlDataOST = [
             notification: 'creation.ocp.cluster.must.select.ocp.image',
             required: true,
         },
+        onSelect: onImageChange,
     },
     //Always Hidden
     {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.js
@@ -17,6 +17,7 @@ import {
     architectureData,
     appendKlusterletAddonConfig,
     insertToggleModalFunction,
+    onImageChange,
 } from './ControlDataHelpers'
 import { DevPreviewLabel } from '../../../../../../components/TechPreviewAlert'
 import installConfigHbs from '../templates/install-config.hbs'
@@ -88,6 +89,7 @@ const controlDataVMW = [
             notification: 'creation.ocp.cluster.must.select.ocp.image',
             required: true,
         },
+        onSelect: onImageChange,
     },
     //Always Hidden
     {


### PR DESCRIPTION
regarding: https://github.com/stolostron/backlog/issues/26524

"onImageChange" runs on release image selection, and changes the default active value for networkType based on the image version  selected. 

OCP 4.12+  defaults  to OVNKubernetes
....OpenShiftSDN for below 4.12
