### PR TITLE
Hide cluster claim name for standalone clusters w/o a clusterpool and…

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
@@ -329,6 +329,16 @@ export function ClusterOverviewPageContent(props: {
         leftItems.splice(5, 0, clusterProperties.channel)
     }
 
+    // clusterClaim should not be shown for stand alone clusters not from a clusterpool and not for hosted control planes.
+    if (
+        (clusterProperties.clusterControlPlaneType?.value === t('Standalone') &&
+            clusterProperties.clusterPool?.value === undefined) ||
+        clusterProperties.clusterControlPlaneType?.value === t('Hosted') ||
+        clusterProperties.clusterControlPlaneType?.value === t('Hub, Hosted')
+    ) {
+        leftItems.splice(2, 1)
+    }
+
     if (
         cluster?.provider === Provider.hostinventory &&
         !cluster?.isHypershift &&


### PR DESCRIPTION
… hosted control planes
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

This PR is for hiding the Cluster Claim name row in the clusterOverview page when the cluster is a standalone cluster with no cluster pool or is a hosted control plane.

Before:
![Screenshot from 2022-12-08 11-57-34](https://user-images.githubusercontent.com/17188326/206515427-464496a7-cab4-4034-8366-27907f85f078.png)

After:
![Screenshot from 2022-12-08 11-54-58](https://user-images.githubusercontent.com/17188326/206514823-764be192-845a-4079-885f-b9050386ba3b.png)

Addresses:
 - https://issues.redhat.com/browse/ACM-1947