### PR TITLE
Fixes ACM-2269 where expandable titles in hypershift cluster details …

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.css
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.css
@@ -5,3 +5,7 @@
 .pf-c-modal-box__footer {
     padding: 0px;
 }
+
+:root:where(.pf-theme-dark) .pf-c-expandable-section__toggle-text {
+    color: #FFFFFF;
+}


### PR DESCRIPTION
…in dark mode had bad contrast

Signed-off-by: Omar Farag <ofarag@redhat.com>

Hypershift cluster details had bad contrast in dark mode:

Before:
![image](https://user-images.githubusercontent.com/15898988/205402038-8037e210-69e5-4a0e-95dd-eb1a3fec3554.png)


After: 
![image](https://user-images.githubusercontent.com/15898988/205401994-c3e645fb-96bd-43de-ba7d-3b30f6d13b70.png)

