### PR TITLE
Add backup label to submariner broker

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetInstallSubmariner/InstallSubmarinerForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetInstallSubmariner/InstallSubmarinerForm.tsx
@@ -447,6 +447,9 @@ export function InstallSubmarinerForm(props: { availableClusters: Cluster[] }) {
                 metadata: {
                     name: defaultBrokerName,
                     namespace: clusterSet?.metadata?.annotations?.[submarinerBrokerNamespaceAnnotation],
+                    labels: {
+                        'cluster.open-cluster-management.io/backup': 'submariner',
+                    },
                 },
                 spec: {
                     globalnetEnabled: false,
@@ -460,6 +463,9 @@ export function InstallSubmarinerForm(props: { availableClusters: Cluster[] }) {
                 metadata: {
                     name: defaultBrokerName,
                     namespace: clusterSet?.metadata?.annotations?.[submarinerBrokerNamespaceAnnotation],
+                    labels: {
+                        'cluster.open-cluster-management.io/backup': 'submariner',
+                    },
                 },
                 spec: {
                     globalnetEnabled,


### PR DESCRIPTION
Add `'cluster.open-cluster-management.io/backup': 'submariner'` label to SubmarinerBroker resource so it gets backed up during backup hub operation.

Fixes https://github.com/stolostron/backlog/issues/26876

Signed-off-by: Vishal Thapar <5137689+vthapar@users.noreply.github.com>