### PR TITLE
Fixed typo in upgrade hcp modal

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1373,7 +1373,7 @@
     "Hosted cluster requires a manual import.": "Hosted cluster requires a manual import.",
     "Hosted control plane": "Hosted control plane",
     "Hosted control plane command": "Hosted control plane command",
-    "Hosted control plane is already upgrade to the latest version available. Cluster node pools can be upgraded to match the control plane.": "Hosted control plane is already upgrade to the latest version available. Cluster node pools can be upgraded to match the control plane.",
+    "Hosted control plane is already upgraded to the latest version available. Cluster node pools can be upgraded to match the control plane.": "Hosted control plane is already upgraded to the latest version available. Cluster node pools can be upgraded to match the control plane.",
     "Hosted control plane operator must be enabled in order to continue": "Hosted control plane operator must be enabled in order to continue",
     "hosts": "hosts",
     "Hosts": "Hosts",

--- a/frontend/public/locales/ja/translation.json
+++ b/frontend/public/locales/ja/translation.json
@@ -1374,7 +1374,7 @@
     "Hosted cluster requires a manual import.": "ホスト型クラスターには、手動インポートが必要です。",
     "Hosted control plane": "ホスト型コントロールプレーン",
     "Hosted control plane command": "ホスト型コントロールプレーンコマンド",
-    "Hosted control plane is already upgrade to the latest version available. Cluster node pools can be upgraded to match the control plane.": "ホスト型コントロールプレーンは、利用可能な最新バージョンにすでにアップグレードされています。クラスターノードプールは、コントロールプレーンに合わせてアップグレードできます。",
+    "Hosted control plane is already upgraded to the latest version available. Cluster node pools can be upgraded to match the control plane.": "ホスト型コントロールプレーンは、利用可能な最新バージョンにすでにアップグレードされています。クラスターノードプールは、コントロールプレーンに合わせてアップグレードできます。",
     "Hosted control plane operator must be enabled in order to continue": "続行するには、ホストされたコントロールプレーン Operator を有効にする必要があります",
     "Hosting service cluster": "ホスティングサービスクラスター",
     "hosts": "ホスト",

--- a/frontend/public/locales/ko/translation.json
+++ b/frontend/public/locales/ko/translation.json
@@ -1374,7 +1374,7 @@
     "Hosted cluster requires a manual import.": "호스트된 클러스터에는 수동 가져오기가 필요합니다.",
     "Hosted control plane": "호스팅 컨트롤 플레인",
     "Hosted control plane command": "호스팅 컨트롤 플레인 명령",
-    "Hosted control plane is already upgrade to the latest version available. Cluster node pools can be upgraded to match the control plane.": "호스트 컨트롤 플레인은 이미 사용 가능한 최신 버전으로 업그레이드되었습니다. 컨트롤 플레인과 일치하도록 클러스터 노드 풀을 업그레이드할 수 있습니다.",
+    "Hosted control plane is already upgraded to the latest version available. Cluster node pools can be upgraded to match the control plane.": "호스트 컨트롤 플레인은 이미 사용 가능한 최신 버전으로 업그레이드되었습니다. 컨트롤 플레인과 일치하도록 클러스터 노드 풀을 업그레이드할 수 있습니다.",
     "Hosted control plane operator must be enabled in order to continue": "계속하려면 호스팅된 컨트롤 플레인 Operator를 활성화해야 합니다.",
     "Hosting service cluster": "서비스 클러스터 호스팅",
     "hosts": "호스트",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1374,7 +1374,7 @@
     "Hosted cluster requires a manual import.": "托管集群需要手动导入。",
     "Hosted control plane": "托管的控制平面",
     "Hosted control plane command": "托管的控制平面命令",
-    "Hosted control plane is already upgrade to the latest version available. Cluster node pools can be upgraded to match the control plane.": "托管的控制平面可以被升级到最新可用的版本。集群节点池可以升级以匹配控制平面。",
+    "Hosted control plane is already upgraded to the latest version available. Cluster node pools can be upgraded to match the control plane.": "托管的控制平面可以被升级到最新可用的版本。集群节点池可以升级以匹配控制平面。",
     "Hosted control plane operator must be enabled in order to continue": "必须启用托管的控制平面 Operator 才能继续",
     "Hosting service cluster": "托管服务集群",
     "hosts": "主机",

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftUpgradeModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftUpgradeModal.tsx
@@ -506,7 +506,7 @@ export function HypershiftUpgradeModal(props: {
                                                 variant="info"
                                                 title={t('Version availability')}
                                                 message={t(
-                                                    'Hosted control plane is already upgrade to the latest version available. Cluster node pools can be upgraded to match the control plane.'
+                                                    'Hosted control plane is already upgraded to the latest version available. Cluster node pools can be upgraded to match the control plane.'
                                                 )}
                                             />
                                         </Td>


### PR DESCRIPTION
Signed-off-by: Omar Farag <ofarag@redhat.com>

Changed `is already upgrade` -> `is already upgraded`

Before:
![image](https://user-images.githubusercontent.com/15898988/206798509-28d0baf4-a123-4a34-9a35-691a5b3edec8.png)

After:
![image](https://user-images.githubusercontent.com/15898988/206798380-656d91f4-044c-4c91-b9da-ad17eed731aa.png)
