### PR TITLE
Validate policy dependencies in yaml editor

### DIFF
--- a/frontend/__mocks__/react-monaco-editor.tsx
+++ b/frontend/__mocks__/react-monaco-editor.tsx
@@ -12,7 +12,10 @@ let mockEditor: {
     focus: () => void
     trigger: () => void
     onKeyDown: () => void
+    onMouseDown: () => void
+    onDidBlurEditorWidget: () => void
     changeViewZones: () => void
+    addCommand: () => void
     getSelection: () => void
     setSelection: () => void
     setSelections: () => void
@@ -30,7 +33,13 @@ let mockEditor: {
         ) => { range: { startColumn: number; startLineNumber: number; endColumn: number; endLineNumber: number } }[]
     }
 }
-let mockMonaco: { editor: { setModelLanguage: () => void }; Range: Range }
+let mockMonaco: {
+    editor: { setModelLanguage: () => void; defineTheme: () => void; setTheme: () => void }
+    languages: { registerHoverProvider: () => void }
+    KeyMod: any
+    KeyCode: any
+    Range: Range
+}
 let mockChangeModelCallback: () => void
 
 const MonacoEditor = (props: {
@@ -42,6 +51,8 @@ const MonacoEditor = (props: {
             focus: () => void
             trigger: () => void
             onKeyDown: () => void
+            onMouseDown: () => void
+            onDidBlurEditorWidget: () => void
             changeViewZones: () => void
             getSelection: () => void
             setSelection: () => void
@@ -71,6 +82,7 @@ const MonacoEditor = (props: {
             getFullModelRange: () => {},
             canUndo: () => true,
             canRedo: () => true,
+            onDidChangeContent: () => {},
             findMatches: (find: string) => {
                 return find === 'that'
                     ? [
@@ -85,6 +97,9 @@ const MonacoEditor = (props: {
             focus: () => {},
             trigger: () => {},
             onKeyDown: () => {},
+            onMouseDown: () => {},
+            onDidBlurEditorWidget: () => {},
+            addCommand: () => {},
             changeViewZones: () => {},
             getSelection: () => {},
             setSelection: () => {},
@@ -97,7 +112,10 @@ const MonacoEditor = (props: {
             getModel: () => model,
         }
         mockMonaco = {
-            editor: { setModelLanguage: () => {} },
+            editor: { setModelLanguage: () => {}, defineTheme: () => {}, setTheme: () => {} },
+            languages: { registerHoverProvider: () => {} },
+            KeyMod: {},
+            KeyCode: {},
             Range: Range,
         }
         props.editorDidMount(mockEditor, mockMonaco)

--- a/frontend/src/components/SyncEditor/SyncEditor.test.js
+++ b/frontend/src/components/SyncEditor/SyncEditor.test.js
@@ -1,0 +1,176 @@
+/* Copyright Contributors to the Open Cluster Management project */
+'use strict'
+
+import React from 'react'
+import { SyncEditor } from './SyncEditor'
+import { render } from '@testing-library/react'
+import schema from '../../routes/Governance/policies/schema.json'
+
+describe('SyncEditor component', () => {
+    afterAll(() => {
+        jest.resetAllMocks()
+    })
+
+    it('renders as expected', () => {
+        const update = jest.fn()
+        const Component = (props) => {
+            return <SyncEditor {...props} />
+        }
+        const { asFragment } = render(
+            <Component
+                editorTitle={'Policy YAML'}
+                variant="toolbar"
+                resources={[
+                    {
+                        apiVersion: 'policy.open-cluster-management.io/v1',
+                        kind: 'Policy',
+                        metadata: {
+                            name: 'policy-pod',
+                            namespace: 'default',
+                        },
+                        spec: {
+                            dependencies: [
+                                {
+                                    apiVersion: 'policy.open-cluster-management.io/v1',
+                                    compliance: 'Compliant',
+                                    kind: 'Policy',
+                                    name: 'case-test-policy',
+                                    namespace: 'default',
+                                },
+                            ],
+                            disabled: false,
+                            'policy-templates': [
+                                {
+                                    objectDefinition: {
+                                        apiVersion: 'policy.open-cluster-management.io/v1',
+                                        kind: 'ConfigurationPolicy',
+                                        metadata: {
+                                            name: 'policy-pod-1',
+                                        },
+                                        spec: {},
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ]}
+                schema={schema}
+                onEditorChange={(changes) => {
+                    update(changes?.resources)
+                }}
+                mock={true}
+                readonly={true}
+            />
+        )
+
+        expect(asFragment()).toMatchSnapshot()
+    })
+    it('renders as expected when a dependency compliance is invalid', () => {
+        const update = jest.fn()
+        const Component = (props) => {
+            return <SyncEditor {...props} />
+        }
+        const { asFragment } = render(
+            <Component
+                editorTitle={'Policy YAML'}
+                variant="toolbar"
+                resources={[
+                    {
+                        apiVersion: 'policy.open-cluster-management.io/v1',
+                        kind: 'Policy',
+                        metadata: {
+                            name: 'policy-pod',
+                            namespace: 'default',
+                        },
+                        spec: {
+                            dependencies: [
+                                {
+                                    apiVersion: 'policy.open-cluster-management.io/v1',
+                                    compliance: 'notAComplianceType',
+                                    kind: 'Policy',
+                                    name: 'case-test-policy',
+                                    namespace: 'default',
+                                },
+                            ],
+                            disabled: false,
+                            'policy-templates': [
+                                {
+                                    objectDefinition: {
+                                        apiVersion: 'policy.open-cluster-management.io/v1',
+                                        kind: 'ConfigurationPolicy',
+                                        metadata: {
+                                            name: 'policy-pod-1',
+                                        },
+                                        spec: {},
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ]}
+                schema={schema}
+                onEditorChange={(changes) => {
+                    update(changes?.resources)
+                }}
+                mock={true}
+                readonly={true}
+            />
+        )
+
+        expect(asFragment()).toMatchSnapshot()
+    })
+    it('renders as expected when a dependency namespace is invalid', () => {
+        const update = jest.fn()
+        const Component = (props) => {
+            return <SyncEditor {...props} />
+        }
+        const { asFragment } = render(
+            <Component
+                editorTitle={'Policy YAML'}
+                variant="toolbar"
+                resources={[
+                    {
+                        apiVersion: 'policy.open-cluster-management.io/v1',
+                        kind: 'Policy',
+                        metadata: {
+                            name: 'policy-pod',
+                            namespace: 'default',
+                        },
+                        spec: {
+                            dependencies: [
+                                {
+                                    apiVersion: 'policy.open-cluster-management.io/v1',
+                                    compliance: 'Compliant',
+                                    kind: 'ConfigurationPolicy',
+                                    name: 'case-test-policy',
+                                    namespace: 'default',
+                                },
+                            ],
+                            disabled: false,
+                            'policy-templates': [
+                                {
+                                    objectDefinition: {
+                                        apiVersion: 'policy.open-cluster-management.io/v1',
+                                        kind: 'ConfigurationPolicy',
+                                        metadata: {
+                                            name: 'policy-pod-1',
+                                        },
+                                        spec: {},
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ]}
+                schema={schema}
+                onEditorChange={(changes) => {
+                    update(changes?.resources)
+                }}
+                mock={true}
+                readonly={true}
+            />
+        )
+
+        expect(asFragment()).toMatchSnapshot()
+    })
+})

--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -25,6 +25,7 @@ export interface SyncEditorProps extends HTMLProps<HTMLPreElement> {
     immutables?: (string | string[])[]
     syncs?: unknown
     readonly?: boolean
+    mock?: boolean
     onClose?: () => void
     onStatusChange?: (editorState: any) => void
     onEditorChange?: (editorResources: any) => void
@@ -42,6 +43,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
         syncs,
         filters,
         readonly,
+        mock,
         onStatusChange,
         onEditorChange,
         onClose,
@@ -49,6 +51,24 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
     const pageRef = useRef<HTMLDivElement>(null)
     const editorRef = useRef<any | null>(null)
     const monacoRef = useRef<any | null>(null)
+    if (mock) {
+        if (!monacoRef.current) {
+            monacoRef.current = {
+                editor: {
+                    setTheme: () => {},
+                },
+                languages: {
+                    registerHoverProvider: () => {},
+                },
+            }
+            editorRef.current = {
+                getModel: () => {},
+                onMouseDown: () => {},
+                onKeyDown: () => {},
+                onDidBlurEditorWidget: () => {},
+            }
+        }
+    }
     const editorHadFocus = useRef(false)
     const defaultCopy: ReactNode = <span style={{ wordBreak: 'keep-all' }}>Copy</span>
     const copiedCopy: ReactNode = <span style={{ wordBreak: 'keep-all' }}>Selection copied</span>
@@ -166,8 +186,8 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
 
     // prevent editor from flashing when typing in form
     useEffect(() => {
-        const model = editorRef.current?.getModel()
-        model.onDidChangeContent(() => {
+        const model = editorRef.current.getModel()
+        model?.onDidChangeContent(() => {
             model?.forceTokenization(model?.getLineCount())
         })
     }, [])

--- a/frontend/src/components/SyncEditor/__snapshots__/SyncEditor.test.js.snap
+++ b/frontend/src/components/SyncEditor/__snapshots__/SyncEditor.test.js.snap
@@ -1,0 +1,280 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SyncEditor component renders as expected 1`] = `
+<DocumentFragment>
+  <div
+    class="sync-editor__container"
+  >
+    <div
+      class="pf-c-code-editor pf-m-read-only"
+    >
+      <div
+        class="pf-c-code-editor__header"
+      >
+        <div
+          class="pf-c-code-editor__controls"
+        >
+          <div
+            class="sy-c-code-editor__title"
+          >
+            Policy YAML
+          </div>
+          <div
+            style="display: flex;"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Find"
+              class="pf-c-button pf-m-control"
+              data-ouia-component-id="OUIA-Generated-Button-control-1"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                />
+              </svg>
+            </button>
+            <button
+              aria-disabled="false"
+              aria-label="Copy to clipboard"
+              aria-labelledby="copy-button code-content"
+              class="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-1"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              id="copy-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="pf-c-code-editor__header-main"
+        />
+      </div>
+      <div
+        class="pf-c-code-editor__main"
+      >
+        <div
+          class="pf-c-code-editor__code"
+          tabindex="0"
+        >
+          <textarea
+            aria-label="monaco"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SyncEditor component renders as expected when a dependency compliance is invalid 1`] = `
+<DocumentFragment>
+  <div
+    class="sync-editor__container"
+  >
+    <div
+      class="pf-c-code-editor pf-m-read-only"
+    >
+      <div
+        class="pf-c-code-editor__header"
+      >
+        <div
+          class="pf-c-code-editor__controls"
+        >
+          <div
+            class="sy-c-code-editor__title"
+          >
+            Policy YAML
+          </div>
+          <div
+            style="display: flex;"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Find"
+              class="pf-c-button pf-m-control"
+              data-ouia-component-id="OUIA-Generated-Button-control-2"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                />
+              </svg>
+            </button>
+            <button
+              aria-disabled="false"
+              aria-label="Copy to clipboard"
+              aria-labelledby="copy-button code-content"
+              class="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              id="copy-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="pf-c-code-editor__header-main"
+        />
+      </div>
+      <div
+        class="pf-c-code-editor__main"
+      >
+        <div
+          class="pf-c-code-editor__code"
+          tabindex="0"
+        >
+          <textarea
+            aria-label="monaco"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`SyncEditor component renders as expected when a dependency namespace is invalid 1`] = `
+<DocumentFragment>
+  <div
+    class="sync-editor__container"
+  >
+    <div
+      class="pf-c-code-editor pf-m-read-only"
+    >
+      <div
+        class="pf-c-code-editor__header"
+      >
+        <div
+          class="pf-c-code-editor__controls"
+        >
+          <div
+            class="sy-c-code-editor__title"
+          >
+            Policy YAML
+          </div>
+          <div
+            style="display: flex;"
+          >
+            <button
+              aria-disabled="false"
+              aria-label="Find"
+              class="pf-c-button pf-m-control"
+              data-ouia-component-id="OUIA-Generated-Button-control-3"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M505 442.7L405.3 343c-4.5-4.5-10.6-7-17-7H372c27.6-35.3 44-79.7 44-128C416 93.1 322.9 0 208 0S0 93.1 0 208s93.1 208 208 208c48.3 0 92.7-16.4 128-44v16.3c0 6.4 2.5 12.5 7 17l99.7 99.7c9.4 9.4 24.6 9.4 33.9 0l28.3-28.3c9.4-9.4 9.4-24.6.1-34zM208 336c-70.7 0-128-57.2-128-128 0-70.7 57.2-128 128-128 70.7 0 128 57.2 128 128 0 70.7-57.2 128-128 128z"
+                />
+              </svg>
+            </button>
+            <button
+              aria-disabled="false"
+              aria-label="Copy to clipboard"
+              aria-labelledby="copy-button code-content"
+              class="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-3"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              id="copy-button"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 448 512"
+                width="1em"
+              >
+                <path
+                  d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <div
+          class="pf-c-code-editor__header-main"
+        />
+      </div>
+      <div
+        class="pf-c-code-editor__main"
+      >
+        <div
+          class="pf-c-code-editor__code"
+          tabindex="0"
+        >
+          <textarea
+            aria-label="monaco"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/components/SyncEditor/__snapshots__/validation.test.js.snap
+++ b/frontend/src/components/SyncEditor/__snapshots__/validation.test.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`validation compileAJVSchemas - returns properly 1`] = `
+Array [
+  Object {
+    "required": 1,
+    "type": "Policy",
+    "validator": [Function],
+  },
+  Object {
+    "required": undefined,
+    "type": "Placement",
+    "validator": [Function],
+  },
+  Object {
+    "required": undefined,
+    "type": "PlacementRule",
+    "validator": [Function],
+  },
+  Object {
+    "required": undefined,
+    "type": "PlacementBinding",
+    "validator": [Function],
+  },
+]
+`;

--- a/frontend/src/components/SyncEditor/synchronize.ts
+++ b/frontend/src/components/SyncEditor/synchronize.ts
@@ -72,7 +72,13 @@ export const crossReference = (paths: { [name: string]: any }) => {
             const references: { [name: string]: any[] } = {}
             const set = { value: values[0], references }
             Object.values(paths).forEach((path: { $v: string; $p: any[] }) => {
-                if (typeof path.$v === 'string' && path.$v.length && path.$v.startsWith(values[0])) {
+                if (
+                    typeof path.$v === 'string' &&
+                    path.$v.length &&
+                    path.$v.startsWith(values[0]) &&
+                    !path.$p.includes('dependencies') &&
+                    !path.$p.includes('extraDependencies')
+                ) {
                     references[JSON.stringify(path.$p)] = path.$p
                 }
             })

--- a/frontend/src/components/SyncEditor/validation.test.js
+++ b/frontend/src/components/SyncEditor/validation.test.js
@@ -1,0 +1,117 @@
+/* Copyright Contributors to the Open Cluster Management project */
+// import { render, waitFor } from '@testing-library/react'
+// import { createBrowserHistory } from 'history'
+// import { Router } from 'react-router-dom'
+// import { RecoilRoot } from 'recoil'
+import Ajv from 'ajv'
+import { addAjvKeywords, compileAjvSchemas, validateResource } from './validation'
+import schema from '../../routes/Governance/policies/schema.json'
+import { keyBy } from 'lodash'
+
+describe('validation', () => {
+    it('addAjvKeywords - returns properly', async () => {
+        const ajvKeywords = new Ajv({ allErrors: true, verbose: true })
+        addAjvKeywords(ajvKeywords)
+
+        expect(ajvKeywords.RULES.all.validateName).toEqual(expect.objectContaining({ keyword: 'validateName' }))
+        expect(ajvKeywords.RULES.all.validateDep).toEqual(expect.objectContaining({ keyword: 'validateDep' }))
+        expect(ajvKeywords.RULES.all.validateLabel).toEqual(expect.objectContaining({ keyword: 'validateLabel' }))
+    })
+
+    it('compileAJVSchemas - returns properly', async () => {
+        const ajvSchemas = compileAjvSchemas(schema)
+
+        expect(ajvSchemas).toMatchSnapshot()
+    })
+
+    it('validates incorrect compliance', async () => {
+        // raw policy data for validation - ignoring lint for test readability
+
+        // prettier-ignore
+        const mappings = {"Policy":[{"apiVersion":{"$k":"apiVersion","$r":1,"$l":1,"$v":"policy.open-cluster-management.io/v1",
+            "$gk":{"start":{"line":1,"col":1},"end":{"line":1,"col":11}},"$gv":{"start":{"line":1,"col":13},"end":{"line":1,"col":49}}},
+            "kind":{"$k":"kind","$r":2,"$l":1,"$v":"Policy","$gk":{"start":{"line":2,"col":1},"end":{"line":2,"col":5}},
+            "$gv":{"start":{"line":2,"col":7},"end":{"line":2,"col":13}}},"metadata":{"$k":"metadata","$r":3,"$l":3,
+            "$v":{"name":{"$k":"name","$r":4,"$l":1,"$v":"policy-pod","$gk":{"start":{"line":4,"col":3},"end":{"line":4,"col":7}},
+            "$gv":{"start":{"line":4,"col":9},"end":{"line":4,"col":19}}},"namespace":{"$k":"namespace","$r":5,"$l":1,"$v":"default",
+            "$gk":{"start":{"line":5,"col":3},"end":{"line":5,"col":12}},"$gv":{"start":{"line":5,"col":14},"end":{"line":5,"col":21}}}},
+            "$gk":{"start":{"line":3,"col":1},"end":{"line":3,"col":9}},"$gv":{"start":{"line":4,"col":3},"end":{"line":6,"col":1}}},
+            "spec":{"$k":"spec","$r":6,"$l":8,"$v":{"disabled":{"$k":"disabled","$r":7,"$l":1,"$v":false,"$gk":{"start":{"line":7,"col":3},
+            "end":{"line":7,"col":11}},"$gv":{"start":{"line":7,"col":13},"end":{"line":7,"col":18}}},"dependencies":{"$k":"dependencies",
+            "$r":8,"$l":6,"$v":[{"$k":"0","$r":9,"$l":5,"$v":{"name":{"$k":"name","$r":9,"$l":1,"$v":"namespace-foo-setup-policy",
+            "$gk":{"start":{"line":9,"col":7},"end":{"line":9,"col":11}},"$gv":{"start":{"line":9,"col":13},"end":{"line":9,"col":39}}},
+            "namespace":{"$k":"namespace","$r":10,"$l":1,"$v":"","$gk":{"start":{"line":10,"col":7},"end":{"line":10,"col":16}},
+            "$gv":{"start":{"line":10,"col":18},"end":{"line":10,"col":20}}},"apiVersion":{"$k":"apiVersion","$r":11,"$l":1,
+            "$v":"policy.open-cluster-management.io/v1","$gk":{"start":{"line":11,"col":7},"end":{"line":11,"col":17}},"$gv":{"start":{"line":11,"col":19},
+            "end":{"line":11,"col":55}}},"kind":{"$k":"kind","$r":12,"$l":1,"$v":"Policy","$gk":{"start":{"line":12,"col":7},"end":{"line":12,"col":11}},
+            "$gv":{"start":{"line":12,"col":13},"end":{"line":12,"col":19}}},"compliance":{"$k":"compliance","$r":13,"$l":1,"$v":"Complianta",
+            "$gk":{"start":{"line":13,"col":7},"end":{"line":13,"col":17}},"$gv":{"start":{"line":13,"col":19},"end":{"line":13,"col":29}}}},
+            "$gv":{"start":{"line":9,"col":7},"end":{"line":14,"col":1}}}],"$gk":{"start":{"line":8,"col":3},"end":{"line":8,"col":15}},
+            "$gv":{"start":{"line":9,"col":5},"end":{"line":14,"col":1}}}},"$gk":{"start":{"line":6,"col":1},"end":{"line":6,"col":5}},
+            "$gv":{"start":{"line":7,"col":3},"end":{"line":14,"col":1}}}}]}
+
+        // prettier-ignore
+        const resource = {"apiVersion":"policy.open-cluster-management.io/v1","kind":"Policy","metadata":{"name":"policy-pod",
+            "namespace":"default"},"spec":{"disabled":false,"dependencies":[{"name":"namespace-foo-setup-policy","namespace":"",
+            "apiVersion":"policy.open-cluster-management.io/v1","kind":"Policy","compliance":"Complianta"}]}}
+
+        const prefix = ['Policy', 0]
+        const errors = []
+        const ajvSchemas = compileAjvSchemas(schema)
+        const validatorMap = keyBy(ajvSchemas, 'type')
+        const validator = validatorMap['Policy'].validator
+
+        validateResource(validator, mappings, prefix, resource, errors, [])
+
+        expect(errors[0]).toEqual(
+            expect.objectContaining({
+                message: 'must be equal to one of the allowed values: "Compliant", "NonCompliant", "Pending"',
+            })
+        )
+    })
+
+    it('validates incorrect namespace in dependency', async () => {
+        // raw policy data for validation - ignoring lint for test readability
+
+        // prettier-ignore
+        const mappings = {"Policy":[{"apiVersion":{"$k":"apiVersion","$r":1,"$l":1,"$v":"policy.open-cluster-management.io/v1",
+            "$gk":{"start":{"line":1,"col":1},"end":{"line":1,"col":11}},"$gv":{"start":{"line":1,"col":13},"end":{"line":1,"col":49}}},
+            "kind":{"$k":"kind","$r":2,"$l":1,"$v":"Policy","$gk":{"start":{"line":2,"col":1},"end":{"line":2,"col":5}},"$gv":{"start":{"line":2,"col":7},
+            "end":{"line":2,"col":13}}},"metadata":{"$k":"metadata","$r":3,"$l":3,"$v":{"name":{"$k":"name","$r":4,"$l":1,"$v":"policy-pod",
+            "$gk":{"start":{"line":4,"col":3},"end":{"line":4,"col":7}},"$gv":{"start":{"line":4,"col":9},"end":{"line":4,"col":19}}},
+            "namespace":{"$k":"namespace","$r":5,"$l":1,"$v":"default","$gk":{"start":{"line":5,"col":3},"end":{"line":5,"col":12}},
+            "$gv":{"start":{"line":5,"col":14},"end":{"line":5,"col":21}}}},"$gk":{"start":{"line":3,"col":1},"end":{"line":3,"col":9}},
+            "$gv":{"start":{"line":4,"col":3},"end":{"line":6,"col":1}}},"spec":{"$k":"spec","$r":6,"$l":8,"$v":{"disabled":{"$k":"disabled",
+            "$r":7,"$l":1,"$v":false,"$gk":{"start":{"line":7,"col":3},"end":{"line":7,"col":11}},"$gv":{"start":{"line":7,"col":13},
+            "end":{"line":7,"col":18}}},"dependencies":{"$k":"dependencies","$r":8,"$l":6,"$v":[{"$k":"0","$r":9,"$l":5,"$v":{"name":{"$k":"name","$r":9,
+            "$l":1,"$v":"namespace-foo-setup-policy","$gk":{"start":{"line":9,"col":7},"end":{"line":9,"col":11}},"$gv":{"start":{"line":9,"col":13},
+            "end":{"line":9,"col":39}}},"namespace":{"$k":"namespace","$r":10,"$l":1,"$v":"default","$gk":{"start":{"line":10,"col":7},"end":{"line":10,
+            "col":16}},"$gv":{"start":{"line":10,"col":18},"end":{"line":10,"col":25}}},"apiVersion":{"$k":"apiVersion","$r":11,"$l":1,
+            "$v":"policy.open-cluster-management.io/v1","$gk":{"start":{"line":11,"col":7},"end":{"line":11,"col":17}},"$gv":{"start":{"line":11,"col":19},
+            "end":{"line":11,"col":55}}},"kind":{"$k":"kind","$r":12,"$l":1,"$v":"ConfigurationPolicy","$gk":{"start":{"line":12,"col":7},"end":{"line":12,"col":11}},
+            "$gv":{"start":{"line":12,"col":13},"end":{"line":12,"col":32}}},"compliance":{"$k":"compliance","$r":13,"$l":1,"$v":"Compliant",
+            "$gk":{"start":{"line":13,"col":7},"end":{"line":13,"col":17}},"$gv":{"start":{"line":13,"col":19},"end":{"line":13,"col":28}}}},"$gv":{"start":{"line":9,
+            "col":7},"end":{"line":14,"col":1}}}],"$gk":{"start":{"line":8,"col":3},"end":{"line":8,"col":15}},"$gv":{"start":{"line":9,"col":5},
+            "end":{"line":14,"col":1}}}},"$gk":{"start":{"line":6,"col":1},"end":{"line":6,"col":5}},"$gv":{"start":{"line":7,"col":3},"end":{"line":14,"col":1}}}}]}
+
+        // prettier-ignore
+        const resource = {"apiVersion":"policy.open-cluster-management.io/v1","kind":"Policy","metadata":{"name":"policy-pod","namespace":"default"},
+            "spec":{"disabled":false,"dependencies":[{"name":"namespace-foo-setup-policy","namespace":"default","apiVersion":"policy.open-cluster-management.io/v1",
+            "kind":"ConfigurationPolicy","compliance":"Compliant"}]}}
+
+        const prefix = ['Policy', 0]
+        const errors = []
+        const ajvSchemas = compileAjvSchemas(schema)
+        const validatorMap = keyBy(ajvSchemas, 'type')
+        const validator = validatorMap['Policy'].validator
+
+        validateResource(validator, mappings, prefix, resource, errors, [])
+
+        expect(errors[0]).toEqual(
+            expect.objectContaining({
+                message:
+                    'Dependencies on ConfigurationPolicies, IamPolicies, and CertificatePolicies cannot contain a namespace',
+            })
+        )
+    })
+})

--- a/frontend/src/routes/Governance/policies/schema.json
+++ b/frontend/src/routes/Governance/policies/schema.json
@@ -21,7 +21,35 @@
                     "type": "object",
                     "properties": {
                         "disabled": { "type": "boolean" },
-                        "remediationAction": { "enum": ["inform", "enforce"] }
+                        "remediationAction": { "enum": ["inform", "enforce"] },
+                        "dependencies": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "compliance": { "enum": ["Compliant", "NonCompliant", "Pending"] }
+                                },
+                                "validateDep": true
+                            }
+                        },
+                        "policy-templates": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "extraDependencies": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "compliance": { "enum": ["Compliant", "NonCompliant", "Pending"] }
+                                            },
+                                            "validateDep": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     },
                     "required": ["disabled"]
                 }


### PR DESCRIPTION
for https://issues.redhat.com/browse/ACM-2148

Validates the compliance state of a dependency to make sure it is an accepted value and validates that dependencies on ConfigurationPolicies, IamPolicies, and CertificatePolicies do not have a namespace specified, since that namespace will be ignored in favor of the cluster namespace anyway. Also fixes a crash related to the editor where a deleted namespace in a dependency with the same value as the policy namespace would cause an error.