### PR TITLE
Fix console crash add new nodepool

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -584,6 +584,7 @@
     "Control plane": "Control plane",
     "Control Plane": "Control Plane",
     "Control plane pods": "Control plane pods",
+    "Control plane status": "Control plane status",
     "Control plane type": "Control plane type",
     "controllers": "controllers",
     "Controls": "Controls",

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -99,7 +99,7 @@ export function DistributionField(props: {
         if (props.cluster?.hypershift?.nodePools && props.cluster?.hypershift?.nodePools.length > 0) {
             for (let i = 0; i < props.cluster?.hypershift?.nodePools.length; i++) {
                 if (
-                    props.cluster?.hypershift?.nodePools[i].status.version <
+                    props.cluster?.hypershift?.nodePools[i].status?.version <
                     (props.cluster.distribution?.ocp?.version || '')
                 ) {
                     updateAvailable = true

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftClusterDetails.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftClusterDetails.tsx
@@ -6,8 +6,10 @@ import { getResource } from '../../../../../resources'
 import { AcmExpandableCard } from '../../../../../ui-components'
 import { launchToOCP } from '../../../../../lib/ocp-utils'
 import { useSharedAtoms, useSharedRecoil, useRecoilValue } from '../../../../../shared-recoil'
+import { useTranslation } from '../../../../../lib/acm-i18next'
 
 const HypershiftClusterDetails: React.FC = () => {
+    const { t } = useTranslation()
     const { hostedCluster } = useContext(ClusterContext)
     const { waitForAll } = useSharedRecoil()
     const { agentMachinesState, clusterImageSetsState, configMapsState, nodePoolsState } = useSharedAtoms()
@@ -24,7 +26,7 @@ const HypershiftClusterDetails: React.FC = () => {
     return (
         <>
             <div style={{ marginBottom: '24px' }}>
-                <AcmExpandableCard title="Cluster installation progress" id="hypershift-progress">
+                <AcmExpandableCard title={t('Control plane status')} id="hypershift-progress">
                     <HypershiftClusterInstallProgress
                         hostedCluster={hostedCluster}
                         fetchSecret={(name, namespace) =>


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://issues.redhat.com/browse/ACM-2084
https://issues.redhat.com/browse/ACM-2120

- Add check for nodepool status undefined to prevent crash
- Changed cluster installation progress text to control plane status
