### PR TITLE
Add testids for onboarding modal

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.test.tsx
@@ -21,7 +21,6 @@ describe('OnboardingModal open', () => {
             'data-ouia-component-id',
             'clustersOnboardingModal'
         )
-        expect(screen.getByTestId('clustersOnboardingModal')).toHaveAttribute('data-testid', 'clustersOnboardingModal')
         expect(screen.queryAllByText('Import an existing cluster').length).toBe(1)
         expect(screen.queryAllByText('Connect your cloud provider').length).toBe(1)
         expect(screen.queryAllByText('Discover hosts to create host inventory').length).toBe(1)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { waitForText } from '../../../../../lib/test-util'
 import { OnboardingModal } from './OnboardingModal'
-
+import '@testing-library/jest-dom'
 describe('OnboardingModal open', () => {
     beforeEach(async () => {
         render(
@@ -17,6 +17,11 @@ describe('OnboardingModal open', () => {
     })
 
     it('should render OnboardingModal', async () => {
+        expect(screen.getByTestId('clustersOnboardingModal')).toHaveAttribute(
+            'data-ouia-component-id',
+            'clustersOnboardingModal'
+        )
+        expect(screen.getByTestId('clustersOnboardingModal')).toHaveAttribute('data-testid', 'clustersOnboardingModal')
         expect(screen.queryAllByText('Import an existing cluster').length).toBe(1)
         expect(screen.queryAllByText('Connect your cloud provider').length).toBe(1)
         expect(screen.queryAllByText('Discover hosts to create host inventory').length).toBe(1)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { waitForText } from '../../../../../lib/test-util'
 import { OnboardingModal } from './OnboardingModal'
-import '@testing-library/jest-dom'
+
 describe('OnboardingModal open', () => {
     beforeEach(async () => {
         render(

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.tsx
@@ -49,7 +49,10 @@ export function OnboardingModal(props: IOnboardingModalProps) {
     return (
         <AcmModal
             variant={ModalVariant.medium}
-            title=" "
+            title=""
+            id="clustersOnboardingModal"
+            data-testid="clustersOnboardingModal"
+            ouiaId="clustersOnboardingModal"
             isOpen={true}
             onClose={props.close}
             footer={

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.tsx
@@ -51,7 +51,6 @@ export function OnboardingModal(props: IOnboardingModalProps) {
             variant={ModalVariant.medium}
             title=" "
             id="clustersOnboardingModal"
-            data-testid="clustersOnboardingModal"
             ouiaId="clustersOnboardingModal"
             isOpen={true}
             onClose={props.close}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.tsx
@@ -49,7 +49,7 @@ export function OnboardingModal(props: IOnboardingModalProps) {
     return (
         <AcmModal
             variant={ModalVariant.medium}
-            title=""
+            title=" "
             id="clustersOnboardingModal"
             data-testid="clustersOnboardingModal"
             ouiaId="clustersOnboardingModal"


### PR DESCRIPTION
Signed-off-by: David Huynh <dhuynh@redhat.com>

The new onboarding modal doesn't have id nor any predictable testid to grab the element in our test automation. In order to reduce test flake and improve usability we should set these values.