### PR TITLE
Back port fix Argo app crash when no status to 2.6

### DIFF
--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -345,7 +345,7 @@ export default function ApplicationsOverview() {
         () =>
             argoApplications
                 .filter((argoApp) => {
-                    const resources = argoApp.status.resources
+                    const resources = argoApp.status ? argoApp.status.resources : undefined
                     let definedNamespace = ''
                     resources &&
                         resources.forEach((resource: any) => {


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

This issue is already fixed in 2.7. Backporting due to user created BZ. Targeting for 2.6.4.

https://github.com/stolostron/backlog/issues/26947

- Add check if status is undefined