### PR TITLE
Capture cluster control data baseline snapshots

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAI.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAI.test.js
@@ -1,0 +1,18 @@
+// Copyright (c) 2022 Red Hat, Inc.
+// Copyright Contributors to the Open Cluster Management project
+'use strict'
+
+import { getControlDataAI } from './ControlDataAI'
+import i18next from 'i18next'
+
+const t = i18next.t.bind(i18next)
+const handleModalToggle = jest.fn()
+
+describe('Cluster creation control data for AI', () => {
+    it('generates correctly', () => {
+        expect(getControlDataAI(t, handleModalToggle, true)).toMatchSnapshot()
+    })
+    it('generates correctly for MCE', () => {
+        expect(getControlDataAI(t, handleModalToggle, false)).toMatchSnapshot()
+    })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAWS.test.js
@@ -2,28 +2,33 @@
 // Copyright Contributors to the Open Cluster Management project
 'use strict'
 import { getControlDataAWS } from './ControlDataAWS'
+import { getControlDataAWS as getControlDataAWSClusterPool } from '../../../ClusterPools/CreateClusterPool/controlData/ControlDataAWS'
+import { fixupControlsForClusterPool } from '../../../ClusterPools/CreateClusterPool/controlData/ControlDataHelper'
 import i18next from 'i18next'
 
 const t = i18next.t.bind(i18next)
+const handleModalToggle = jest.fn()
 
-describe('getControlDataAWS', () => {
-    it('get control data for AWS - default', () => {
-        getControlDataAWS(t, undefined, false, false, false, true)
+describe('Cluster creation control data for AWS', () => {
+    it('generates correctly', () => {
+        expect(getControlDataAWS(t, handleModalToggle, true, false, false, true)).toMatchSnapshot()
     })
 
-    it('get control data for AWS - no automation', () => {
-        getControlDataAWS(t, undefined, false, true, true, true)
+    it('generates correctly with SNO enabled', () => {
+        expect(getControlDataAWS(t, handleModalToggle, true, false, true, true)).toMatchSnapshot()
     })
 
-    it('get control data for AWS - include sno cluster', () => {
-        getControlDataAWS(t, undefined, true, true, true, true)
+    it('generates correctly for MCE', () => {
+        expect(getControlDataAWS(t, handleModalToggle, true, false, false, false)).toMatchSnapshot()
     })
 
-    it('get control data for AWS - no klusterletaddon', () => {
-        getControlDataAWS(t, undefined, true, true, true, false)
+    it('generates correctly for cluster pools', () => {
+        expect(
+            fixupControlsForClusterPool(getControlDataAWSClusterPool(t, handleModalToggle, false, false), t)
+        ).toMatchSnapshot()
     })
 
-    it('get control data for AWS - no awsprivate', () => {
-        getControlDataAWS(t, undefined, true, false, true, true)
+    it('generates correctly with AWS private', () => {
+        expect(getControlDataAWS(t, handleModalToggle, true, true, false, true)).toMatchSnapshot()
     })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataAZR.test.js
@@ -1,26 +1,30 @@
 // Copyright (c) 2022 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 'use strict'
-
 import { getControlDataAZR } from './ControlDataAZR'
+import { getControlDataAZR as getControlDataAZRClusterPool } from '../../../ClusterPools/CreateClusterPool/controlData/ControlDataAZR'
+import { fixupControlsForClusterPool } from '../../../ClusterPools/CreateClusterPool/controlData/ControlDataHelper'
 import i18next from 'i18next'
 
 const t = i18next.t.bind(i18next)
+const handleModalToggle = jest.fn()
 
-describe('getControlDataAZR', () => {
-    it('get control data for Azure - default', () => {
-        getControlDataAZR(t, undefined, true, true, false)
+describe('Cluster creation control data for AZR', () => {
+    it('generates correctly', () => {
+        expect(getControlDataAZR(t, handleModalToggle, true, true, false)).toMatchSnapshot()
     })
 
-    it('get control data for Azure - no automation', () => {
-        getControlDataAZR(t, undefined, false, true, false)
+    it('generates correctly with SNO enabled', () => {
+        expect(getControlDataAZR(t, handleModalToggle, true, true, true)).toMatchSnapshot()
     })
 
-    it('get control data for Azure - include sno cluster', () => {
-        getControlDataAZR(t, undefined, true, true, true)
+    it('generates correctly for MCE', () => {
+        expect(getControlDataAZR(t, handleModalToggle, true, false, false)).toMatchSnapshot()
     })
 
-    it('get control data for Azure - no klusterletaddon', () => {
-        getControlDataAZR(t, undefined, true, false, true)
+    it('generates correctly for cluster pools', () => {
+        expect(
+            fixupControlsForClusterPool(getControlDataAZRClusterPool(t, handleModalToggle, false, false), t)
+        ).toMatchSnapshot()
     })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataCIM.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataCIM.test.js
@@ -3,17 +3,17 @@
 'use strict'
 
 import { Warning } from '../Warning'
-import { getControlDataHypershift } from './ControlDataHypershift'
+import { getControlDataCIM } from './ControlDataCIM'
 import i18next from 'i18next'
 
 const t = i18next.t.bind(i18next)
 const handleModalToggle = jest.fn()
 
-describe('Cluster creation control data for Hypershift', () => {
+describe('Cluster creation control data for CIM', () => {
     it('generates correctly', () => {
-        expect(getControlDataHypershift(t, handleModalToggle, <Warning />, true, true)).toMatchSnapshot()
+        expect(getControlDataCIM(t, handleModalToggle, <Warning />, true)).toMatchSnapshot()
     })
     it('generates correctly for MCE', () => {
-        expect(getControlDataHypershift(t, handleModalToggle, <Warning />, true, false)).toMatchSnapshot()
+        expect(getControlDataCIM(t, handleModalToggle, <Warning />, false)).toMatchSnapshot()
     })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataGCP.test.js
@@ -1,26 +1,30 @@
 // Copyright (c) 2022 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 'use strict'
-
 import { getControlDataGCP } from './ControlDataGCP'
+import { getControlDataGCP as getControlDataGCPClusterPool } from '../../../ClusterPools/CreateClusterPool/controlData/ControlDataGCP'
+import { fixupControlsForClusterPool } from '../../../ClusterPools/CreateClusterPool/controlData/ControlDataHelper'
 import i18next from 'i18next'
 
 const t = i18next.t.bind(i18next)
+const handleModalToggle = jest.fn()
 
-describe('getControlDataGCP', () => {
-    it('get control data for GCP - default', () => {
-        getControlDataGCP(t, undefined, true, true, false)
+describe('Cluster creation control data for GCP', () => {
+    it('generates correctly', () => {
+        expect(getControlDataGCP(t, handleModalToggle, true, true, false)).toMatchSnapshot()
     })
 
-    it('get control data for GCP - no automation', () => {
-        getControlDataGCP(t, undefined, false, true, false)
+    it('generates correctly with SNO enabled', () => {
+        expect(getControlDataGCP(t, handleModalToggle, true, true, true)).toMatchSnapshot()
     })
 
-    it('get control data for GCP - include sno cluster', () => {
-        getControlDataGCP(t, undefined, true, true, true)
+    it('generates correctly for MCE', () => {
+        expect(getControlDataGCP(t, handleModalToggle, true, false, false)).toMatchSnapshot()
     })
 
-    it('get control data for GCP - no klusterletaddon', () => {
-        getControlDataGCP(t, undefined, true, false, true)
+    it('generates correctly for cluster pools', () => {
+        expect(
+            fixupControlsForClusterPool(getControlDataGCPClusterPool(t, handleModalToggle, false, false), t)
+        ).toMatchSnapshot()
     })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataOST.test.js
@@ -1,26 +1,22 @@
 // Copyright (c) 2022 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 'use strict'
-
 import { getControlDataOST } from './ControlDataOST'
 import i18next from 'i18next'
 
 const t = i18next.t.bind(i18next)
+const handleModalToggle = jest.fn()
 
-describe('getControlDataOST', () => {
-    it('get control data for openstack - default', () => {
-        getControlDataOST(t, undefined, true, true, false)
+describe('Cluster creation control data for OST', () => {
+    it('generates correctly', () => {
+        expect(getControlDataOST(t, handleModalToggle, true, true, false)).toMatchSnapshot()
     })
 
-    it('get control data for openstack - no automation', () => {
-        getControlDataOST(t, undefined, false, true, false)
+    it('generates correctly with SNO enabled', () => {
+        expect(getControlDataOST(t, handleModalToggle, true, true, true)).toMatchSnapshot()
     })
 
-    it('get control data for openstack - include sno cluster', () => {
-        getControlDataOST(t, undefined, true, true, true)
-    })
-
-    it('get control data for openstack - no klusterletaddon', () => {
-        getControlDataOST(t, undefined, true, false, true)
+    it('generates correctly for MCE', () => {
+        expect(getControlDataOST(t, handleModalToggle, true, false, false)).toMatchSnapshot()
     })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataRHV.test.js
@@ -1,22 +1,22 @@
 // Copyright (c) 2022 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 'use strict'
-
 import { getControlDataRHV } from './ControlDataRHV'
 import i18next from 'i18next'
 
 const t = i18next.t.bind(i18next)
+const handleModalToggle = jest.fn()
 
-describe('getControlDataRHV', () => {
-    it('get control data for RHV - default', () => {
-        getControlDataRHV(t, undefined, true, true)
+describe('Cluster creation control data for RHV', () => {
+    it('generates correctly', () => {
+        expect(getControlDataRHV(t, handleModalToggle, true, true, false)).toMatchSnapshot()
     })
 
-    it('get control data for RHV - no automation', () => {
-        getControlDataRHV(t, undefined, false, true)
+    it('generates correctly with SNO enabled', () => {
+        expect(getControlDataRHV(t, handleModalToggle, true, true, true)).toMatchSnapshot()
     })
 
-    it('get control data for RHV - no klusterletaddon', () => {
-        getControlDataRHV(t, undefined, true, false)
+    it('generates correctly for MCE', () => {
+        expect(getControlDataRHV(t, handleModalToggle, true, false, false)).toMatchSnapshot()
     })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataVMW.test.js
@@ -1,26 +1,22 @@
 // Copyright (c) 2022 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 'use strict'
-
 import { getControlDataVMW } from './ControlDataVMW'
 import i18next from 'i18next'
 
 const t = i18next.t.bind(i18next)
+const handleModalToggle = jest.fn()
 
-describe('getControlDataVMW', () => {
-    it('get control data for vsphere - default', () => {
-        getControlDataVMW(t, undefined, true, true, false)
+describe('Cluster creation control data for VMW', () => {
+    it('generates correctly', () => {
+        expect(getControlDataVMW(t, handleModalToggle, true, true, false)).toMatchSnapshot()
     })
 
-    it('get control data for vsphere - no automation', () => {
-        getControlDataVMW(t, undefined, false, true, false)
+    it('generates correctly with SNO enabled', () => {
+        expect(getControlDataVMW(t, handleModalToggle, true, true, true)).toMatchSnapshot()
     })
 
-    it('get control data for vsphere - include sno cluster', () => {
-        getControlDataVMW(t, undefined, true, true, true)
-    })
-
-    it('get control data for vsphere - no klusterletaddon', () => {
-        getControlDataVMW(t, undefined, true, false, true)
+    it('generates correctly for MCE', () => {
+        expect(getControlDataVMW(t, handleModalToggle, true, false, false)).toMatchSnapshot()
     })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAI.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAI.test.js.snap
@@ -1,0 +1,327 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cluster creation control data for AI generates correctly 1`] = `
+Array [
+  Object {
+    "id": "aiDetailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "Host inventory",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "active": "Standalone",
+    "id": "controlplane",
+    "name": "Control plane type",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "placeholder": "Select a credential",
+    "providerId": Array [
+      "hybrid",
+      "hostinventory",
+    ],
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": false,
+    },
+  },
+  Object {
+    "additionalProps": Object {
+      "promptSshPublicKey": true,
+    },
+    "component": <DetailsForm />,
+    "encodeValues": Array [
+      "pullSecret",
+    ],
+    "id": "ai",
+    "mustValidate": true,
+    "providerId": "ai",
+    "type": "custom",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "comment": "Ensure these settings are correct. The saved cluster draft will be used to determine the available network resources. Therefore after you press Save you will not be able to change these cluster settings.",
+    "disableEditorOnSuccess": true,
+    "disablePreviousControlsOnSuccess": true,
+    "id": "reviewSave",
+    "nextButtonLabel": "Save",
+    "title": "Review and save",
+    "type": "review",
+  },
+  Object {
+    "disabled": true,
+    "id": "aiHostsStep",
+    "title": "Hosts",
+    "type": "step",
+  },
+  Object {
+    "disabled": true,
+    "id": "aiNetworkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for AI generates correctly for MCE 1`] = `
+Array [
+  Object {
+    "id": "aiDetailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "Host inventory",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "active": "Standalone",
+    "id": "controlplane",
+    "name": "Control plane type",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "placeholder": "Select a credential",
+    "providerId": Array [
+      "hybrid",
+      "hostinventory",
+    ],
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": false,
+    },
+  },
+  Object {
+    "additionalProps": Object {
+      "promptSshPublicKey": true,
+    },
+    "component": <DetailsForm />,
+    "encodeValues": Array [
+      "pullSecret",
+    ],
+    "id": "ai",
+    "mustValidate": true,
+    "providerId": "ai",
+    "type": "custom",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "comment": "Ensure these settings are correct. The saved cluster draft will be used to determine the available network resources. Therefore after you press Save you will not be able to change these cluster settings.",
+    "disableEditorOnSuccess": true,
+    "disablePreviousControlsOnSuccess": true,
+    "id": "reviewSave",
+    "nextButtonLabel": "Save",
+    "title": "Review and save",
+    "type": "review",
+  },
+  Object {
+    "disabled": true,
+    "id": "aiHostsStep",
+    "title": "Hosts",
+    "type": "step",
+  },
+  Object {
+    "disabled": true,
+    "id": "aiNetworkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": false,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+]
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAWS.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAWS.test.js.snap
@@ -1668,7 +1668,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -3493,7 +3493,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -5338,7 +5338,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -7098,7 +7098,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -9045,7 +9045,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAWS.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAWS.test.js.snap
@@ -1,0 +1,9203 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cluster creation control data for AWS generates correctly 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "AWS",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "aws",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "AWS",
+    ],
+    "availableMap": Object {
+      "AWS": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "us-east-1",
+    "available": Array [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "af-south-1",
+      "ap-east-1",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-northeast-3",
+      "ap-south-1",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-north-1",
+      "eu-south-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "me-south-1",
+      "sa-east-1",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "onSelect": [Function],
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The AWS region where the installation program creates your cluster resources. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.master.zones",
+        "id": "masterZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your control plane nodes are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "description": "2 vCPU, 8 GiB RAM - General Purpose",
+            "value": "m5.large",
+          },
+          Object {
+            "description": "4 vCPU, 16 GiB RAM - General Purpose",
+            "value": "m5.xlarge",
+          },
+          Object {
+            "description": "8 vCPU, 32 GiB RAM - General Purpose",
+            "value": "m5.2xlarge",
+          },
+          Object {
+            "description": "16 vCPU, 64 GiB RAM - General Purpose",
+            "value": "m5.4xlarge",
+          },
+          Object {
+            "description": "40 vCPU, 160 GiB RAM - General Purpose",
+            "value": "m5.10xlarge",
+          },
+          Object {
+            "description": "64 vCPU, 256 GiB RAM - General Purpose",
+            "value": "m5.16xlarge",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.master.type",
+        "id": "masterType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.master.root.storage",
+        "id": "masterRootStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.worker.zones",
+        "id": "workerZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your worker pools are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m4.4xlarge",
+                      },
+                      Object {
+                        "description": "40 vCPU, 160 GiB RAM - General Purpose",
+                        "value": "m4.10xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m4.16xlarge",
+                      },
+                    ],
+                    "label": "M4 - 2.3 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5.24xlarge",
+                      },
+                    ],
+                    "label": "M5 - 3.1 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5a.24xlarge",
+                      },
+                    ],
+                    "label": "M5a - AMD processors, up to 10% cost savings over M5",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5n.24xlarge",
+                      },
+                    ],
+                    "label": "M5n - Network optimized",
+                  },
+                ],
+                "label": "Balanced",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 2 GiB RAM - Network Optimized",
+                    "value": "a1.medium",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Network Optimized",
+                    "value": "a1.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Network Optimized",
+                    "value": "a1.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Network Optimized",
+                    "value": "a1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.4xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.metal",
+                  },
+                ],
+                "label": "Network Optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "1 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t2.nano",
+                      },
+                      Object {
+                        "description": "1 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t2.micro",
+                      },
+                      Object {
+                        "description": "1 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t2.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t2.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t2.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t2.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t2.2xlarge",
+                      },
+                    ],
+                    "label": "T2 - Lowest-cost",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - Burstable CPU",
+                        "value": "t3.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - Burstable CPU",
+                        "value": "t3.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - Burstable CPU",
+                        "value": "t3.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - Burstable CPU",
+                        "value": "t3.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - Burstable CPU",
+                        "value": "t3.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - Burstable CPU",
+                        "value": "t3.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - Burstable CPU",
+                        "value": "t3.2xlarge",
+                      },
+                    ],
+                    "label": "T3 - General purpose",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t3a.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t3a.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t3a.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t3a.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t3a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t3a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t3a.2xlarge",
+                      },
+                    ],
+                    "label": "T3a - Up to 10% cost savings over T3",
+                  },
+                ],
+                "label": "Burstable CPU",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.metal",
+                      },
+                    ],
+                    "label": "M5d - Intel processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5ad.24xlarge",
+                      },
+                    ],
+                    "label": "M5ad - AMD processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5dn.24xlarge",
+                      },
+                    ],
+                    "label": "M5dn - Network optimized with SSDs physically connected to the host server",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.metal",
+                  },
+                ],
+                "label": "C5 - Intel processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5a.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5a.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5a.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5a.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 64 GiB RAM - Compute Optimized",
+                    "value": "c5a.8xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5a.12xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 128 GiB RAM - Compute Optimized",
+                    "value": "c5a.16xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5a.24xlarge",
+                  },
+                ],
+                "label": "C5a - AMD processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5d.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5d.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5d.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5d.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5d.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5d.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5d.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.metal",
+                  },
+                ],
+                "label": "C5d - Intel processors with SSD",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 5.25 GiB RAM - Compute Optimized",
+                    "value": "c5n.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 10.5 GiB RAM - Compute Optimized",
+                    "value": "c5n.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 21 GiB RAM - Compute Optimized",
+                    "value": "c5n.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 42 GiB RAM - Compute Optimized",
+                    "value": "c5n.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5n.9xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.18xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.metal",
+                  },
+                ],
+                "label": "C5n - Intel processors, optimized network",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 3.75GiB RAM - Compute Optimized",
+                    "value": "c4.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 7.5 GiB RAM - Compute Optimized",
+                    "value": "c4.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 15 GiB RAM - Compute Optimized",
+                    "value": "c4.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 30 GiB RAM - Compute Optimized",
+                    "value": "c4.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 60GiB RAM - Compute Optimized",
+                    "value": "c4.8xlarge",
+                  },
+                ],
+                "label": "C4  - Intel processors, cost-effective",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 15.25 GiB RAM - Memory Optimized",
+                        "value": "r4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 30.5 GiB RAM - Memory Optimized",
+                        "value": "r4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 61 GiB RAM - Memory Optimized",
+                        "value": "r4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "r4.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "r4.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "r4.16xlarge",
+                      },
+                    ],
+                    "label": "R4 - Optimized for memory-intensive applications",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128GiB RAM - Memory Optimized",
+                        "value": "r5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256GiB RAM - Memory Optimized",
+                        "value": "r5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384GiB RAM - Memory Optimized",
+                        "value": "r5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512GiB RAM - Memory Optimized",
+                        "value": "r5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.metal",
+                      },
+                    ],
+                    "label": "R5 - 5% additional memory per vCPU over R4",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5a.24xlarge",
+                      },
+                    ],
+                    "label": "R5a - AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5n.24xlarge",
+                      },
+                    ],
+                    "label": "R5n - Network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "448 vCPU, 6144 GiB RAM - Memory Optimized",
+                        "value": "u-6tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 9216 GiB RAM - Memory Optimized",
+                        "value": "u-9tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 12288 GiB RAM - Memory Optimized",
+                        "value": "u-12tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 18432 GiB RAM - Memory Optimized",
+                        "value": "u-18tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 24576 GiB RAM - Memory Optimized",
+                        "value": "u-24tb1.metal",
+                      },
+                    ],
+                    "label": "High Memory - Metal",
+                  },
+                ],
+                "label": "General Purpose",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "64 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1.32xlarge",
+                      },
+                    ],
+                    "label": "X1 - Xeon processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "x1e.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "x1e.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "x1e.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1e.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1e.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 3,904 GiB RAM - Memory Optimized",
+                        "value": "x1e.32xlarge",
+                      },
+                    ],
+                    "label": "X1e - Xeon processors, in-memory database optimized",
+                  },
+                ],
+                "label": "With Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.metal",
+                      },
+                    ],
+                    "label": "R5d - With SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5dn.24xlarge",
+                      },
+                    ],
+                    "label": "R5dn - With SSD, network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5ad.24xlarge",
+                      },
+                    ],
+                    "label": "R5ad - With SSD, AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "z1d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "z1d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "z1d.2xlarge",
+                      },
+                      Object {
+                        "description": "12 vCPU, 96 GiB RAM - Memory Optimized",
+                        "value": "z1d.3xlarge",
+                      },
+                      Object {
+                        "description": "24 vCPU, 192 GiB RAM - Memory Optimized",
+                        "value": "z1d.6xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.12xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.metal",
+                      },
+                    ],
+                    "label": "Z1d - With SSD, fastest processor",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 61 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "p3.2xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 32 vCPU, 244 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "p3.8xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 64 vCPU, 488 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "p3.16xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 768 GiB, 256 GPU GiB - Accelerated Computing",
+                    "value": "p3dn.24xlarge",
+                  },
+                ],
+                "label": "P3 - NVIDIA Tesla V100 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 61 GiB, 12 GPU GiB - Accelerated Computing",
+                    "value": "p2.xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 32 vCPU, 488 GiB, 96 GPU GiB - Accelerated Computing",
+                    "value": "p2.8xlarge",
+                  },
+                  Object {
+                    "description": "16 GPUs, 64 vCPU, 732 GiB, 192 GPU GiB - Accelerated Computing",
+                    "value": "p2.16xlarge",
+                  },
+                ],
+                "label": "P2 - NVIDIA K80 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 16 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 32 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.2xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 64 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.4xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 32 vCPU, 128 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.8xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 64 vCPU, 256 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.16xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 48 vCPU, 192 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.12xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 384 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.metal",
+                  },
+                ],
+                "label": "G4 - NVIDIA T4 Tensor Core GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 30.5 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3s.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 122 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3.4xlarge",
+                  },
+                  Object {
+                    "description": "2 GPUs, 32 vCPU, 244 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g3.8xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 64 vCPU, 488 GiB, 32 GPU GiB - Accelerated Computing",
+                    "value": "g3.16xlarge",
+                  },
+                ],
+                "label": "G3 - NVIDIA Tesla M60 GPUs",
+              },
+            ],
+            "label": "Accelerated Computing",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 15.25 GiB RAM - Storage Optimized",
+                    "value": "i3.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "i3.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "i3.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "i3.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "i3.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 488 GiB RAM - Storage Optimized",
+                    "value": "i3.16xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 512GiB RAM - Storage Optimized",
+                    "value": "i3.metal",
+                  },
+                ],
+                "label": "I3 - High Frequency Intel Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 16 GiB RAM - Storage Optimized",
+                    "value": "i3en.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "i3en.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "i3en.2xlarge",
+                  },
+                  Object {
+                    "description": "12 vCPU, 96 GiB RAM - Storage Optimized",
+                    "value": "i3en.3xlarge",
+                  },
+                  Object {
+                    "description": "24 vCPU, 192 GiB RAM - Storage Optimized",
+                    "value": "i3en.6xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB RAM - Storage Optimized",
+                    "value": "i3en.12xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.metal",
+                  },
+                ],
+                "label": "I3en - Non-Volatile Memory Express SSD instance storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "d2.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "d2.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "d2.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "d2.8xlarge",
+                  },
+                ],
+                "label": "D2 - Up to 48 TB of HDD-based local storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "h1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "h1.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB RAM - Storage Optimized",
+                    "value": "h1.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB RAM - Storage Optimized",
+                    "value": "h1.16xlarge",
+                  },
+                ],
+                "label": "H1 - 16 TB of HDD-based local storage",
+              },
+            ],
+            "label": "Storage Optimized",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.persistent.storage",
+        "id": "workerStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "onChange": [Function],
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for AWS generates correctly for MCE 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "AWS",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "aws",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "AWS",
+    ],
+    "availableMap": Object {
+      "AWS": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "us-east-1",
+    "available": Array [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "af-south-1",
+      "ap-east-1",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-northeast-3",
+      "ap-south-1",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-north-1",
+      "eu-south-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "me-south-1",
+      "sa-east-1",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "onSelect": [Function],
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The AWS region where the installation program creates your cluster resources. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.master.zones",
+        "id": "masterZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your control plane nodes are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "description": "2 vCPU, 8 GiB RAM - General Purpose",
+            "value": "m5.large",
+          },
+          Object {
+            "description": "4 vCPU, 16 GiB RAM - General Purpose",
+            "value": "m5.xlarge",
+          },
+          Object {
+            "description": "8 vCPU, 32 GiB RAM - General Purpose",
+            "value": "m5.2xlarge",
+          },
+          Object {
+            "description": "16 vCPU, 64 GiB RAM - General Purpose",
+            "value": "m5.4xlarge",
+          },
+          Object {
+            "description": "40 vCPU, 160 GiB RAM - General Purpose",
+            "value": "m5.10xlarge",
+          },
+          Object {
+            "description": "64 vCPU, 256 GiB RAM - General Purpose",
+            "value": "m5.16xlarge",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.master.type",
+        "id": "masterType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.master.root.storage",
+        "id": "masterRootStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.worker.zones",
+        "id": "workerZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your worker pools are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m4.4xlarge",
+                      },
+                      Object {
+                        "description": "40 vCPU, 160 GiB RAM - General Purpose",
+                        "value": "m4.10xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m4.16xlarge",
+                      },
+                    ],
+                    "label": "M4 - 2.3 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5.24xlarge",
+                      },
+                    ],
+                    "label": "M5 - 3.1 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5a.24xlarge",
+                      },
+                    ],
+                    "label": "M5a - AMD processors, up to 10% cost savings over M5",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5n.24xlarge",
+                      },
+                    ],
+                    "label": "M5n - Network optimized",
+                  },
+                ],
+                "label": "Balanced",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 2 GiB RAM - Network Optimized",
+                    "value": "a1.medium",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Network Optimized",
+                    "value": "a1.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Network Optimized",
+                    "value": "a1.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Network Optimized",
+                    "value": "a1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.4xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.metal",
+                  },
+                ],
+                "label": "Network Optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "1 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t2.nano",
+                      },
+                      Object {
+                        "description": "1 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t2.micro",
+                      },
+                      Object {
+                        "description": "1 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t2.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t2.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t2.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t2.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t2.2xlarge",
+                      },
+                    ],
+                    "label": "T2 - Lowest-cost",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - Burstable CPU",
+                        "value": "t3.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - Burstable CPU",
+                        "value": "t3.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - Burstable CPU",
+                        "value": "t3.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - Burstable CPU",
+                        "value": "t3.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - Burstable CPU",
+                        "value": "t3.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - Burstable CPU",
+                        "value": "t3.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - Burstable CPU",
+                        "value": "t3.2xlarge",
+                      },
+                    ],
+                    "label": "T3 - General purpose",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t3a.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t3a.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t3a.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t3a.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t3a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t3a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t3a.2xlarge",
+                      },
+                    ],
+                    "label": "T3a - Up to 10% cost savings over T3",
+                  },
+                ],
+                "label": "Burstable CPU",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.metal",
+                      },
+                    ],
+                    "label": "M5d - Intel processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5ad.24xlarge",
+                      },
+                    ],
+                    "label": "M5ad - AMD processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5dn.24xlarge",
+                      },
+                    ],
+                    "label": "M5dn - Network optimized with SSDs physically connected to the host server",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.metal",
+                  },
+                ],
+                "label": "C5 - Intel processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5a.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5a.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5a.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5a.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 64 GiB RAM - Compute Optimized",
+                    "value": "c5a.8xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5a.12xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 128 GiB RAM - Compute Optimized",
+                    "value": "c5a.16xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5a.24xlarge",
+                  },
+                ],
+                "label": "C5a - AMD processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5d.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5d.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5d.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5d.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5d.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5d.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5d.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.metal",
+                  },
+                ],
+                "label": "C5d - Intel processors with SSD",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 5.25 GiB RAM - Compute Optimized",
+                    "value": "c5n.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 10.5 GiB RAM - Compute Optimized",
+                    "value": "c5n.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 21 GiB RAM - Compute Optimized",
+                    "value": "c5n.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 42 GiB RAM - Compute Optimized",
+                    "value": "c5n.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5n.9xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.18xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.metal",
+                  },
+                ],
+                "label": "C5n - Intel processors, optimized network",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 3.75GiB RAM - Compute Optimized",
+                    "value": "c4.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 7.5 GiB RAM - Compute Optimized",
+                    "value": "c4.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 15 GiB RAM - Compute Optimized",
+                    "value": "c4.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 30 GiB RAM - Compute Optimized",
+                    "value": "c4.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 60GiB RAM - Compute Optimized",
+                    "value": "c4.8xlarge",
+                  },
+                ],
+                "label": "C4  - Intel processors, cost-effective",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 15.25 GiB RAM - Memory Optimized",
+                        "value": "r4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 30.5 GiB RAM - Memory Optimized",
+                        "value": "r4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 61 GiB RAM - Memory Optimized",
+                        "value": "r4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "r4.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "r4.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "r4.16xlarge",
+                      },
+                    ],
+                    "label": "R4 - Optimized for memory-intensive applications",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128GiB RAM - Memory Optimized",
+                        "value": "r5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256GiB RAM - Memory Optimized",
+                        "value": "r5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384GiB RAM - Memory Optimized",
+                        "value": "r5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512GiB RAM - Memory Optimized",
+                        "value": "r5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.metal",
+                      },
+                    ],
+                    "label": "R5 - 5% additional memory per vCPU over R4",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5a.24xlarge",
+                      },
+                    ],
+                    "label": "R5a - AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5n.24xlarge",
+                      },
+                    ],
+                    "label": "R5n - Network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "448 vCPU, 6144 GiB RAM - Memory Optimized",
+                        "value": "u-6tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 9216 GiB RAM - Memory Optimized",
+                        "value": "u-9tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 12288 GiB RAM - Memory Optimized",
+                        "value": "u-12tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 18432 GiB RAM - Memory Optimized",
+                        "value": "u-18tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 24576 GiB RAM - Memory Optimized",
+                        "value": "u-24tb1.metal",
+                      },
+                    ],
+                    "label": "High Memory - Metal",
+                  },
+                ],
+                "label": "General Purpose",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "64 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1.32xlarge",
+                      },
+                    ],
+                    "label": "X1 - Xeon processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "x1e.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "x1e.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "x1e.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1e.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1e.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 3,904 GiB RAM - Memory Optimized",
+                        "value": "x1e.32xlarge",
+                      },
+                    ],
+                    "label": "X1e - Xeon processors, in-memory database optimized",
+                  },
+                ],
+                "label": "With Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.metal",
+                      },
+                    ],
+                    "label": "R5d - With SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5dn.24xlarge",
+                      },
+                    ],
+                    "label": "R5dn - With SSD, network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5ad.24xlarge",
+                      },
+                    ],
+                    "label": "R5ad - With SSD, AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "z1d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "z1d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "z1d.2xlarge",
+                      },
+                      Object {
+                        "description": "12 vCPU, 96 GiB RAM - Memory Optimized",
+                        "value": "z1d.3xlarge",
+                      },
+                      Object {
+                        "description": "24 vCPU, 192 GiB RAM - Memory Optimized",
+                        "value": "z1d.6xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.12xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.metal",
+                      },
+                    ],
+                    "label": "Z1d - With SSD, fastest processor",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 61 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "p3.2xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 32 vCPU, 244 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "p3.8xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 64 vCPU, 488 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "p3.16xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 768 GiB, 256 GPU GiB - Accelerated Computing",
+                    "value": "p3dn.24xlarge",
+                  },
+                ],
+                "label": "P3 - NVIDIA Tesla V100 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 61 GiB, 12 GPU GiB - Accelerated Computing",
+                    "value": "p2.xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 32 vCPU, 488 GiB, 96 GPU GiB - Accelerated Computing",
+                    "value": "p2.8xlarge",
+                  },
+                  Object {
+                    "description": "16 GPUs, 64 vCPU, 732 GiB, 192 GPU GiB - Accelerated Computing",
+                    "value": "p2.16xlarge",
+                  },
+                ],
+                "label": "P2 - NVIDIA K80 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 16 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 32 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.2xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 64 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.4xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 32 vCPU, 128 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.8xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 64 vCPU, 256 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.16xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 48 vCPU, 192 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.12xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 384 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.metal",
+                  },
+                ],
+                "label": "G4 - NVIDIA T4 Tensor Core GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 30.5 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3s.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 122 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3.4xlarge",
+                  },
+                  Object {
+                    "description": "2 GPUs, 32 vCPU, 244 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g3.8xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 64 vCPU, 488 GiB, 32 GPU GiB - Accelerated Computing",
+                    "value": "g3.16xlarge",
+                  },
+                ],
+                "label": "G3 - NVIDIA Tesla M60 GPUs",
+              },
+            ],
+            "label": "Accelerated Computing",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 15.25 GiB RAM - Storage Optimized",
+                    "value": "i3.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "i3.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "i3.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "i3.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "i3.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 488 GiB RAM - Storage Optimized",
+                    "value": "i3.16xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 512GiB RAM - Storage Optimized",
+                    "value": "i3.metal",
+                  },
+                ],
+                "label": "I3 - High Frequency Intel Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 16 GiB RAM - Storage Optimized",
+                    "value": "i3en.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "i3en.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "i3en.2xlarge",
+                  },
+                  Object {
+                    "description": "12 vCPU, 96 GiB RAM - Storage Optimized",
+                    "value": "i3en.3xlarge",
+                  },
+                  Object {
+                    "description": "24 vCPU, 192 GiB RAM - Storage Optimized",
+                    "value": "i3en.6xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB RAM - Storage Optimized",
+                    "value": "i3en.12xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.metal",
+                  },
+                ],
+                "label": "I3en - Non-Volatile Memory Express SSD instance storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "d2.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "d2.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "d2.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "d2.8xlarge",
+                  },
+                ],
+                "label": "D2 - Up to 48 TB of HDD-based local storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "h1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "h1.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB RAM - Storage Optimized",
+                    "value": "h1.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB RAM - Storage Optimized",
+                    "value": "h1.16xlarge",
+                  },
+                ],
+                "label": "H1 - 16 TB of HDD-based local storage",
+              },
+            ],
+            "label": "Storage Optimized",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.persistent.storage",
+        "id": "workerStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "onChange": [Function],
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": false,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for AWS generates correctly for cluster pools 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster pool details",
+    "type": "step",
+  },
+  Object {
+    "active": "AWS",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "aws",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster pool name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterPool[0].metadata.name",
+    "tooltip": "The unique name of your cluster pool. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "namespace",
+    "name": "Cluster pool namespace",
+    "placeholder": "Select or create a namespace",
+    "tooltip": "The namespace to create your cluster pool. Multiple cluster pools can be created in the same namespace.",
+    "type": "combobox",
+    "validation": Object {
+      "required": true,
+    },
+  },
+  Object {
+    "id": "size",
+    "initial": "1",
+    "name": "Cluster pool size",
+    "tooltip": "The desired number of clusters for the cluster pool.",
+    "type": "number",
+    "validation": Object {
+      "required": true,
+    },
+  },
+  Object {
+    "id": "runningCount",
+    "initial": "0",
+    "name": "Cluster pool running count",
+    "tooltip": "The desired number of clusters that can be claimed immediately for the cluster pool.",
+    "type": "number",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [
+      "AWS",
+    ],
+    "availableMap": Object {
+      "AWS": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "us-east-1",
+    "available": Array [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "af-south-1",
+      "ap-east-1",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-northeast-3",
+      "ap-south-1",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-north-1",
+      "eu-south-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "me-south-1",
+      "sa-east-1",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "onSelect": [Function],
+    "reverse": "ClusterPool[0].metadata.labels.region",
+    "tooltip": "The AWS region where the installation program creates your cluster resources. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.master.zones",
+        "id": "masterZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your control plane nodes are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "description": "2 vCPU, 8 GiB RAM - General Purpose",
+            "value": "m5.large",
+          },
+          Object {
+            "description": "4 vCPU, 16 GiB RAM - General Purpose",
+            "value": "m5.xlarge",
+          },
+          Object {
+            "description": "8 vCPU, 32 GiB RAM - General Purpose",
+            "value": "m5.2xlarge",
+          },
+          Object {
+            "description": "16 vCPU, 64 GiB RAM - General Purpose",
+            "value": "m5.4xlarge",
+          },
+          Object {
+            "description": "40 vCPU, 160 GiB RAM - General Purpose",
+            "value": "m5.10xlarge",
+          },
+          Object {
+            "description": "64 vCPU, 256 GiB RAM - General Purpose",
+            "value": "m5.16xlarge",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.master.type",
+        "id": "masterType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.master.root.storage",
+        "id": "masterRootStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.worker.zones",
+        "id": "workerZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your worker pools are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m4.4xlarge",
+                      },
+                      Object {
+                        "description": "40 vCPU, 160 GiB RAM - General Purpose",
+                        "value": "m4.10xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m4.16xlarge",
+                      },
+                    ],
+                    "label": "M4 - 2.3 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5.24xlarge",
+                      },
+                    ],
+                    "label": "M5 - 3.1 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5a.24xlarge",
+                      },
+                    ],
+                    "label": "M5a - AMD processors, up to 10% cost savings over M5",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5n.24xlarge",
+                      },
+                    ],
+                    "label": "M5n - Network optimized",
+                  },
+                ],
+                "label": "Balanced",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 2 GiB RAM - Network Optimized",
+                    "value": "a1.medium",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Network Optimized",
+                    "value": "a1.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Network Optimized",
+                    "value": "a1.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Network Optimized",
+                    "value": "a1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.4xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.metal",
+                  },
+                ],
+                "label": "Network Optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "1 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t2.nano",
+                      },
+                      Object {
+                        "description": "1 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t2.micro",
+                      },
+                      Object {
+                        "description": "1 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t2.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t2.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t2.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t2.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t2.2xlarge",
+                      },
+                    ],
+                    "label": "T2 - Lowest-cost",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - Burstable CPU",
+                        "value": "t3.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - Burstable CPU",
+                        "value": "t3.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - Burstable CPU",
+                        "value": "t3.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - Burstable CPU",
+                        "value": "t3.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - Burstable CPU",
+                        "value": "t3.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - Burstable CPU",
+                        "value": "t3.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - Burstable CPU",
+                        "value": "t3.2xlarge",
+                      },
+                    ],
+                    "label": "T3 - General purpose",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t3a.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t3a.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t3a.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t3a.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t3a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t3a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t3a.2xlarge",
+                      },
+                    ],
+                    "label": "T3a - Up to 10% cost savings over T3",
+                  },
+                ],
+                "label": "Burstable CPU",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.metal",
+                      },
+                    ],
+                    "label": "M5d - Intel processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5ad.24xlarge",
+                      },
+                    ],
+                    "label": "M5ad - AMD processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5dn.24xlarge",
+                      },
+                    ],
+                    "label": "M5dn - Network optimized with SSDs physically connected to the host server",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.metal",
+                  },
+                ],
+                "label": "C5 - Intel processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5a.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5a.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5a.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5a.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 64 GiB RAM - Compute Optimized",
+                    "value": "c5a.8xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5a.12xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 128 GiB RAM - Compute Optimized",
+                    "value": "c5a.16xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5a.24xlarge",
+                  },
+                ],
+                "label": "C5a - AMD processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5d.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5d.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5d.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5d.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5d.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5d.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5d.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.metal",
+                  },
+                ],
+                "label": "C5d - Intel processors with SSD",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 5.25 GiB RAM - Compute Optimized",
+                    "value": "c5n.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 10.5 GiB RAM - Compute Optimized",
+                    "value": "c5n.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 21 GiB RAM - Compute Optimized",
+                    "value": "c5n.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 42 GiB RAM - Compute Optimized",
+                    "value": "c5n.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5n.9xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.18xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.metal",
+                  },
+                ],
+                "label": "C5n - Intel processors, optimized network",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 3.75GiB RAM - Compute Optimized",
+                    "value": "c4.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 7.5 GiB RAM - Compute Optimized",
+                    "value": "c4.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 15 GiB RAM - Compute Optimized",
+                    "value": "c4.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 30 GiB RAM - Compute Optimized",
+                    "value": "c4.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 60GiB RAM - Compute Optimized",
+                    "value": "c4.8xlarge",
+                  },
+                ],
+                "label": "C4  - Intel processors, cost-effective",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 15.25 GiB RAM - Memory Optimized",
+                        "value": "r4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 30.5 GiB RAM - Memory Optimized",
+                        "value": "r4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 61 GiB RAM - Memory Optimized",
+                        "value": "r4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "r4.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "r4.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "r4.16xlarge",
+                      },
+                    ],
+                    "label": "R4 - Optimized for memory-intensive applications",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128GiB RAM - Memory Optimized",
+                        "value": "r5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256GiB RAM - Memory Optimized",
+                        "value": "r5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384GiB RAM - Memory Optimized",
+                        "value": "r5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512GiB RAM - Memory Optimized",
+                        "value": "r5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.metal",
+                      },
+                    ],
+                    "label": "R5 - 5% additional memory per vCPU over R4",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5a.24xlarge",
+                      },
+                    ],
+                    "label": "R5a - AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5n.24xlarge",
+                      },
+                    ],
+                    "label": "R5n - Network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "448 vCPU, 6144 GiB RAM - Memory Optimized",
+                        "value": "u-6tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 9216 GiB RAM - Memory Optimized",
+                        "value": "u-9tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 12288 GiB RAM - Memory Optimized",
+                        "value": "u-12tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 18432 GiB RAM - Memory Optimized",
+                        "value": "u-18tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 24576 GiB RAM - Memory Optimized",
+                        "value": "u-24tb1.metal",
+                      },
+                    ],
+                    "label": "High Memory - Metal",
+                  },
+                ],
+                "label": "General Purpose",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "64 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1.32xlarge",
+                      },
+                    ],
+                    "label": "X1 - Xeon processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "x1e.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "x1e.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "x1e.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1e.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1e.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 3,904 GiB RAM - Memory Optimized",
+                        "value": "x1e.32xlarge",
+                      },
+                    ],
+                    "label": "X1e - Xeon processors, in-memory database optimized",
+                  },
+                ],
+                "label": "With Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.metal",
+                      },
+                    ],
+                    "label": "R5d - With SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5dn.24xlarge",
+                      },
+                    ],
+                    "label": "R5dn - With SSD, network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5ad.24xlarge",
+                      },
+                    ],
+                    "label": "R5ad - With SSD, AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "z1d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "z1d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "z1d.2xlarge",
+                      },
+                      Object {
+                        "description": "12 vCPU, 96 GiB RAM - Memory Optimized",
+                        "value": "z1d.3xlarge",
+                      },
+                      Object {
+                        "description": "24 vCPU, 192 GiB RAM - Memory Optimized",
+                        "value": "z1d.6xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.12xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.metal",
+                      },
+                    ],
+                    "label": "Z1d - With SSD, fastest processor",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 61 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "p3.2xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 32 vCPU, 244 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "p3.8xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 64 vCPU, 488 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "p3.16xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 768 GiB, 256 GPU GiB - Accelerated Computing",
+                    "value": "p3dn.24xlarge",
+                  },
+                ],
+                "label": "P3 - NVIDIA Tesla V100 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 61 GiB, 12 GPU GiB - Accelerated Computing",
+                    "value": "p2.xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 32 vCPU, 488 GiB, 96 GPU GiB - Accelerated Computing",
+                    "value": "p2.8xlarge",
+                  },
+                  Object {
+                    "description": "16 GPUs, 64 vCPU, 732 GiB, 192 GPU GiB - Accelerated Computing",
+                    "value": "p2.16xlarge",
+                  },
+                ],
+                "label": "P2 - NVIDIA K80 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 16 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 32 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.2xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 64 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.4xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 32 vCPU, 128 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.8xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 64 vCPU, 256 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.16xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 48 vCPU, 192 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.12xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 384 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.metal",
+                  },
+                ],
+                "label": "G4 - NVIDIA T4 Tensor Core GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 30.5 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3s.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 122 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3.4xlarge",
+                  },
+                  Object {
+                    "description": "2 GPUs, 32 vCPU, 244 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g3.8xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 64 vCPU, 488 GiB, 32 GPU GiB - Accelerated Computing",
+                    "value": "g3.16xlarge",
+                  },
+                ],
+                "label": "G3 - NVIDIA Tesla M60 GPUs",
+              },
+            ],
+            "label": "Accelerated Computing",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 15.25 GiB RAM - Storage Optimized",
+                    "value": "i3.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "i3.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "i3.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "i3.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "i3.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 488 GiB RAM - Storage Optimized",
+                    "value": "i3.16xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 512GiB RAM - Storage Optimized",
+                    "value": "i3.metal",
+                  },
+                ],
+                "label": "I3 - High Frequency Intel Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 16 GiB RAM - Storage Optimized",
+                    "value": "i3en.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "i3en.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "i3en.2xlarge",
+                  },
+                  Object {
+                    "description": "12 vCPU, 96 GiB RAM - Storage Optimized",
+                    "value": "i3en.3xlarge",
+                  },
+                  Object {
+                    "description": "24 vCPU, 192 GiB RAM - Storage Optimized",
+                    "value": "i3en.6xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB RAM - Storage Optimized",
+                    "value": "i3en.12xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.metal",
+                  },
+                ],
+                "label": "I3en - Non-Volatile Memory Express SSD instance storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "d2.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "d2.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "d2.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "d2.8xlarge",
+                  },
+                ],
+                "label": "D2 - Up to 48 TB of HDD-based local storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "h1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "h1.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB RAM - Storage Optimized",
+                    "value": "h1.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB RAM - Storage Optimized",
+                    "value": "h1.16xlarge",
+                  },
+                ],
+                "label": "H1 - 16 TB of HDD-based local storage",
+              },
+            ],
+            "label": "Storage Optimized",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.persistent.storage",
+        "id": "workerStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "onChange": [Function],
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+]
+`;
+
+exports[`Cluster creation control data for AWS generates correctly with AWS private 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "AWS",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "aws",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "AWS",
+    ],
+    "availableMap": Object {
+      "AWS": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "us-east-1",
+    "available": Array [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "af-south-1",
+      "ap-east-1",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-northeast-3",
+      "ap-south-1",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-north-1",
+      "eu-south-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "me-south-1",
+      "sa-east-1",
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "af-south-1",
+      "ap-east-1",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-northeast-3",
+      "ap-south-1",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-north-1",
+      "eu-south-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "me-south-1",
+      "sa-east-1",
+      "us-gov-west-1",
+      "us-gov-east-1",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "onSelect": [Function],
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The AWS region where the installation program creates your cluster resources. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.master.zones",
+        "id": "masterZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your control plane nodes are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "description": "2 vCPU, 8 GiB RAM - General Purpose",
+            "value": "m5.large",
+          },
+          Object {
+            "description": "4 vCPU, 16 GiB RAM - General Purpose",
+            "value": "m5.xlarge",
+          },
+          Object {
+            "description": "8 vCPU, 32 GiB RAM - General Purpose",
+            "value": "m5.2xlarge",
+          },
+          Object {
+            "description": "16 vCPU, 64 GiB RAM - General Purpose",
+            "value": "m5.4xlarge",
+          },
+          Object {
+            "description": "40 vCPU, 160 GiB RAM - General Purpose",
+            "value": "m5.10xlarge",
+          },
+          Object {
+            "description": "64 vCPU, 256 GiB RAM - General Purpose",
+            "value": "m5.16xlarge",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.master.type",
+        "id": "masterType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.master.root.storage",
+        "id": "masterRootStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.worker.zones",
+        "id": "workerZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your worker pools are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m4.4xlarge",
+                      },
+                      Object {
+                        "description": "40 vCPU, 160 GiB RAM - General Purpose",
+                        "value": "m4.10xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m4.16xlarge",
+                      },
+                    ],
+                    "label": "M4 - 2.3 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5.24xlarge",
+                      },
+                    ],
+                    "label": "M5 - 3.1 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5a.24xlarge",
+                      },
+                    ],
+                    "label": "M5a - AMD processors, up to 10% cost savings over M5",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5n.24xlarge",
+                      },
+                    ],
+                    "label": "M5n - Network optimized",
+                  },
+                ],
+                "label": "Balanced",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 2 GiB RAM - Network Optimized",
+                    "value": "a1.medium",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Network Optimized",
+                    "value": "a1.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Network Optimized",
+                    "value": "a1.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Network Optimized",
+                    "value": "a1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.4xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.metal",
+                  },
+                ],
+                "label": "Network Optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "1 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t2.nano",
+                      },
+                      Object {
+                        "description": "1 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t2.micro",
+                      },
+                      Object {
+                        "description": "1 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t2.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t2.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t2.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t2.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t2.2xlarge",
+                      },
+                    ],
+                    "label": "T2 - Lowest-cost",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - Burstable CPU",
+                        "value": "t3.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - Burstable CPU",
+                        "value": "t3.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - Burstable CPU",
+                        "value": "t3.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - Burstable CPU",
+                        "value": "t3.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - Burstable CPU",
+                        "value": "t3.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - Burstable CPU",
+                        "value": "t3.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - Burstable CPU",
+                        "value": "t3.2xlarge",
+                      },
+                    ],
+                    "label": "T3 - General purpose",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t3a.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t3a.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t3a.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t3a.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t3a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t3a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t3a.2xlarge",
+                      },
+                    ],
+                    "label": "T3a - Up to 10% cost savings over T3",
+                  },
+                ],
+                "label": "Burstable CPU",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.metal",
+                      },
+                    ],
+                    "label": "M5d - Intel processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5ad.24xlarge",
+                      },
+                    ],
+                    "label": "M5ad - AMD processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5dn.24xlarge",
+                      },
+                    ],
+                    "label": "M5dn - Network optimized with SSDs physically connected to the host server",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.metal",
+                  },
+                ],
+                "label": "C5 - Intel processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5a.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5a.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5a.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5a.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 64 GiB RAM - Compute Optimized",
+                    "value": "c5a.8xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5a.12xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 128 GiB RAM - Compute Optimized",
+                    "value": "c5a.16xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5a.24xlarge",
+                  },
+                ],
+                "label": "C5a - AMD processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5d.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5d.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5d.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5d.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5d.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5d.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5d.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.metal",
+                  },
+                ],
+                "label": "C5d - Intel processors with SSD",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 5.25 GiB RAM - Compute Optimized",
+                    "value": "c5n.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 10.5 GiB RAM - Compute Optimized",
+                    "value": "c5n.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 21 GiB RAM - Compute Optimized",
+                    "value": "c5n.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 42 GiB RAM - Compute Optimized",
+                    "value": "c5n.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5n.9xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.18xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.metal",
+                  },
+                ],
+                "label": "C5n - Intel processors, optimized network",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 3.75GiB RAM - Compute Optimized",
+                    "value": "c4.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 7.5 GiB RAM - Compute Optimized",
+                    "value": "c4.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 15 GiB RAM - Compute Optimized",
+                    "value": "c4.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 30 GiB RAM - Compute Optimized",
+                    "value": "c4.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 60GiB RAM - Compute Optimized",
+                    "value": "c4.8xlarge",
+                  },
+                ],
+                "label": "C4  - Intel processors, cost-effective",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 15.25 GiB RAM - Memory Optimized",
+                        "value": "r4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 30.5 GiB RAM - Memory Optimized",
+                        "value": "r4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 61 GiB RAM - Memory Optimized",
+                        "value": "r4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "r4.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "r4.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "r4.16xlarge",
+                      },
+                    ],
+                    "label": "R4 - Optimized for memory-intensive applications",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128GiB RAM - Memory Optimized",
+                        "value": "r5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256GiB RAM - Memory Optimized",
+                        "value": "r5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384GiB RAM - Memory Optimized",
+                        "value": "r5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512GiB RAM - Memory Optimized",
+                        "value": "r5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.metal",
+                      },
+                    ],
+                    "label": "R5 - 5% additional memory per vCPU over R4",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5a.24xlarge",
+                      },
+                    ],
+                    "label": "R5a - AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5n.24xlarge",
+                      },
+                    ],
+                    "label": "R5n - Network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "448 vCPU, 6144 GiB RAM - Memory Optimized",
+                        "value": "u-6tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 9216 GiB RAM - Memory Optimized",
+                        "value": "u-9tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 12288 GiB RAM - Memory Optimized",
+                        "value": "u-12tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 18432 GiB RAM - Memory Optimized",
+                        "value": "u-18tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 24576 GiB RAM - Memory Optimized",
+                        "value": "u-24tb1.metal",
+                      },
+                    ],
+                    "label": "High Memory - Metal",
+                  },
+                ],
+                "label": "General Purpose",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "64 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1.32xlarge",
+                      },
+                    ],
+                    "label": "X1 - Xeon processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "x1e.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "x1e.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "x1e.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1e.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1e.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 3,904 GiB RAM - Memory Optimized",
+                        "value": "x1e.32xlarge",
+                      },
+                    ],
+                    "label": "X1e - Xeon processors, in-memory database optimized",
+                  },
+                ],
+                "label": "With Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.metal",
+                      },
+                    ],
+                    "label": "R5d - With SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5dn.24xlarge",
+                      },
+                    ],
+                    "label": "R5dn - With SSD, network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5ad.24xlarge",
+                      },
+                    ],
+                    "label": "R5ad - With SSD, AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "z1d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "z1d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "z1d.2xlarge",
+                      },
+                      Object {
+                        "description": "12 vCPU, 96 GiB RAM - Memory Optimized",
+                        "value": "z1d.3xlarge",
+                      },
+                      Object {
+                        "description": "24 vCPU, 192 GiB RAM - Memory Optimized",
+                        "value": "z1d.6xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.12xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.metal",
+                      },
+                    ],
+                    "label": "Z1d - With SSD, fastest processor",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 61 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "p3.2xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 32 vCPU, 244 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "p3.8xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 64 vCPU, 488 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "p3.16xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 768 GiB, 256 GPU GiB - Accelerated Computing",
+                    "value": "p3dn.24xlarge",
+                  },
+                ],
+                "label": "P3 - NVIDIA Tesla V100 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 61 GiB, 12 GPU GiB - Accelerated Computing",
+                    "value": "p2.xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 32 vCPU, 488 GiB, 96 GPU GiB - Accelerated Computing",
+                    "value": "p2.8xlarge",
+                  },
+                  Object {
+                    "description": "16 GPUs, 64 vCPU, 732 GiB, 192 GPU GiB - Accelerated Computing",
+                    "value": "p2.16xlarge",
+                  },
+                ],
+                "label": "P2 - NVIDIA K80 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 16 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 32 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.2xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 64 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.4xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 32 vCPU, 128 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.8xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 64 vCPU, 256 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.16xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 48 vCPU, 192 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.12xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 384 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.metal",
+                  },
+                ],
+                "label": "G4 - NVIDIA T4 Tensor Core GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 30.5 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3s.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 122 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3.4xlarge",
+                  },
+                  Object {
+                    "description": "2 GPUs, 32 vCPU, 244 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g3.8xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 64 vCPU, 488 GiB, 32 GPU GiB - Accelerated Computing",
+                    "value": "g3.16xlarge",
+                  },
+                ],
+                "label": "G3 - NVIDIA Tesla M60 GPUs",
+              },
+            ],
+            "label": "Accelerated Computing",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 15.25 GiB RAM - Storage Optimized",
+                    "value": "i3.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "i3.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "i3.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "i3.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "i3.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 488 GiB RAM - Storage Optimized",
+                    "value": "i3.16xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 512GiB RAM - Storage Optimized",
+                    "value": "i3.metal",
+                  },
+                ],
+                "label": "I3 - High Frequency Intel Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 16 GiB RAM - Storage Optimized",
+                    "value": "i3en.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "i3en.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "i3en.2xlarge",
+                  },
+                  Object {
+                    "description": "12 vCPU, 96 GiB RAM - Storage Optimized",
+                    "value": "i3en.3xlarge",
+                  },
+                  Object {
+                    "description": "24 vCPU, 192 GiB RAM - Storage Optimized",
+                    "value": "i3en.6xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB RAM - Storage Optimized",
+                    "value": "i3en.12xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.metal",
+                  },
+                ],
+                "label": "I3en - Non-Volatile Memory Express SSD instance storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "d2.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "d2.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "d2.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "d2.8xlarge",
+                  },
+                ],
+                "label": "D2 - Up to 48 TB of HDD-based local storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "h1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "h1.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB RAM - Storage Optimized",
+                    "value": "h1.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB RAM - Storage Optimized",
+                    "value": "h1.16xlarge",
+                  },
+                ],
+                "label": "H1 - 16 TB of HDD-based local storage",
+              },
+            ],
+            "label": "Storage Optimized",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.persistent.storage",
+        "id": "workerStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "onChange": [Function],
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "privateAWS",
+    "title": "AWS private configuration",
+    "type": "step",
+  },
+  Object {
+    "id": "privateAWSTitle",
+    "info": "Optional: Configuration for private AWS cluster provision",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasPrivateConfig",
+    "name": "Use private configuration",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "active": "",
+    "disabled": true,
+    "id": "amiID",
+    "name": "AMI ID",
+    "placeholder": "Enter AMI ID",
+    "tooltip": "The ID of the AMI used to boot machines for the cluster. If set, the AMI must belong to the same region as the cluster.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "active": "",
+    "disabled": true,
+    "id": "hostedZone",
+    "name": "Hosted zone",
+    "placeholder": "Enter hosted zone ID",
+    "tooltip": "The ID of your existing Route 53 private hosted zone.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be alphanumeric, including periods.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\.\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "subnetSection",
+        "info": "Specify subnets for each availability zone that your cluster uses.",
+        "subtitle": "Subnets",
+        "type": "section",
+      },
+      Object {
+        "active": Array [],
+        "id": "subnetID",
+        "name": "Subnet ID",
+        "placeholder": "Enter one or more subnet IDs",
+        "tooltip": "If you provide your own VPC, specify subnets for each availability zone that your cluster uses.",
+        "type": "values",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+    ],
+    "hidden": true,
+    "id": "privateLink",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "serviceEndpoint",
+        "info": "The AWS service endpoint name. Custom API endpoints can be specified for EC2, S3, IAM, Elastic Load Balancing, Tagging, Route 53, and STS AWS services.",
+        "subtitle": "Service Endpoints",
+        "type": "section",
+      },
+      Object {
+        "active": "",
+        "id": "endpointName",
+        "name": "Name",
+        "placeholder": "Enter AWS service endpoint name",
+        "tooltip": "The AWS service endpoints. Custom endpoints are required when installing to an unknown AWS region.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "",
+        "id": "endpointURL",
+        "name": "URL",
+        "placeholder": "Enter AWS service endpoint URL",
+        "tooltip": "The AWS service endpoint URL. The endpoint URL must use the https protocol and the host must trust the certificate.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\.\\]\\+\\$/,
+        },
+      },
+    ],
+    "hidden": true,
+    "id": "serviceEndpoints",
+    "onlyOne": false,
+    "prompts": Object {
+      "addPrompt": "Add Service Endpoint",
+      "baseName": "Subnet ID",
+      "deletePrompt": "Remove Service Endpoint",
+      "nameId": "tester",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for AWS generates correctly with SNO enabled 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "AWS",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "aws",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "AWS",
+    ],
+    "availableMap": Object {
+      "AWS": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "us-east-1",
+    "available": Array [
+      "us-east-1",
+      "us-east-2",
+      "us-west-1",
+      "us-west-2",
+      "af-south-1",
+      "ap-east-1",
+      "ap-northeast-1",
+      "ap-northeast-2",
+      "ap-northeast-3",
+      "ap-south-1",
+      "ap-southeast-1",
+      "ap-southeast-2",
+      "ca-central-1",
+      "eu-central-1",
+      "eu-north-1",
+      "eu-south-1",
+      "eu-west-1",
+      "eu-west-2",
+      "eu-west-3",
+      "me-south-1",
+      "sa-east-1",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "onSelect": [Function],
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The AWS region where the installation program creates your cluster resources. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster unless single node is enabled, in which case there will only be one control plane node.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.master.zones",
+        "id": "masterZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your control plane nodes are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "description": "2 vCPU, 8 GiB RAM - General Purpose",
+            "value": "m5.large",
+          },
+          Object {
+            "description": "4 vCPU, 16 GiB RAM - General Purpose",
+            "value": "m5.xlarge",
+          },
+          Object {
+            "description": "8 vCPU, 32 GiB RAM - General Purpose",
+            "value": "m5.2xlarge",
+          },
+          Object {
+            "description": "16 vCPU, 64 GiB RAM - General Purpose",
+            "value": "m5.4xlarge",
+          },
+          Object {
+            "description": "40 vCPU, 160 GiB RAM - General Purpose",
+            "value": "m5.10xlarge",
+          },
+          Object {
+            "description": "64 vCPU, 256 GiB RAM - General Purpose",
+            "value": "m5.16xlarge",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.master.type",
+        "id": "masterType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.master.root.storage",
+        "id": "masterRootStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "available": Array [
+          "us-east-1a",
+          "us-east-1b",
+          "us-east-1c",
+          "us-east-1d",
+          "us-east-1e",
+          "us-east-1f",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.worker.zones",
+        "id": "workerZones",
+        "multiselect": true,
+        "name": "Zones",
+        "placeholder": "Select zones",
+        "tooltip": "The availability zones where your worker pools are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "m5.xlarge",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m4.4xlarge",
+                      },
+                      Object {
+                        "description": "40 vCPU, 160 GiB RAM - General Purpose",
+                        "value": "m4.10xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m4.16xlarge",
+                      },
+                    ],
+                    "label": "M4 - 2.3 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5.24xlarge",
+                      },
+                    ],
+                    "label": "M5 - 3.1 GHz Intel processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5a.24xlarge",
+                      },
+                    ],
+                    "label": "M5a - AMD processors, up to 10% cost savings over M5",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5n.24xlarge",
+                      },
+                    ],
+                    "label": "M5n - Network optimized",
+                  },
+                ],
+                "label": "Balanced",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 2 GiB RAM - Network Optimized",
+                    "value": "a1.medium",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Network Optimized",
+                    "value": "a1.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Network Optimized",
+                    "value": "a1.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Network Optimized",
+                    "value": "a1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.4xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Network Optimized",
+                    "value": "a1.metal",
+                  },
+                ],
+                "label": "Network Optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "1 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t2.nano",
+                      },
+                      Object {
+                        "description": "1 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t2.micro",
+                      },
+                      Object {
+                        "description": "1 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t2.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t2.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t2.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t2.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t2.2xlarge",
+                      },
+                    ],
+                    "label": "T2 - Lowest-cost",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - Burstable CPU",
+                        "value": "t3.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - Burstable CPU",
+                        "value": "t3.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - Burstable CPU",
+                        "value": "t3.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - Burstable CPU",
+                        "value": "t3.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - Burstable CPU",
+                        "value": "t3.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - Burstable CPU",
+                        "value": "t3.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - Burstable CPU",
+                        "value": "t3.2xlarge",
+                      },
+                    ],
+                    "label": "T3 - General purpose",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 0.5 GiB RAM - General Purpose",
+                        "value": "t3a.nano",
+                      },
+                      Object {
+                        "description": "2 vCPU, 1 GiB RAM - General Purpose",
+                        "value": "t3a.micro",
+                      },
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "t3a.small",
+                      },
+                      Object {
+                        "description": "2 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "t3a.medium",
+                      },
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "t3a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "t3a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "t3a.2xlarge",
+                      },
+                    ],
+                    "label": "T3a - Up to 10% cost savings over T3",
+                  },
+                ],
+                "label": "Burstable CPU",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5d.metal",
+                      },
+                    ],
+                    "label": "M5d - Intel processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5ad.24xlarge",
+                      },
+                    ],
+                    "label": "M5ad - AMD processor with SSDs physically connected to the host server",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "m5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "m5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "m5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "m5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "m5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "m5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "m5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "m5dn.24xlarge",
+                      },
+                    ],
+                    "label": "M5dn - Network optimized with SSDs physically connected to the host server",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5.metal",
+                  },
+                ],
+                "label": "C5 - Intel processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5a.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5a.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5a.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5a.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 64 GiB RAM - Compute Optimized",
+                    "value": "c5a.8xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5a.12xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 128 GiB RAM - Compute Optimized",
+                    "value": "c5a.16xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5a.24xlarge",
+                  },
+                ],
+                "label": "C5a - AMD processors, compute optimized",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 4 GiB RAM - Compute Optimized",
+                    "value": "c5d.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB RAM - Compute Optimized",
+                    "value": "c5d.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB RAM - Compute Optimized",
+                    "value": "c5d.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB RAM - Compute Optimized",
+                    "value": "c5d.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 72 GiB RAM - Compute Optimized",
+                    "value": "c5d.9xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5d.12xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 144 GiB RAM - Compute Optimized",
+                    "value": "c5d.18xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5d.metal",
+                  },
+                ],
+                "label": "C5d - Intel processors with SSD",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 5.25 GiB RAM - Compute Optimized",
+                    "value": "c5n.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 10.5 GiB RAM - Compute Optimized",
+                    "value": "c5n.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 21 GiB RAM - Compute Optimized",
+                    "value": "c5n.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 42 GiB RAM - Compute Optimized",
+                    "value": "c5n.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 96 GiB RAM - Compute Optimized",
+                    "value": "c5n.9xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.18xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 192 GiB RAM - Compute Optimized",
+                    "value": "c5n.metal",
+                  },
+                ],
+                "label": "C5n - Intel processors, optimized network",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 3.75GiB RAM - Compute Optimized",
+                    "value": "c4.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 7.5 GiB RAM - Compute Optimized",
+                    "value": "c4.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 15 GiB RAM - Compute Optimized",
+                    "value": "c4.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 30 GiB RAM - Compute Optimized",
+                    "value": "c4.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 60GiB RAM - Compute Optimized",
+                    "value": "c4.8xlarge",
+                  },
+                ],
+                "label": "C4  - Intel processors, cost-effective",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 15.25 GiB RAM - Memory Optimized",
+                        "value": "r4.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 30.5 GiB RAM - Memory Optimized",
+                        "value": "r4.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 61 GiB RAM - Memory Optimized",
+                        "value": "r4.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "r4.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "r4.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "r4.16xlarge",
+                      },
+                    ],
+                    "label": "R4 - Optimized for memory-intensive applications",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128GiB RAM - Memory Optimized",
+                        "value": "r5.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256GiB RAM - Memory Optimized",
+                        "value": "r5.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384GiB RAM - Memory Optimized",
+                        "value": "r5.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512GiB RAM - Memory Optimized",
+                        "value": "r5.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768GiB RAM - Memory Optimized",
+                        "value": "r5.metal",
+                      },
+                    ],
+                    "label": "R5 - 5% additional memory per vCPU over R4",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5a.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5a.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5a.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5a.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5a.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5a.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5a.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5a.24xlarge",
+                      },
+                    ],
+                    "label": "R5a - AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5n.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5n.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5n.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5n.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5n.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5n.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5n.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5n.24xlarge",
+                      },
+                    ],
+                    "label": "R5n - Network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "448 vCPU, 6144 GiB RAM - Memory Optimized",
+                        "value": "u-6tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 9216 GiB RAM - Memory Optimized",
+                        "value": "u-9tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 12288 GiB RAM - Memory Optimized",
+                        "value": "u-12tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 18432 GiB RAM - Memory Optimized",
+                        "value": "u-18tb1.metal",
+                      },
+                      Object {
+                        "description": "448 vCPU, 24576 GiB RAM - Memory Optimized",
+                        "value": "u-24tb1.metal",
+                      },
+                    ],
+                    "label": "High Memory - Metal",
+                  },
+                ],
+                "label": "General Purpose",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "64 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1.32xlarge",
+                      },
+                    ],
+                    "label": "X1 - Xeon processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "4 vCPU, 122 GiB RAM - Memory Optimized",
+                        "value": "x1e.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 244 GiB RAM - Memory Optimized",
+                        "value": "x1e.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 488 GiB RAM - Memory Optimized",
+                        "value": "x1e.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 976 GiB RAM - Memory Optimized",
+                        "value": "x1e.8xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 1,952 GiB RAM - Memory Optimized",
+                        "value": "x1e.16xlarge",
+                      },
+                      Object {
+                        "description": "128 vCPU, 3,904 GiB RAM - Memory Optimized",
+                        "value": "x1e.32xlarge",
+                      },
+                    ],
+                    "label": "X1e - Xeon processors, in-memory database optimized",
+                  },
+                ],
+                "label": "With Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5d.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5d.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5d.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5d.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5d.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.24xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5d.metal",
+                      },
+                    ],
+                    "label": "R5d - With SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5dn.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5dn.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5dn.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5dn.4xlarge",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - Memory Optimized",
+                        "value": "r5dn.8xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5dn.12xlarge",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - Memory Optimized",
+                        "value": "r5dn.16xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5dn.24xlarge",
+                      },
+                    ],
+                    "label": "R5dn - With SSD, network optimized",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "r5ad.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "r5ad.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "r5ad.2xlarge",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - Memory Optimized",
+                        "value": "r5ad.4xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "r5ad.12xlarge",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - Memory Optimized",
+                        "value": "r5ad.24xlarge",
+                      },
+                    ],
+                    "label": "R5ad - With SSD, AMD processors",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - Memory Optimized",
+                        "value": "z1d.large",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - Memory Optimized",
+                        "value": "z1d.xlarge",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - Memory Optimized",
+                        "value": "z1d.2xlarge",
+                      },
+                      Object {
+                        "description": "12 vCPU, 96 GiB RAM - Memory Optimized",
+                        "value": "z1d.3xlarge",
+                      },
+                      Object {
+                        "description": "24 vCPU, 192 GiB RAM - Memory Optimized",
+                        "value": "z1d.6xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.12xlarge",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - Memory Optimized",
+                        "value": "z1d.metal",
+                      },
+                    ],
+                    "label": "Z1d - With SSD, fastest processor",
+                  },
+                ],
+                "label": "With SSD",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 61 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "p3.2xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 32 vCPU, 244 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "p3.8xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 64 vCPU, 488 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "p3.16xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 768 GiB, 256 GPU GiB - Accelerated Computing",
+                    "value": "p3dn.24xlarge",
+                  },
+                ],
+                "label": "P3 - NVIDIA Tesla V100 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 61 GiB, 12 GPU GiB - Accelerated Computing",
+                    "value": "p2.xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 32 vCPU, 488 GiB, 96 GPU GiB - Accelerated Computing",
+                    "value": "p2.8xlarge",
+                  },
+                  Object {
+                    "description": "16 GPUs, 64 vCPU, 732 GiB, 192 GPU GiB - Accelerated Computing",
+                    "value": "p2.16xlarge",
+                  },
+                ],
+                "label": "P2 - NVIDIA K80 GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 16 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 8 vCPU, 32 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.2xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 64 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.4xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 32 vCPU, 128 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.8xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 64 vCPU, 256 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.16xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 48 vCPU, 192 GiB, 64 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.12xlarge",
+                  },
+                  Object {
+                    "description": "8 GPUs, 96 vCPU, 384 GiB, 128 GPU GiB - Accelerated Computing",
+                    "value": "g4dn.metal",
+                  },
+                ],
+                "label": "G4 - NVIDIA T4 Tensor Core GPUs",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 GPUs, 4 vCPU, 30.5 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3s.xlarge",
+                  },
+                  Object {
+                    "description": "1 GPUs, 16 vCPU, 122 GiB, 8 GPU GiB - Accelerated Computing",
+                    "value": "g3.4xlarge",
+                  },
+                  Object {
+                    "description": "2 GPUs, 32 vCPU, 244 GiB, 16 GPU GiB - Accelerated Computing",
+                    "value": "g3.8xlarge",
+                  },
+                  Object {
+                    "description": "4 GPUs, 64 vCPU, 488 GiB, 32 GPU GiB - Accelerated Computing",
+                    "value": "g3.16xlarge",
+                  },
+                ],
+                "label": "G3 - NVIDIA Tesla M60 GPUs",
+              },
+            ],
+            "label": "Accelerated Computing",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 15.25 GiB RAM - Storage Optimized",
+                    "value": "i3.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "i3.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "i3.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "i3.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "i3.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 488 GiB RAM - Storage Optimized",
+                    "value": "i3.16xlarge",
+                  },
+                  Object {
+                    "description": "72 vCPU, 512GiB RAM - Storage Optimized",
+                    "value": "i3.metal",
+                  },
+                ],
+                "label": "I3 - High Frequency Intel Xeon Processors",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 16 GiB RAM - Storage Optimized",
+                    "value": "i3en.large",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "i3en.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "i3en.2xlarge",
+                  },
+                  Object {
+                    "description": "12 vCPU, 96 GiB RAM - Storage Optimized",
+                    "value": "i3en.3xlarge",
+                  },
+                  Object {
+                    "description": "24 vCPU, 192 GiB RAM - Storage Optimized",
+                    "value": "i3en.6xlarge",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB RAM - Storage Optimized",
+                    "value": "i3en.12xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.24xlarge",
+                  },
+                  Object {
+                    "description": "96 vCPU, 768 GiB RAM - Storage Optimized",
+                    "value": "i3en.metal",
+                  },
+                ],
+                "label": "I3en - Non-Volatile Memory Express SSD instance storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "4 vCPU, 30.5 GiB RAM - Storage Optimized",
+                    "value": "d2.xlarge",
+                  },
+                  Object {
+                    "description": "8 vCPU, 61 GiB RAM - Storage Optimized",
+                    "value": "d2.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 122 GiB RAM - Storage Optimized",
+                    "value": "d2.4xlarge",
+                  },
+                  Object {
+                    "description": "36 vCPU, 244 GiB RAM - Storage Optimized",
+                    "value": "d2.8xlarge",
+                  },
+                ],
+                "label": "D2 - Up to 48 TB of HDD-based local storage",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 32 GiB RAM - Storage Optimized",
+                    "value": "h1.2xlarge",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB RAM - Storage Optimized",
+                    "value": "h1.4xlarge",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB RAM - Storage Optimized",
+                    "value": "h1.8xlarge",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB RAM - Storage Optimized",
+                    "value": "h1.16xlarge",
+                  },
+                ],
+                "label": "H1 - 16 TB of HDD-based local storage",
+              },
+            ],
+            "label": "Storage Optimized",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://aws.amazon.com/ec2/instance-types/",
+        "name": "Instance type",
+        "tooltip": "The EC2 instance type for your compute machines.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "100",
+        "available": Array [
+          "100",
+          "300",
+          "500",
+          "800",
+          "1000",
+          "1200",
+        ],
+        "cacheUserValueKey": "create.cluster.persistent.storage",
+        "id": "workerStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The EC2 instance root volume size.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "onChange": [Function],
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+]
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAZR.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAZR.test.js.snap
@@ -1,0 +1,5749 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cluster creation control data for AZR generates correctly 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "Azure",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "azr",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "Azure",
+    ],
+    "availableMap": Object {
+      "Azure": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "centralus",
+    "available": Array [
+      "australiaeast",
+      "brazilsouth",
+      "canadacentral",
+      "centralindia",
+      "centralus",
+      "eastasia",
+      "eastus",
+      "eastus2",
+      "francecentral",
+      "germanywestcentral",
+      "japaneast",
+      "koreacentral",
+      "northcentralus",
+      "northeurope",
+      "norwayeast",
+      "southafricanorth",
+      "southcentralus",
+      "southeastasia",
+      "switzerlandnorth",
+      "uaenorth",
+      "uksouth",
+      "westeurope",
+      "westus",
+      "westus2",
+      "westus3",
+      "australiacentral",
+      "australiasoutheast",
+      "canadaeast",
+      "japanwest",
+      "koreasouth",
+      "southindia",
+      "ukwest",
+      "westcentralus",
+      "westindia",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The name of the Azure region where your cluster is hosted. For example, centralus for Azure. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "Standard_D4s_v3",
+        "available": Array [
+          Object {
+            "description": "2 vCPU, 8 GiB RAM - General Purpose",
+            "value": "Standard_D2s_v3",
+          },
+          Object {
+            "description": "4 vCPU, 16 GiB RAM - General Purpose",
+            "value": "Standard_D4s_v3",
+          },
+          Object {
+            "description": "8 vCPU, 32 GiB RAM - General Purpose",
+            "value": "Standard_D8s_v3",
+          },
+          Object {
+            "description": "16 vCPU, 64 GiB RAM - General Purpose",
+            "value": "Standard_D16s_v3",
+          },
+          Object {
+            "description": "32 vCPU, 128 GiB RAM - General Purpose",
+            "value": "Standard_D32s_v3",
+          },
+          Object {
+            "description": "48 vCPU, 192 GiB RAM - General Purpose",
+            "value": "Standard_D48s_v3",
+          },
+          Object {
+            "description": "64 vCPU, 256 GiB RAM - General Purpose",
+            "value": "Standard_D64s_v3",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.master.type",
+        "id": "masterType",
+        "learnMore": "https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-general",
+        "name": "Instance type",
+        "tooltip": "The Azure VM instance type.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9_]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "active": "128",
+        "available": Array [
+          "128",
+          "256",
+          "512",
+          "1024",
+          "2048",
+        ],
+        "cacheUserValueKey": "create.cluster.master.root.storage",
+        "id": "masterRootStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The Azure disk size for the VM.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": Array [
+          "1",
+          "2",
+          "3",
+        ],
+        "available": Array [
+          "1",
+          "2",
+          "3",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.worker.zones",
+        "id": "workerZones",
+        "multiselect": true,
+        "name": "Zones",
+        "tooltip": "The availability zones where your worker pools are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "Standard_D2s_v3",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 2 GiB - General Purpose",
+                    "value": "Standard_A1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_A2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB - General Purpose",
+                    "value": "Standard_A4_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_A8_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_A2m_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_A4m_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_A8m_v2",
+                  },
+                ],
+                "label": "Av2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 0.5 GiB - General Purpose",
+                    "value": "Standard_B1ls1",
+                  },
+                  Object {
+                    "description": "1 vCPU, 1 GiB - General Purpose",
+                    "value": "Standard_B1s",
+                  },
+                  Object {
+                    "description": "1 vCPU, 2 GiB - General Purpose",
+                    "value": "Standard_B1ms  ",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_B2s",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_B2ms",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_B4ms",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_B8ms",
+                  },
+                  Object {
+                    "description": "12 vCPU, 48 GiB - General Purpose",
+                    "value": "Standard_B12ms",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_B16ms",
+                  },
+                  Object {
+                    "description": "20 vCPU, 80 GiB - General Purpose",
+                    "value": "Standard_B20ms",
+                  },
+                ],
+                "label": "B-series burstable virtual machine sizes",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_DC1s_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_DC2s_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_DC4s_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_DC8_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 3.5 GiB - General Purpose",
+                    "value": "Standard_D1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 7 GiB - General Purpose",
+                    "value": "Standard_D2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB - General Purpose",
+                    "value": "Standard_D3_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB - General Purpose",
+                    "value": "Standard_D4_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB - General Purpose",
+                    "value": "Standard_D5_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 3.5 GiB - General Purpose",
+                    "value": "Standard_DS1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 7 GiB - General Purpose",
+                    "value": "Standard_DS2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB - General Purpose",
+                    "value": "Standard_DS3_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB - General Purpose",
+                    "value": "Standard_DS4_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB - General Purpose",
+                    "value": "Standard_DS5_v2",
+                  },
+                ],
+                "label": "Dv2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64_v3",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4s_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8s_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16s_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64s_v3",
+                  },
+                ],
+                "label": "Dv3-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 50 GiB - General Purpose",
+                    "value": "Standard_D2a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 100 GiB - General Purpose",
+                    "value": "Standard_D4a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 200 GiB - General Purpose",
+                    "value": "Standard_D8a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32a_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64a_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 384 GiB - General Purpose",
+                    "value": "Standard_D96a_v4",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2as_v4",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8as_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16as_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32as_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48as_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64as_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 384 GiB - General Purpose",
+                    "value": "Standard_D96as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 75 GiB - General Purpose",
+                    "value": "Standard_D2d_v42",
+                  },
+                  Object {
+                    "description": "16 vCPU, 150 GiB - General Purpose",
+                    "value": "Standard_D4d_v44",
+                  },
+                  Object {
+                    "description": "32 vCPU, 300 GiB - General Purpose",
+                    "value": "Standard_D8d_v48",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16d_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32d_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48d_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64d_v4",
+                  },
+                ],
+                "label": "Dav4-series",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "4 vCPU, 8 GiB - Compute Optimized",
+                "value": "Standard_F4s_v2",
+              },
+              Object {
+                "description": "8 vCPU, 16 GiB - Compute Optimized",
+                "value": "Standard_F8s_v2",
+              },
+              Object {
+                "description": "16 vCPU, 32 GiB - Compute Optimized",
+                "value": "Standard_F16s_v2",
+              },
+              Object {
+                "description": "32 vCPU, 64 GiB - Compute Optimized",
+                "value": "Standard_F32s_v2",
+              },
+              Object {
+                "description": "48 vCPU, 96 GiB - Compute Optimized",
+                "value": "Standard_F48s_v2",
+              },
+              Object {
+                "description": "64 vCPU, 128 GiB - Compute Optimized",
+                "value": "Standard_F64s_v2",
+              },
+              Object {
+                "description": "72 vCPU, 144 GiB - Compute Optimized",
+                "value": "Standard_F72s_v21",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 14 GiB - Memory Optimized",
+                    "value": "Standard_D11_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 28 GiB - Memory Optimized",
+                    "value": "Standard_D12_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 56 GiB - Memory Optimized",
+                    "value": "Standard_D13_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 112 GiB - Memory Optimized",
+                    "value": "Standard_D14_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 20 GiB - Memory Optimized",
+                    "value": "Standard_D15_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 2 GiB - Memory Optimized",
+                    "value": "Standard_DS11_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 4 GiB - Memory Optimized",
+                    "value": "Standard_DS12_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 8 GiB - Memory Optimized",
+                    "value": "Standard_DS13_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_DS14_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 20 GiB - Memory Optimized",
+                    "value": "Standard_DS15_v2",
+                  },
+                ],
+                "label": "Dv2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_E2_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16_v3",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64i_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E2s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4s_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8s_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16s_v3",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20s_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64is_v3",
+                  },
+                ],
+                "label": "Ev3-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "16 vCPU, 50 GiB - Memory Optimized",
+                    "value": "Standard_E2a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 100 GiB - Memory Optimized",
+                    "value": "Standard_E4a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 200 GiB - Memory Optimized",
+                    "value": "Standard_E8a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16a_v4",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32a_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 512 GiB - Memory Optimized",
+                    "value": "Standard_E64a_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 672 GiB - Memory Optimized",
+                    "value": "Standard_E96a_v4",
+                  },
+                  Object {
+                    "description": "2 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_E2ds_v4",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4ds_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8ds_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16ds_v4",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20ds_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32ds_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48ds_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 504 GiB - Memory Optimized",
+                    "value": "Standard_E64ds_v4",
+                  },
+                ],
+                "label": "Eav4-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 218.75 GiB - Memory Optimized",
+                    "value": "Standard_M8ms",
+                  },
+                  Object {
+                    "description": "16 vCPU, 437.5 GiB - Memory Optimized",
+                    "value": "Standard_M16ms",
+                  },
+                  Object {
+                    "description": "32 vCPU, 192 GiB - Memory Optimized",
+                    "value": "Standard_M32ts",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_M32ls",
+                  },
+                  Object {
+                    "description": "32 vCPU, 875 GiB - Memory Optimized",
+                    "value": "Standard_M32ms",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1024 GiB - Memory Optimized",
+                    "value": "Standard_M64s",
+                  },
+                  Object {
+                    "description": "64 vCPU, 512 GiB - Memory Optimized",
+                    "value": "Standard_M64ls",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1792 GiB - Memory Optimized",
+                    "value": "Standard_M64ms",
+                  },
+                  Object {
+                    "description": "128 vCPU, 2048 GiB - Memory Optimized",
+                    "value": "Standard_M128s",
+                  },
+                  Object {
+                    "description": "128 vCPU, 3892 GiB - Memory Optimized",
+                    "value": "Standard_M128ms",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1024 GiB - Memory Optimized",
+                    "value": "Standard_M64",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1792 GiB - Memory Optimized",
+                    "value": "Standard_M64m",
+                  },
+                  Object {
+                    "description": "128 vCPU, 2048 GiB - Memory Optimized",
+                    "value": "Standard_M128",
+                  },
+                  Object {
+                    "description": "128 vCPU, 3892 GiB - Memory Optimized",
+                    "value": "Standard_M128m",
+                  },
+                ],
+                "label": "M-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "208 vCPU, 5700 GiB - Memory Optimized",
+                    "value": "Standard_M208ms_v21",
+                  },
+                  Object {
+                    "description": "208 vCPU, 2850 GiB - Memory Optimized",
+                    "value": "Standard_M208s_v21",
+                  },
+                  Object {
+                    "description": "416 vCPU, 11400 GiB - Memory Optimized",
+                    "value": "Standard_M416ms_v21",
+                  },
+                  Object {
+                    "description": "416 vCPU, 5700 GiB - Memory Optimized",
+                    "value": "Standard_M416s_v21",
+                  },
+                ],
+                "label": "Mv2-series",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "64 vCPU, 80 GiB - Storage Optimized",
+                "value": "Standard_L8s_v2",
+              },
+              Object {
+                "description": "16 vCPU, 128 GiB - Storage Optimized",
+                "value": "Standard_L16s_v2",
+              },
+              Object {
+                "description": "32 vCPU, 256 GiB - Storage Optimized",
+                "value": "Standard_L32s_v2",
+              },
+              Object {
+                "description": "48 vCPU, 384 GiB - Storage Optimized",
+                "value": "Standard_L48s_v2",
+              },
+              Object {
+                "description": "64 vCPU, 512 GiB - Storage Optimized",
+                "value": "Standard_L64s_v2",
+              },
+              Object {
+                "description": "80 vCPU, 640 GiB - Storage Optimized",
+                "value": "Standard_L80s_v26",
+              },
+            ],
+            "label": "Storage Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 56 GiB, 12 GPUs, 24 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, 24 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, 4 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, 4 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24r",
+                  },
+                  Object {
+                    "description": "6 vCPU, 112 GiB, 16 GPUs, 12 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6s_v2",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, 2 GPUs, 32 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12s_v2",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, 4 GPUs, 64 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24s_v2",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24rs_v2",
+                  },
+                  Object {
+                    "description": "6 vCPU, 112 GiB, 16 GPUs, 12 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6s_v3",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, 2 GPUs, 32 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, 4 GPUs, 64 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24rs_v3",
+                  },
+                ],
+                "label": "NC-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 112 GiB, GPUs,24 GPU 12GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND6s",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, GPUs,48 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND12s",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs,96 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND24s",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND24rs",
+                  },
+                ],
+                "label": "ND-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 56 GiB, GPUs, 8 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV6",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, GPUs,16 GPU 48GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV12",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, GPUs,4 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV24",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, GPUs,8 GPU 12GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV12s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, GPUs,16 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV24s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 448 GiB, GPUs,4 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV48s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB, GPUs,2 GPU 4 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV4as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB, GPUs,4  GPU 8 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV8as_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB, GPUs,8  GPU 16 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV16as_v4",
+                  },
+                ],
+                "label": "NV-series",
+              },
+            ],
+            "label": "GPU Accelerated Compute",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "8 vCPU, 56 GiB RAM - High Performance Compute",
+                "value": "Standard_H8",
+              },
+              Object {
+                "description": "16 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H16",
+              },
+              Object {
+                "description": "8 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H8m",
+              },
+              Object {
+                "description": "16 vCPU, 224 GiB RAM - High Performance Compute",
+                "value": "Standard_H16m",
+              },
+              Object {
+                "description": "16 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H16r",
+              },
+              Object {
+                "description": "16 vCPU, 224 GiB RAM - High Performance Compute",
+                "value": "Standard_H16mr",
+              },
+            ],
+            "label": "High Performance Compute",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-general",
+        "name": "Instance type",
+        "tooltip": "The Azure VM instance type.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9_]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "128",
+        "available": Array [
+          "128",
+          "256",
+          "512",
+          "1024",
+          "2048",
+        ],
+        "cacheUserValueKey": "create.cluster.persistent.storage",
+        "id": "workerStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The Azure disk size for the VM.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for AZR generates correctly for MCE 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "Azure",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "azr",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "Azure",
+    ],
+    "availableMap": Object {
+      "Azure": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "centralus",
+    "available": Array [
+      "australiaeast",
+      "brazilsouth",
+      "canadacentral",
+      "centralindia",
+      "centralus",
+      "eastasia",
+      "eastus",
+      "eastus2",
+      "francecentral",
+      "germanywestcentral",
+      "japaneast",
+      "koreacentral",
+      "northcentralus",
+      "northeurope",
+      "norwayeast",
+      "southafricanorth",
+      "southcentralus",
+      "southeastasia",
+      "switzerlandnorth",
+      "uaenorth",
+      "uksouth",
+      "westeurope",
+      "westus",
+      "westus2",
+      "westus3",
+      "australiacentral",
+      "australiasoutheast",
+      "canadaeast",
+      "japanwest",
+      "koreasouth",
+      "southindia",
+      "ukwest",
+      "westcentralus",
+      "westindia",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The name of the Azure region where your cluster is hosted. For example, centralus for Azure. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "Standard_D4s_v3",
+        "available": Array [
+          Object {
+            "description": "2 vCPU, 8 GiB RAM - General Purpose",
+            "value": "Standard_D2s_v3",
+          },
+          Object {
+            "description": "4 vCPU, 16 GiB RAM - General Purpose",
+            "value": "Standard_D4s_v3",
+          },
+          Object {
+            "description": "8 vCPU, 32 GiB RAM - General Purpose",
+            "value": "Standard_D8s_v3",
+          },
+          Object {
+            "description": "16 vCPU, 64 GiB RAM - General Purpose",
+            "value": "Standard_D16s_v3",
+          },
+          Object {
+            "description": "32 vCPU, 128 GiB RAM - General Purpose",
+            "value": "Standard_D32s_v3",
+          },
+          Object {
+            "description": "48 vCPU, 192 GiB RAM - General Purpose",
+            "value": "Standard_D48s_v3",
+          },
+          Object {
+            "description": "64 vCPU, 256 GiB RAM - General Purpose",
+            "value": "Standard_D64s_v3",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.master.type",
+        "id": "masterType",
+        "learnMore": "https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-general",
+        "name": "Instance type",
+        "tooltip": "The Azure VM instance type.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9_]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "active": "128",
+        "available": Array [
+          "128",
+          "256",
+          "512",
+          "1024",
+          "2048",
+        ],
+        "cacheUserValueKey": "create.cluster.master.root.storage",
+        "id": "masterRootStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The Azure disk size for the VM.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": Array [
+          "1",
+          "2",
+          "3",
+        ],
+        "available": Array [
+          "1",
+          "2",
+          "3",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.worker.zones",
+        "id": "workerZones",
+        "multiselect": true,
+        "name": "Zones",
+        "tooltip": "The availability zones where your worker pools are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "Standard_D2s_v3",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 2 GiB - General Purpose",
+                    "value": "Standard_A1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_A2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB - General Purpose",
+                    "value": "Standard_A4_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_A8_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_A2m_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_A4m_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_A8m_v2",
+                  },
+                ],
+                "label": "Av2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 0.5 GiB - General Purpose",
+                    "value": "Standard_B1ls1",
+                  },
+                  Object {
+                    "description": "1 vCPU, 1 GiB - General Purpose",
+                    "value": "Standard_B1s",
+                  },
+                  Object {
+                    "description": "1 vCPU, 2 GiB - General Purpose",
+                    "value": "Standard_B1ms  ",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_B2s",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_B2ms",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_B4ms",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_B8ms",
+                  },
+                  Object {
+                    "description": "12 vCPU, 48 GiB - General Purpose",
+                    "value": "Standard_B12ms",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_B16ms",
+                  },
+                  Object {
+                    "description": "20 vCPU, 80 GiB - General Purpose",
+                    "value": "Standard_B20ms",
+                  },
+                ],
+                "label": "B-series burstable virtual machine sizes",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_DC1s_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_DC2s_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_DC4s_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_DC8_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 3.5 GiB - General Purpose",
+                    "value": "Standard_D1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 7 GiB - General Purpose",
+                    "value": "Standard_D2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB - General Purpose",
+                    "value": "Standard_D3_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB - General Purpose",
+                    "value": "Standard_D4_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB - General Purpose",
+                    "value": "Standard_D5_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 3.5 GiB - General Purpose",
+                    "value": "Standard_DS1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 7 GiB - General Purpose",
+                    "value": "Standard_DS2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB - General Purpose",
+                    "value": "Standard_DS3_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB - General Purpose",
+                    "value": "Standard_DS4_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB - General Purpose",
+                    "value": "Standard_DS5_v2",
+                  },
+                ],
+                "label": "Dv2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64_v3",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4s_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8s_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16s_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64s_v3",
+                  },
+                ],
+                "label": "Dv3-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 50 GiB - General Purpose",
+                    "value": "Standard_D2a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 100 GiB - General Purpose",
+                    "value": "Standard_D4a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 200 GiB - General Purpose",
+                    "value": "Standard_D8a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32a_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64a_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 384 GiB - General Purpose",
+                    "value": "Standard_D96a_v4",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2as_v4",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8as_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16as_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32as_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48as_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64as_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 384 GiB - General Purpose",
+                    "value": "Standard_D96as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 75 GiB - General Purpose",
+                    "value": "Standard_D2d_v42",
+                  },
+                  Object {
+                    "description": "16 vCPU, 150 GiB - General Purpose",
+                    "value": "Standard_D4d_v44",
+                  },
+                  Object {
+                    "description": "32 vCPU, 300 GiB - General Purpose",
+                    "value": "Standard_D8d_v48",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16d_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32d_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48d_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64d_v4",
+                  },
+                ],
+                "label": "Dav4-series",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "4 vCPU, 8 GiB - Compute Optimized",
+                "value": "Standard_F4s_v2",
+              },
+              Object {
+                "description": "8 vCPU, 16 GiB - Compute Optimized",
+                "value": "Standard_F8s_v2",
+              },
+              Object {
+                "description": "16 vCPU, 32 GiB - Compute Optimized",
+                "value": "Standard_F16s_v2",
+              },
+              Object {
+                "description": "32 vCPU, 64 GiB - Compute Optimized",
+                "value": "Standard_F32s_v2",
+              },
+              Object {
+                "description": "48 vCPU, 96 GiB - Compute Optimized",
+                "value": "Standard_F48s_v2",
+              },
+              Object {
+                "description": "64 vCPU, 128 GiB - Compute Optimized",
+                "value": "Standard_F64s_v2",
+              },
+              Object {
+                "description": "72 vCPU, 144 GiB - Compute Optimized",
+                "value": "Standard_F72s_v21",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 14 GiB - Memory Optimized",
+                    "value": "Standard_D11_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 28 GiB - Memory Optimized",
+                    "value": "Standard_D12_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 56 GiB - Memory Optimized",
+                    "value": "Standard_D13_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 112 GiB - Memory Optimized",
+                    "value": "Standard_D14_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 20 GiB - Memory Optimized",
+                    "value": "Standard_D15_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 2 GiB - Memory Optimized",
+                    "value": "Standard_DS11_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 4 GiB - Memory Optimized",
+                    "value": "Standard_DS12_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 8 GiB - Memory Optimized",
+                    "value": "Standard_DS13_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_DS14_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 20 GiB - Memory Optimized",
+                    "value": "Standard_DS15_v2",
+                  },
+                ],
+                "label": "Dv2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_E2_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16_v3",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64i_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E2s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4s_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8s_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16s_v3",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20s_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64is_v3",
+                  },
+                ],
+                "label": "Ev3-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "16 vCPU, 50 GiB - Memory Optimized",
+                    "value": "Standard_E2a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 100 GiB - Memory Optimized",
+                    "value": "Standard_E4a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 200 GiB - Memory Optimized",
+                    "value": "Standard_E8a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16a_v4",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32a_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 512 GiB - Memory Optimized",
+                    "value": "Standard_E64a_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 672 GiB - Memory Optimized",
+                    "value": "Standard_E96a_v4",
+                  },
+                  Object {
+                    "description": "2 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_E2ds_v4",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4ds_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8ds_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16ds_v4",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20ds_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32ds_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48ds_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 504 GiB - Memory Optimized",
+                    "value": "Standard_E64ds_v4",
+                  },
+                ],
+                "label": "Eav4-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 218.75 GiB - Memory Optimized",
+                    "value": "Standard_M8ms",
+                  },
+                  Object {
+                    "description": "16 vCPU, 437.5 GiB - Memory Optimized",
+                    "value": "Standard_M16ms",
+                  },
+                  Object {
+                    "description": "32 vCPU, 192 GiB - Memory Optimized",
+                    "value": "Standard_M32ts",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_M32ls",
+                  },
+                  Object {
+                    "description": "32 vCPU, 875 GiB - Memory Optimized",
+                    "value": "Standard_M32ms",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1024 GiB - Memory Optimized",
+                    "value": "Standard_M64s",
+                  },
+                  Object {
+                    "description": "64 vCPU, 512 GiB - Memory Optimized",
+                    "value": "Standard_M64ls",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1792 GiB - Memory Optimized",
+                    "value": "Standard_M64ms",
+                  },
+                  Object {
+                    "description": "128 vCPU, 2048 GiB - Memory Optimized",
+                    "value": "Standard_M128s",
+                  },
+                  Object {
+                    "description": "128 vCPU, 3892 GiB - Memory Optimized",
+                    "value": "Standard_M128ms",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1024 GiB - Memory Optimized",
+                    "value": "Standard_M64",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1792 GiB - Memory Optimized",
+                    "value": "Standard_M64m",
+                  },
+                  Object {
+                    "description": "128 vCPU, 2048 GiB - Memory Optimized",
+                    "value": "Standard_M128",
+                  },
+                  Object {
+                    "description": "128 vCPU, 3892 GiB - Memory Optimized",
+                    "value": "Standard_M128m",
+                  },
+                ],
+                "label": "M-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "208 vCPU, 5700 GiB - Memory Optimized",
+                    "value": "Standard_M208ms_v21",
+                  },
+                  Object {
+                    "description": "208 vCPU, 2850 GiB - Memory Optimized",
+                    "value": "Standard_M208s_v21",
+                  },
+                  Object {
+                    "description": "416 vCPU, 11400 GiB - Memory Optimized",
+                    "value": "Standard_M416ms_v21",
+                  },
+                  Object {
+                    "description": "416 vCPU, 5700 GiB - Memory Optimized",
+                    "value": "Standard_M416s_v21",
+                  },
+                ],
+                "label": "Mv2-series",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "64 vCPU, 80 GiB - Storage Optimized",
+                "value": "Standard_L8s_v2",
+              },
+              Object {
+                "description": "16 vCPU, 128 GiB - Storage Optimized",
+                "value": "Standard_L16s_v2",
+              },
+              Object {
+                "description": "32 vCPU, 256 GiB - Storage Optimized",
+                "value": "Standard_L32s_v2",
+              },
+              Object {
+                "description": "48 vCPU, 384 GiB - Storage Optimized",
+                "value": "Standard_L48s_v2",
+              },
+              Object {
+                "description": "64 vCPU, 512 GiB - Storage Optimized",
+                "value": "Standard_L64s_v2",
+              },
+              Object {
+                "description": "80 vCPU, 640 GiB - Storage Optimized",
+                "value": "Standard_L80s_v26",
+              },
+            ],
+            "label": "Storage Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 56 GiB, 12 GPUs, 24 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, 24 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, 4 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, 4 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24r",
+                  },
+                  Object {
+                    "description": "6 vCPU, 112 GiB, 16 GPUs, 12 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6s_v2",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, 2 GPUs, 32 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12s_v2",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, 4 GPUs, 64 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24s_v2",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24rs_v2",
+                  },
+                  Object {
+                    "description": "6 vCPU, 112 GiB, 16 GPUs, 12 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6s_v3",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, 2 GPUs, 32 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, 4 GPUs, 64 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24rs_v3",
+                  },
+                ],
+                "label": "NC-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 112 GiB, GPUs,24 GPU 12GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND6s",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, GPUs,48 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND12s",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs,96 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND24s",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND24rs",
+                  },
+                ],
+                "label": "ND-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 56 GiB, GPUs, 8 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV6",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, GPUs,16 GPU 48GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV12",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, GPUs,4 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV24",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, GPUs,8 GPU 12GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV12s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, GPUs,16 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV24s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 448 GiB, GPUs,4 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV48s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB, GPUs,2 GPU 4 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV4as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB, GPUs,4  GPU 8 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV8as_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB, GPUs,8  GPU 16 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV16as_v4",
+                  },
+                ],
+                "label": "NV-series",
+              },
+            ],
+            "label": "GPU Accelerated Compute",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "8 vCPU, 56 GiB RAM - High Performance Compute",
+                "value": "Standard_H8",
+              },
+              Object {
+                "description": "16 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H16",
+              },
+              Object {
+                "description": "8 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H8m",
+              },
+              Object {
+                "description": "16 vCPU, 224 GiB RAM - High Performance Compute",
+                "value": "Standard_H16m",
+              },
+              Object {
+                "description": "16 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H16r",
+              },
+              Object {
+                "description": "16 vCPU, 224 GiB RAM - High Performance Compute",
+                "value": "Standard_H16mr",
+              },
+            ],
+            "label": "High Performance Compute",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-general",
+        "name": "Instance type",
+        "tooltip": "The Azure VM instance type.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9_]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "128",
+        "available": Array [
+          "128",
+          "256",
+          "512",
+          "1024",
+          "2048",
+        ],
+        "cacheUserValueKey": "create.cluster.persistent.storage",
+        "id": "workerStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The Azure disk size for the VM.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "active": false,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for AZR generates correctly for cluster pools 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster pool details",
+    "type": "step",
+  },
+  Object {
+    "active": "Azure",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "azr",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster pool name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterPool[0].metadata.name",
+    "tooltip": "The unique name of your cluster pool. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "namespace",
+    "name": "Cluster pool namespace",
+    "placeholder": "Select or create a namespace",
+    "tooltip": "The namespace to create your cluster pool. Multiple cluster pools can be created in the same namespace.",
+    "type": "combobox",
+    "validation": Object {
+      "required": true,
+    },
+  },
+  Object {
+    "id": "size",
+    "initial": "1",
+    "name": "Cluster pool size",
+    "tooltip": "The desired number of clusters for the cluster pool.",
+    "type": "number",
+    "validation": Object {
+      "required": true,
+    },
+  },
+  Object {
+    "id": "runningCount",
+    "initial": "0",
+    "name": "Cluster pool running count",
+    "tooltip": "The desired number of clusters that can be claimed immediately for the cluster pool.",
+    "type": "number",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [
+      "Azure",
+    ],
+    "availableMap": Object {
+      "Azure": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "centralus",
+    "available": Array [
+      "australiaeast",
+      "brazilsouth",
+      "canadacentral",
+      "centralindia",
+      "centralus",
+      "eastasia",
+      "eastus",
+      "eastus2",
+      "francecentral",
+      "germanywestcentral",
+      "japaneast",
+      "koreacentral",
+      "northcentralus",
+      "northeurope",
+      "norwayeast",
+      "southafricanorth",
+      "southcentralus",
+      "southeastasia",
+      "switzerlandnorth",
+      "uaenorth",
+      "uksouth",
+      "westeurope",
+      "westus",
+      "westus2",
+      "westus3",
+      "australiacentral",
+      "australiasoutheast",
+      "canadaeast",
+      "japanwest",
+      "koreasouth",
+      "southindia",
+      "ukwest",
+      "westcentralus",
+      "westindia",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "reverse": "ClusterPool[0].metadata.labels.region",
+    "tooltip": "The name of the Azure region where your cluster is hosted. For example, centralus for Azure. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "Standard_D4s_v3",
+        "available": Array [
+          Object {
+            "description": "2 vCPU, 8 GiB RAM - General Purpose",
+            "value": "Standard_D2s_v3",
+          },
+          Object {
+            "description": "4 vCPU, 16 GiB RAM - General Purpose",
+            "value": "Standard_D4s_v3",
+          },
+          Object {
+            "description": "8 vCPU, 32 GiB RAM - General Purpose",
+            "value": "Standard_D8s_v3",
+          },
+          Object {
+            "description": "16 vCPU, 64 GiB RAM - General Purpose",
+            "value": "Standard_D16s_v3",
+          },
+          Object {
+            "description": "32 vCPU, 128 GiB RAM - General Purpose",
+            "value": "Standard_D32s_v3",
+          },
+          Object {
+            "description": "48 vCPU, 192 GiB RAM - General Purpose",
+            "value": "Standard_D48s_v3",
+          },
+          Object {
+            "description": "64 vCPU, 256 GiB RAM - General Purpose",
+            "value": "Standard_D64s_v3",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.master.type",
+        "id": "masterType",
+        "learnMore": "https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-general",
+        "name": "Instance type",
+        "tooltip": "The Azure VM instance type.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9_]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "active": "128",
+        "available": Array [
+          "128",
+          "256",
+          "512",
+          "1024",
+          "2048",
+        ],
+        "cacheUserValueKey": "create.cluster.master.root.storage",
+        "id": "masterRootStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The Azure disk size for the VM.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": Array [
+          "1",
+          "2",
+          "3",
+        ],
+        "available": Array [
+          "1",
+          "2",
+          "3",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.worker.zones",
+        "id": "workerZones",
+        "multiselect": true,
+        "name": "Zones",
+        "tooltip": "The availability zones where your worker pools are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "Standard_D2s_v3",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 2 GiB - General Purpose",
+                    "value": "Standard_A1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_A2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB - General Purpose",
+                    "value": "Standard_A4_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_A8_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_A2m_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_A4m_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_A8m_v2",
+                  },
+                ],
+                "label": "Av2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 0.5 GiB - General Purpose",
+                    "value": "Standard_B1ls1",
+                  },
+                  Object {
+                    "description": "1 vCPU, 1 GiB - General Purpose",
+                    "value": "Standard_B1s",
+                  },
+                  Object {
+                    "description": "1 vCPU, 2 GiB - General Purpose",
+                    "value": "Standard_B1ms  ",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_B2s",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_B2ms",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_B4ms",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_B8ms",
+                  },
+                  Object {
+                    "description": "12 vCPU, 48 GiB - General Purpose",
+                    "value": "Standard_B12ms",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_B16ms",
+                  },
+                  Object {
+                    "description": "20 vCPU, 80 GiB - General Purpose",
+                    "value": "Standard_B20ms",
+                  },
+                ],
+                "label": "B-series burstable virtual machine sizes",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_DC1s_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_DC2s_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_DC4s_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_DC8_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 3.5 GiB - General Purpose",
+                    "value": "Standard_D1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 7 GiB - General Purpose",
+                    "value": "Standard_D2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB - General Purpose",
+                    "value": "Standard_D3_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB - General Purpose",
+                    "value": "Standard_D4_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB - General Purpose",
+                    "value": "Standard_D5_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 3.5 GiB - General Purpose",
+                    "value": "Standard_DS1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 7 GiB - General Purpose",
+                    "value": "Standard_DS2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB - General Purpose",
+                    "value": "Standard_DS3_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB - General Purpose",
+                    "value": "Standard_DS4_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB - General Purpose",
+                    "value": "Standard_DS5_v2",
+                  },
+                ],
+                "label": "Dv2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64_v3",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4s_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8s_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16s_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64s_v3",
+                  },
+                ],
+                "label": "Dv3-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 50 GiB - General Purpose",
+                    "value": "Standard_D2a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 100 GiB - General Purpose",
+                    "value": "Standard_D4a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 200 GiB - General Purpose",
+                    "value": "Standard_D8a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32a_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64a_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 384 GiB - General Purpose",
+                    "value": "Standard_D96a_v4",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2as_v4",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8as_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16as_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32as_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48as_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64as_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 384 GiB - General Purpose",
+                    "value": "Standard_D96as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 75 GiB - General Purpose",
+                    "value": "Standard_D2d_v42",
+                  },
+                  Object {
+                    "description": "16 vCPU, 150 GiB - General Purpose",
+                    "value": "Standard_D4d_v44",
+                  },
+                  Object {
+                    "description": "32 vCPU, 300 GiB - General Purpose",
+                    "value": "Standard_D8d_v48",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16d_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32d_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48d_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64d_v4",
+                  },
+                ],
+                "label": "Dav4-series",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "4 vCPU, 8 GiB - Compute Optimized",
+                "value": "Standard_F4s_v2",
+              },
+              Object {
+                "description": "8 vCPU, 16 GiB - Compute Optimized",
+                "value": "Standard_F8s_v2",
+              },
+              Object {
+                "description": "16 vCPU, 32 GiB - Compute Optimized",
+                "value": "Standard_F16s_v2",
+              },
+              Object {
+                "description": "32 vCPU, 64 GiB - Compute Optimized",
+                "value": "Standard_F32s_v2",
+              },
+              Object {
+                "description": "48 vCPU, 96 GiB - Compute Optimized",
+                "value": "Standard_F48s_v2",
+              },
+              Object {
+                "description": "64 vCPU, 128 GiB - Compute Optimized",
+                "value": "Standard_F64s_v2",
+              },
+              Object {
+                "description": "72 vCPU, 144 GiB - Compute Optimized",
+                "value": "Standard_F72s_v21",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 14 GiB - Memory Optimized",
+                    "value": "Standard_D11_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 28 GiB - Memory Optimized",
+                    "value": "Standard_D12_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 56 GiB - Memory Optimized",
+                    "value": "Standard_D13_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 112 GiB - Memory Optimized",
+                    "value": "Standard_D14_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 20 GiB - Memory Optimized",
+                    "value": "Standard_D15_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 2 GiB - Memory Optimized",
+                    "value": "Standard_DS11_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 4 GiB - Memory Optimized",
+                    "value": "Standard_DS12_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 8 GiB - Memory Optimized",
+                    "value": "Standard_DS13_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_DS14_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 20 GiB - Memory Optimized",
+                    "value": "Standard_DS15_v2",
+                  },
+                ],
+                "label": "Dv2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_E2_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16_v3",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64i_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E2s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4s_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8s_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16s_v3",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20s_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64is_v3",
+                  },
+                ],
+                "label": "Ev3-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "16 vCPU, 50 GiB - Memory Optimized",
+                    "value": "Standard_E2a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 100 GiB - Memory Optimized",
+                    "value": "Standard_E4a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 200 GiB - Memory Optimized",
+                    "value": "Standard_E8a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16a_v4",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32a_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 512 GiB - Memory Optimized",
+                    "value": "Standard_E64a_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 672 GiB - Memory Optimized",
+                    "value": "Standard_E96a_v4",
+                  },
+                  Object {
+                    "description": "2 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_E2ds_v4",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4ds_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8ds_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16ds_v4",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20ds_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32ds_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48ds_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 504 GiB - Memory Optimized",
+                    "value": "Standard_E64ds_v4",
+                  },
+                ],
+                "label": "Eav4-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 218.75 GiB - Memory Optimized",
+                    "value": "Standard_M8ms",
+                  },
+                  Object {
+                    "description": "16 vCPU, 437.5 GiB - Memory Optimized",
+                    "value": "Standard_M16ms",
+                  },
+                  Object {
+                    "description": "32 vCPU, 192 GiB - Memory Optimized",
+                    "value": "Standard_M32ts",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_M32ls",
+                  },
+                  Object {
+                    "description": "32 vCPU, 875 GiB - Memory Optimized",
+                    "value": "Standard_M32ms",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1024 GiB - Memory Optimized",
+                    "value": "Standard_M64s",
+                  },
+                  Object {
+                    "description": "64 vCPU, 512 GiB - Memory Optimized",
+                    "value": "Standard_M64ls",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1792 GiB - Memory Optimized",
+                    "value": "Standard_M64ms",
+                  },
+                  Object {
+                    "description": "128 vCPU, 2048 GiB - Memory Optimized",
+                    "value": "Standard_M128s",
+                  },
+                  Object {
+                    "description": "128 vCPU, 3892 GiB - Memory Optimized",
+                    "value": "Standard_M128ms",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1024 GiB - Memory Optimized",
+                    "value": "Standard_M64",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1792 GiB - Memory Optimized",
+                    "value": "Standard_M64m",
+                  },
+                  Object {
+                    "description": "128 vCPU, 2048 GiB - Memory Optimized",
+                    "value": "Standard_M128",
+                  },
+                  Object {
+                    "description": "128 vCPU, 3892 GiB - Memory Optimized",
+                    "value": "Standard_M128m",
+                  },
+                ],
+                "label": "M-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "208 vCPU, 5700 GiB - Memory Optimized",
+                    "value": "Standard_M208ms_v21",
+                  },
+                  Object {
+                    "description": "208 vCPU, 2850 GiB - Memory Optimized",
+                    "value": "Standard_M208s_v21",
+                  },
+                  Object {
+                    "description": "416 vCPU, 11400 GiB - Memory Optimized",
+                    "value": "Standard_M416ms_v21",
+                  },
+                  Object {
+                    "description": "416 vCPU, 5700 GiB - Memory Optimized",
+                    "value": "Standard_M416s_v21",
+                  },
+                ],
+                "label": "Mv2-series",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "64 vCPU, 80 GiB - Storage Optimized",
+                "value": "Standard_L8s_v2",
+              },
+              Object {
+                "description": "16 vCPU, 128 GiB - Storage Optimized",
+                "value": "Standard_L16s_v2",
+              },
+              Object {
+                "description": "32 vCPU, 256 GiB - Storage Optimized",
+                "value": "Standard_L32s_v2",
+              },
+              Object {
+                "description": "48 vCPU, 384 GiB - Storage Optimized",
+                "value": "Standard_L48s_v2",
+              },
+              Object {
+                "description": "64 vCPU, 512 GiB - Storage Optimized",
+                "value": "Standard_L64s_v2",
+              },
+              Object {
+                "description": "80 vCPU, 640 GiB - Storage Optimized",
+                "value": "Standard_L80s_v26",
+              },
+            ],
+            "label": "Storage Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 56 GiB, 12 GPUs, 24 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, 24 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, 4 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, 4 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24r",
+                  },
+                  Object {
+                    "description": "6 vCPU, 112 GiB, 16 GPUs, 12 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6s_v2",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, 2 GPUs, 32 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12s_v2",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, 4 GPUs, 64 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24s_v2",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24rs_v2",
+                  },
+                  Object {
+                    "description": "6 vCPU, 112 GiB, 16 GPUs, 12 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6s_v3",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, 2 GPUs, 32 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, 4 GPUs, 64 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24rs_v3",
+                  },
+                ],
+                "label": "NC-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 112 GiB, GPUs,24 GPU 12GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND6s",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, GPUs,48 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND12s",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs,96 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND24s",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND24rs",
+                  },
+                ],
+                "label": "ND-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 56 GiB, GPUs, 8 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV6",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, GPUs,16 GPU 48GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV12",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, GPUs,4 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV24",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, GPUs,8 GPU 12GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV12s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, GPUs,16 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV24s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 448 GiB, GPUs,4 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV48s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB, GPUs,2 GPU 4 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV4as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB, GPUs,4  GPU 8 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV8as_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB, GPUs,8  GPU 16 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV16as_v4",
+                  },
+                ],
+                "label": "NV-series",
+              },
+            ],
+            "label": "GPU Accelerated Compute",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "8 vCPU, 56 GiB RAM - High Performance Compute",
+                "value": "Standard_H8",
+              },
+              Object {
+                "description": "16 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H16",
+              },
+              Object {
+                "description": "8 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H8m",
+              },
+              Object {
+                "description": "16 vCPU, 224 GiB RAM - High Performance Compute",
+                "value": "Standard_H16m",
+              },
+              Object {
+                "description": "16 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H16r",
+              },
+              Object {
+                "description": "16 vCPU, 224 GiB RAM - High Performance Compute",
+                "value": "Standard_H16mr",
+              },
+            ],
+            "label": "High Performance Compute",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-general",
+        "name": "Instance type",
+        "tooltip": "The Azure VM instance type.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9_]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "128",
+        "available": Array [
+          "128",
+          "256",
+          "512",
+          "1024",
+          "2048",
+        ],
+        "cacheUserValueKey": "create.cluster.persistent.storage",
+        "id": "workerStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The Azure disk size for the VM.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+]
+`;
+
+exports[`Cluster creation control data for AZR generates correctly with SNO enabled 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "Azure",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "azr",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "Azure",
+    ],
+    "availableMap": Object {
+      "Azure": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "centralus",
+    "available": Array [
+      "australiaeast",
+      "brazilsouth",
+      "canadacentral",
+      "centralindia",
+      "centralus",
+      "eastasia",
+      "eastus",
+      "eastus2",
+      "francecentral",
+      "germanywestcentral",
+      "japaneast",
+      "koreacentral",
+      "northcentralus",
+      "northeurope",
+      "norwayeast",
+      "southafricanorth",
+      "southcentralus",
+      "southeastasia",
+      "switzerlandnorth",
+      "uaenorth",
+      "uksouth",
+      "westeurope",
+      "westus",
+      "westus2",
+      "westus3",
+      "australiacentral",
+      "australiasoutheast",
+      "canadaeast",
+      "japanwest",
+      "koreasouth",
+      "southindia",
+      "ukwest",
+      "westcentralus",
+      "westindia",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The name of the Azure region where your cluster is hosted. For example, centralus for Azure. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster unless single node is enabled, in which case there will only be one control plane node.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "Standard_D4s_v3",
+        "available": Array [
+          Object {
+            "description": "2 vCPU, 8 GiB RAM - General Purpose",
+            "value": "Standard_D2s_v3",
+          },
+          Object {
+            "description": "4 vCPU, 16 GiB RAM - General Purpose",
+            "value": "Standard_D4s_v3",
+          },
+          Object {
+            "description": "8 vCPU, 32 GiB RAM - General Purpose",
+            "value": "Standard_D8s_v3",
+          },
+          Object {
+            "description": "16 vCPU, 64 GiB RAM - General Purpose",
+            "value": "Standard_D16s_v3",
+          },
+          Object {
+            "description": "32 vCPU, 128 GiB RAM - General Purpose",
+            "value": "Standard_D32s_v3",
+          },
+          Object {
+            "description": "48 vCPU, 192 GiB RAM - General Purpose",
+            "value": "Standard_D48s_v3",
+          },
+          Object {
+            "description": "64 vCPU, 256 GiB RAM - General Purpose",
+            "value": "Standard_D64s_v3",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.master.type",
+        "id": "masterType",
+        "learnMore": "https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-general",
+        "name": "Instance type",
+        "tooltip": "The Azure VM instance type.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9_]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "active": "128",
+        "available": Array [
+          "128",
+          "256",
+          "512",
+          "1024",
+          "2048",
+        ],
+        "cacheUserValueKey": "create.cluster.master.root.storage",
+        "id": "masterRootStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The Azure disk size for the VM.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": Array [
+          "1",
+          "2",
+          "3",
+        ],
+        "available": Array [
+          "1",
+          "2",
+          "3",
+        ],
+        "cacheUserValueKey": "create.cluster.aws.worker.zones",
+        "id": "workerZones",
+        "multiselect": true,
+        "name": "Zones",
+        "tooltip": "The availability zones where your worker pools are located. You can select more than one zone to meet availability or user proximity needs. If you do not select any zones, all available zones are used.",
+        "type": "multiselect",
+        "validation": Object {
+          "notification": "Value must be alphanumeric.",
+          "required": false,
+          "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+        },
+      },
+      Object {
+        "active": "Standard_D2s_v3",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 2 GiB - General Purpose",
+                    "value": "Standard_A1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_A2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 8 GiB - General Purpose",
+                    "value": "Standard_A4_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_A8_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_A2m_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_A4m_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_A8m_v2",
+                  },
+                ],
+                "label": "Av2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 0.5 GiB - General Purpose",
+                    "value": "Standard_B1ls1",
+                  },
+                  Object {
+                    "description": "1 vCPU, 1 GiB - General Purpose",
+                    "value": "Standard_B1s",
+                  },
+                  Object {
+                    "description": "1 vCPU, 2 GiB - General Purpose",
+                    "value": "Standard_B1ms  ",
+                  },
+                  Object {
+                    "description": "2 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_B2s",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_B2ms",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_B4ms",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_B8ms",
+                  },
+                  Object {
+                    "description": "12 vCPU, 48 GiB - General Purpose",
+                    "value": "Standard_B12ms",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_B16ms",
+                  },
+                  Object {
+                    "description": "20 vCPU, 80 GiB - General Purpose",
+                    "value": "Standard_B20ms",
+                  },
+                ],
+                "label": "B-series burstable virtual machine sizes",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "1 vCPU, 4 GiB - General Purpose",
+                    "value": "Standard_DC1s_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_DC2s_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_DC4s_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_DC8_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 3.5 GiB - General Purpose",
+                    "value": "Standard_D1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 7 GiB - General Purpose",
+                    "value": "Standard_D2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB - General Purpose",
+                    "value": "Standard_D3_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB - General Purpose",
+                    "value": "Standard_D4_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB - General Purpose",
+                    "value": "Standard_D5_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 3.5 GiB - General Purpose",
+                    "value": "Standard_DS1_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 7 GiB - General Purpose",
+                    "value": "Standard_DS2_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB - General Purpose",
+                    "value": "Standard_DS3_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB - General Purpose",
+                    "value": "Standard_DS4_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB - General Purpose",
+                    "value": "Standard_DS5_v2",
+                  },
+                ],
+                "label": "Dv2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64_v3",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4s_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8s_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16s_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64s_v3",
+                  },
+                ],
+                "label": "Dv3-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 50 GiB - General Purpose",
+                    "value": "Standard_D2a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 100 GiB - General Purpose",
+                    "value": "Standard_D4a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 200 GiB - General Purpose",
+                    "value": "Standard_D8a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32a_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64a_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 384 GiB - General Purpose",
+                    "value": "Standard_D96a_v4",
+                  },
+                  Object {
+                    "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                    "value": "Standard_D2as_v4",
+                  },
+                  Object {
+                    "description": "4 vCPU, 16 GiB - General Purpose",
+                    "value": "Standard_D4as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 32 GiB - General Purpose",
+                    "value": "Standard_D8as_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16as_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32as_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48as_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64as_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 384 GiB - General Purpose",
+                    "value": "Standard_D96as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 75 GiB - General Purpose",
+                    "value": "Standard_D2d_v42",
+                  },
+                  Object {
+                    "description": "16 vCPU, 150 GiB - General Purpose",
+                    "value": "Standard_D4d_v44",
+                  },
+                  Object {
+                    "description": "32 vCPU, 300 GiB - General Purpose",
+                    "value": "Standard_D8d_v48",
+                  },
+                  Object {
+                    "description": "16 vCPU, 64 GiB - General Purpose",
+                    "value": "Standard_D16d_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 128 GiB - General Purpose",
+                    "value": "Standard_D32d_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 192 GiB - General Purpose",
+                    "value": "Standard_D48d_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 256 GiB - General Purpose",
+                    "value": "Standard_D64d_v4",
+                  },
+                ],
+                "label": "Dav4-series",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "4 vCPU, 8 GiB - Compute Optimized",
+                "value": "Standard_F4s_v2",
+              },
+              Object {
+                "description": "8 vCPU, 16 GiB - Compute Optimized",
+                "value": "Standard_F8s_v2",
+              },
+              Object {
+                "description": "16 vCPU, 32 GiB - Compute Optimized",
+                "value": "Standard_F16s_v2",
+              },
+              Object {
+                "description": "32 vCPU, 64 GiB - Compute Optimized",
+                "value": "Standard_F32s_v2",
+              },
+              Object {
+                "description": "48 vCPU, 96 GiB - Compute Optimized",
+                "value": "Standard_F48s_v2",
+              },
+              Object {
+                "description": "64 vCPU, 128 GiB - Compute Optimized",
+                "value": "Standard_F64s_v2",
+              },
+              Object {
+                "description": "72 vCPU, 144 GiB - Compute Optimized",
+                "value": "Standard_F72s_v21",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 14 GiB - Memory Optimized",
+                    "value": "Standard_D11_v2",
+                  },
+                  Object {
+                    "description": "4 vCPU, 28 GiB - Memory Optimized",
+                    "value": "Standard_D12_v2",
+                  },
+                  Object {
+                    "description": "8 vCPU, 56 GiB - Memory Optimized",
+                    "value": "Standard_D13_v2",
+                  },
+                  Object {
+                    "description": "16 vCPU, 112 GiB - Memory Optimized",
+                    "value": "Standard_D14_v2",
+                  },
+                  Object {
+                    "description": "1 vCPU, 20 GiB - Memory Optimized",
+                    "value": "Standard_D15_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 2 GiB - Memory Optimized",
+                    "value": "Standard_DS11_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 4 GiB - Memory Optimized",
+                    "value": "Standard_DS12_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 8 GiB - Memory Optimized",
+                    "value": "Standard_DS13_v2",
+                  },
+                  Object {
+                    "description": "3 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_DS14_v2",
+                  },
+                  Object {
+                    "description": "2 vCPU, 20 GiB - Memory Optimized",
+                    "value": "Standard_DS15_v2",
+                  },
+                ],
+                "label": "Dv2-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "2 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_E2_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16_v3",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64i_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E2s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4s_v3",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8s_v3",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16s_v3",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20s_v3",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64s_v3",
+                  },
+                  Object {
+                    "description": "64 vCPU, 432 GiB - Memory Optimized",
+                    "value": "Standard_E64is_v3",
+                  },
+                ],
+                "label": "Ev3-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "16 vCPU, 50 GiB - Memory Optimized",
+                    "value": "Standard_E2a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 100 GiB - Memory Optimized",
+                    "value": "Standard_E4a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 200 GiB - Memory Optimized",
+                    "value": "Standard_E8a_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16a_v4",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20a_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32a_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48a_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 512 GiB - Memory Optimized",
+                    "value": "Standard_E64a_v4",
+                  },
+                  Object {
+                    "description": "96 vCPU, 672 GiB - Memory Optimized",
+                    "value": "Standard_E96a_v4",
+                  },
+                  Object {
+                    "description": "2 vCPU, 16 GiB - Memory Optimized",
+                    "value": "Standard_E2ds_v4",
+                  },
+                  Object {
+                    "description": "4 vCPU, 32 GiB - Memory Optimized",
+                    "value": "Standard_E4ds_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 64 GiB - Memory Optimized",
+                    "value": "Standard_E8ds_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 128 GiB - Memory Optimized",
+                    "value": "Standard_E16ds_v4",
+                  },
+                  Object {
+                    "description": "20 vCPU, 160 GiB - Memory Optimized",
+                    "value": "Standard_E20ds_v4",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_E32ds_v4",
+                  },
+                  Object {
+                    "description": "48 vCPU, 384 GiB - Memory Optimized",
+                    "value": "Standard_E48ds_v4",
+                  },
+                  Object {
+                    "description": "64 vCPU, 504 GiB - Memory Optimized",
+                    "value": "Standard_E64ds_v4",
+                  },
+                ],
+                "label": "Eav4-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "8 vCPU, 218.75 GiB - Memory Optimized",
+                    "value": "Standard_M8ms",
+                  },
+                  Object {
+                    "description": "16 vCPU, 437.5 GiB - Memory Optimized",
+                    "value": "Standard_M16ms",
+                  },
+                  Object {
+                    "description": "32 vCPU, 192 GiB - Memory Optimized",
+                    "value": "Standard_M32ts",
+                  },
+                  Object {
+                    "description": "32 vCPU, 256 GiB - Memory Optimized",
+                    "value": "Standard_M32ls",
+                  },
+                  Object {
+                    "description": "32 vCPU, 875 GiB - Memory Optimized",
+                    "value": "Standard_M32ms",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1024 GiB - Memory Optimized",
+                    "value": "Standard_M64s",
+                  },
+                  Object {
+                    "description": "64 vCPU, 512 GiB - Memory Optimized",
+                    "value": "Standard_M64ls",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1792 GiB - Memory Optimized",
+                    "value": "Standard_M64ms",
+                  },
+                  Object {
+                    "description": "128 vCPU, 2048 GiB - Memory Optimized",
+                    "value": "Standard_M128s",
+                  },
+                  Object {
+                    "description": "128 vCPU, 3892 GiB - Memory Optimized",
+                    "value": "Standard_M128ms",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1024 GiB - Memory Optimized",
+                    "value": "Standard_M64",
+                  },
+                  Object {
+                    "description": "64 vCPU, 1792 GiB - Memory Optimized",
+                    "value": "Standard_M64m",
+                  },
+                  Object {
+                    "description": "128 vCPU, 2048 GiB - Memory Optimized",
+                    "value": "Standard_M128",
+                  },
+                  Object {
+                    "description": "128 vCPU, 3892 GiB - Memory Optimized",
+                    "value": "Standard_M128m",
+                  },
+                ],
+                "label": "M-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "208 vCPU, 5700 GiB - Memory Optimized",
+                    "value": "Standard_M208ms_v21",
+                  },
+                  Object {
+                    "description": "208 vCPU, 2850 GiB - Memory Optimized",
+                    "value": "Standard_M208s_v21",
+                  },
+                  Object {
+                    "description": "416 vCPU, 11400 GiB - Memory Optimized",
+                    "value": "Standard_M416ms_v21",
+                  },
+                  Object {
+                    "description": "416 vCPU, 5700 GiB - Memory Optimized",
+                    "value": "Standard_M416s_v21",
+                  },
+                ],
+                "label": "Mv2-series",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "64 vCPU, 80 GiB - Storage Optimized",
+                "value": "Standard_L8s_v2",
+              },
+              Object {
+                "description": "16 vCPU, 128 GiB - Storage Optimized",
+                "value": "Standard_L16s_v2",
+              },
+              Object {
+                "description": "32 vCPU, 256 GiB - Storage Optimized",
+                "value": "Standard_L32s_v2",
+              },
+              Object {
+                "description": "48 vCPU, 384 GiB - Storage Optimized",
+                "value": "Standard_L48s_v2",
+              },
+              Object {
+                "description": "64 vCPU, 512 GiB - Storage Optimized",
+                "value": "Standard_L64s_v2",
+              },
+              Object {
+                "description": "80 vCPU, 640 GiB - Storage Optimized",
+                "value": "Standard_L80s_v26",
+              },
+            ],
+            "label": "Storage Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 56 GiB, 12 GPUs, 24 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, 24 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, 4 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, 4 GPUs, 48 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24r",
+                  },
+                  Object {
+                    "description": "6 vCPU, 112 GiB, 16 GPUs, 12 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6s_v2",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, 2 GPUs, 32 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12s_v2",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, 4 GPUs, 64 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24s_v2",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24rs_v2",
+                  },
+                  Object {
+                    "description": "6 vCPU, 112 GiB, 16 GPUs, 12 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC6s_v3",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, 2 GPUs, 32 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC12s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, 4 GPUs, 64 GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_NC24rs_v3",
+                  },
+                ],
+                "label": "NC-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 112 GiB, GPUs,24 GPU 12GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND6s",
+                  },
+                  Object {
+                    "description": "12 vCPU, 224 GiB, GPUs,48 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND12s",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs,96 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND24s",
+                  },
+                  Object {
+                    "description": "24 vCPU, 448 GiB, GPUs, GPU GiB - GPU Accelerated Compute",
+                    "value": "Standard_ND24rs",
+                  },
+                ],
+                "label": "ND-series",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "description": "6 vCPU, 56 GiB, GPUs, 8 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV6",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, GPUs,16 GPU 48GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV12",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, GPUs,4 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV24",
+                  },
+                  Object {
+                    "description": "12 vCPU, 112 GiB, GPUs,8 GPU 12GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV12s_v3",
+                  },
+                  Object {
+                    "description": "24 vCPU, 224 GiB, GPUs,16 GPU 24GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV24s_v3",
+                  },
+                  Object {
+                    "description": "48 vCPU, 448 GiB, GPUs,4 GPU 32GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV48s_v3",
+                  },
+                  Object {
+                    "description": "4 vCPU, 14 GiB, GPUs,2 GPU 4 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV4as_v4",
+                  },
+                  Object {
+                    "description": "8 vCPU, 28 GiB, GPUs,4  GPU 8 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV8as_v4",
+                  },
+                  Object {
+                    "description": "16 vCPU, 56 GiB, GPUs,8  GPU 16 GiB - GPU Accelerated Compute",
+                    "value": "Standard_NV16as_v4",
+                  },
+                ],
+                "label": "NV-series",
+              },
+            ],
+            "label": "GPU Accelerated Compute",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "8 vCPU, 56 GiB RAM - High Performance Compute",
+                "value": "Standard_H8",
+              },
+              Object {
+                "description": "16 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H16",
+              },
+              Object {
+                "description": "8 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H8m",
+              },
+              Object {
+                "description": "16 vCPU, 224 GiB RAM - High Performance Compute",
+                "value": "Standard_H16m",
+              },
+              Object {
+                "description": "16 vCPU, 112 GiB RAM - High Performance Compute",
+                "value": "Standard_H16r",
+              },
+              Object {
+                "description": "16 vCPU, 224 GiB RAM - High Performance Compute",
+                "value": "Standard_H16mr",
+              },
+            ],
+            "label": "High Performance Compute",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://docs.microsoft.com/en-us/azure/virtual-machines/sizes-general",
+        "name": "Instance type",
+        "tooltip": "The Azure VM instance type.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9_]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "128",
+        "available": Array [
+          "128",
+          "256",
+          "512",
+          "1024",
+          "2048",
+        ],
+        "cacheUserValueKey": "create.cluster.persistent.storage",
+        "id": "workerStorage",
+        "name": "Root storage (GiB)",
+        "tooltip": "The Azure disk size for the VM.",
+        "type": "combobox",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAZR.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAZR.test.js.snap
@@ -1297,7 +1297,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -2751,7 +2751,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -4225,7 +4225,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -5591,7 +5591,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataCIM.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataCIM.test.js.snap
@@ -1,0 +1,337 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cluster creation control data for CIM generates correctly 1`] = `
+Array [
+  Object {
+    "id": "aiDetailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "Host inventory",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "active": "Standalone",
+    "id": "controlplane",
+    "name": "Control plane type",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "placeholder": "Select a credential",
+    "providerId": Array [
+      "hybrid",
+      "hostinventory",
+    ],
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": false,
+    },
+  },
+  Object {
+    "additionalProps": Object {
+      "promptSshPublicKey": false,
+    },
+    "component": <DetailsForm />,
+    "encodeValues": Array [
+      "pullSecret",
+    ],
+    "id": "ai",
+    "mustValidate": true,
+    "providerId": "ai",
+    "type": "custom",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "comment": "Ensure these settings are correct. The saved cluster draft will be used to determine the available network resources. Therefore after you press Save you will not be able to change these cluster settings.",
+    "disableEditorOnSuccess": true,
+    "disablePreviousControlsOnSuccess": true,
+    "id": "reviewSave",
+    "nextButtonLabel": "Save",
+    "title": "Review and save",
+    "type": "review",
+  },
+  Object {
+    "disabled": true,
+    "id": "aiHostsStep",
+    "title": "Hosts",
+    "type": "step",
+  },
+  Object {
+    "disabled": true,
+    "id": "aiNetworkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "component": <Warning />,
+    "id": "warning",
+    "type": "custom",
+  },
+]
+`;
+
+exports[`Cluster creation control data for CIM generates correctly for MCE 1`] = `
+Array [
+  Object {
+    "id": "aiDetailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "Host inventory",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "active": "Standalone",
+    "id": "controlplane",
+    "name": "Control plane type",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "placeholder": "Select a credential",
+    "providerId": Array [
+      "hybrid",
+      "hostinventory",
+    ],
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": false,
+    },
+  },
+  Object {
+    "additionalProps": Object {
+      "promptSshPublicKey": false,
+    },
+    "component": <DetailsForm />,
+    "encodeValues": Array [
+      "pullSecret",
+    ],
+    "id": "ai",
+    "mustValidate": true,
+    "providerId": "ai",
+    "type": "custom",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "comment": "Ensure these settings are correct. The saved cluster draft will be used to determine the available network resources. Therefore after you press Save you will not be able to change these cluster settings.",
+    "disableEditorOnSuccess": true,
+    "disablePreviousControlsOnSuccess": true,
+    "id": "reviewSave",
+    "nextButtonLabel": "Save",
+    "title": "Review and save",
+    "type": "review",
+  },
+  Object {
+    "disabled": true,
+    "id": "aiHostsStep",
+    "title": "Hosts",
+    "type": "step",
+  },
+  Object {
+    "disabled": true,
+    "id": "aiNetworkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": false,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "component": <Warning />,
+    "id": "warning",
+    "type": "custom",
+  },
+]
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataGCP.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataGCP.test.js.snap
@@ -911,7 +911,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -1979,7 +1979,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -3067,7 +3067,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -4047,7 +4047,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataGCP.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataGCP.test.js.snap
@@ -1,0 +1,4205 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cluster creation control data for GCP generates correctly 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "GCP",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "gcp",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "GCP",
+    ],
+    "availableMap": Object {
+      "GCP": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "us-east1",
+    "available": Array [
+      "asia-east1",
+      "asia-east2",
+      "asia-northeast1",
+      "asia-northeast2",
+      "asia-northeast3",
+      "asia-south1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "europe-west6",
+      "northamerica-northeast1",
+      "southamerica-east1",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-west1",
+      "us-west2",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The GCP region where you deploy your cluster. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "n1-standard-4",
+        "available": Array [
+          Object {
+            "description": "n1-standard-4 4 vCPU - General Purpose",
+            "value": "n1-standard-4",
+          },
+          Object {
+            "description": "n1-standard-8 8 vCPU - General Purpose",
+            "value": "n1-standard-8",
+          },
+          Object {
+            "description": "n1-standard-16 16 vCPU - General Purpose",
+            "value": "n1-standard-16",
+          },
+          Object {
+            "description": "n1-standard-32 32 vCPU - General Purpose",
+            "value": "n1-standard-32",
+          },
+          Object {
+            "description": "n1-standard-64 64 vCPU - General Purpose",
+            "value": "n1-standard-64",
+          },
+          Object {
+            "description": "n1-standard-96 96 vCPU - General Purpose",
+            "value": "n1-standard-96",
+          },
+        ],
+        "id": "masterType",
+        "learnMore": "https://cloud.google.com/compute/docs/machine-types",
+        "name": "Instance type",
+        "tooltip": "The GCP machine type.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": "n1-standard-4",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "e2-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "e2-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "e2-standard-16",
+                      },
+                    ],
+                    "label": "E2 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "e2-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "e2-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "e2-highmem-16",
+                      },
+                    ],
+                    "label": "E2 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-16",
+                      },
+                    ],
+                    "label": "E2 high-CPU machine types",
+                  },
+                ],
+                "label": "E2 machine types",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2-standard-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "n2-standard-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2-standard-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 320 GiB RAM - General Purpose",
+                        "value": "n2-standard-80",
+                      },
+                    ],
+                    "label": "N2 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2-highmem-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2-highmem-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2-highmem-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 640 GiB RAM - General Purpose",
+                        "value": "n2-highmem-80",
+                      },
+                    ],
+                    "label": "N2 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 48 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 80 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-80",
+                      },
+                    ],
+                    "label": "N2 high-CPU machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2d-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-standard-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "n2d-standard-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2d-standard-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 320 GiB RAM - General Purpose",
+                        "value": "n2d-standard-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2d-standard-96",
+                      },
+                      Object {
+                        "description": "128 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2d-standard-128",
+                      },
+                      Object {
+                        "description": "224 vCPU, 896 GiB RAM - General Purpose",
+                        "value": "n2d-standard-224",
+                      },
+                    ],
+                    "label": "N2D standard machine types with SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 640 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-96",
+                      },
+                    ],
+                    "label": "N2D high-memory machine types with SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 48 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 80 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 96 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-96",
+                      },
+                      Object {
+                        "description": "128 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-128",
+                      },
+                      Object {
+                        "description": "224 vCPU, 224 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-224",
+                      },
+                    ],
+                    "label": "N2D high-CPU machine types with SSD",
+                  },
+                ],
+                "label": "N2 machine types",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "1 vCPU, 3.75 GiB RAM - General Purpose",
+                        "value": "n1-standard-1",
+                      },
+                      Object {
+                        "description": "2 vCPU, 7.50 GiB RAM - General Purpose",
+                        "value": "n1-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 15 GiB RAM - General Purpose",
+                        "value": "n1-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 30 GiB RAM - General Purpose",
+                        "value": "n1-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 60 GiB RAM - General Purpose",
+                        "value": "n1-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 120 GiB RAM - General Purpose",
+                        "value": "n1-standard-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 240 GiB RAM - General Purpose",
+                        "value": "n1-standard-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 360 GiB RAM - General Purpose",
+                        "value": "n1-standard-96",
+                      },
+                    ],
+                    "label": "N1 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 13 GiB RAM - General Purpose",
+                        "value": "n1-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 26 GiB RAM - General Purpose",
+                        "value": "n1-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 52 GiB RAM - General Purpose",
+                        "value": "n1-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 104 GiB RAM - General Purpose",
+                        "value": "n1-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 208 GiB RAM - General Purpose",
+                        "value": "n1-highmem-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 416 GiB RAM - General Purpose",
+                        "value": "n1-highmem-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 624 GiB RAM - General Purpose",
+                        "value": "n1-highmem-96",
+                      },
+                    ],
+                    "label": "N1 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 1.80 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 3.60 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 7.20 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 14.4 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 28.8 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 57.6 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 86.4 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-96",
+                      },
+                    ],
+                    "label": "N1 high-CPU machine types",
+                  },
+                ],
+                "label": "N1 machine types",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "4 vCPU, 16 GiB RAM - Compute Optimized",
+                "value": "c2-standard-4",
+              },
+              Object {
+                "description": "8 vCPU, 32 GiB RAM - Compute Optimized",
+                "value": "c2-standard-8",
+              },
+              Object {
+                "description": "16 vCPU, 64 GiB RAM - Compute Optimized",
+                "value": "c2-standard-16",
+              },
+              Object {
+                "description": "30 vCPU, 120 GiB RAM - Compute Optimized",
+                "value": "c2-standard-30",
+              },
+              Object {
+                "description": "60 vCPU, 240 GiB RAM - Compute Optimized",
+                "value": "c2-standard-60",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "208 vCPU, 5888 GiB RAM - Memory Optimized",
+                "value": "m2-ultramem-2084",
+              },
+              Object {
+                "description": "416 vCPU, 11,776 GiB RAM - Memory Optimized",
+                "value": "m2-ultramem-4164",
+              },
+              Object {
+                "description": "40 vCPU, 961 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-40",
+              },
+              Object {
+                "description": "80 vCPU, 1922 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-80",
+              },
+              Object {
+                "description": "160 vCPU, 3844 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-160",
+              },
+              Object {
+                "description": "96 vCPU, 1433.6 GiB RAM - Memory Optimized",
+                "value": "m1-megamem-96",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://cloud.google.com/compute/docs/machine-types",
+        "name": "Instance type",
+        "tooltip": "The GCP machine type.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for GCP generates correctly for MCE 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "GCP",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "gcp",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "GCP",
+    ],
+    "availableMap": Object {
+      "GCP": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "us-east1",
+    "available": Array [
+      "asia-east1",
+      "asia-east2",
+      "asia-northeast1",
+      "asia-northeast2",
+      "asia-northeast3",
+      "asia-south1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "europe-west6",
+      "northamerica-northeast1",
+      "southamerica-east1",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-west1",
+      "us-west2",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The GCP region where you deploy your cluster. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "n1-standard-4",
+        "available": Array [
+          Object {
+            "description": "n1-standard-4 4 vCPU - General Purpose",
+            "value": "n1-standard-4",
+          },
+          Object {
+            "description": "n1-standard-8 8 vCPU - General Purpose",
+            "value": "n1-standard-8",
+          },
+          Object {
+            "description": "n1-standard-16 16 vCPU - General Purpose",
+            "value": "n1-standard-16",
+          },
+          Object {
+            "description": "n1-standard-32 32 vCPU - General Purpose",
+            "value": "n1-standard-32",
+          },
+          Object {
+            "description": "n1-standard-64 64 vCPU - General Purpose",
+            "value": "n1-standard-64",
+          },
+          Object {
+            "description": "n1-standard-96 96 vCPU - General Purpose",
+            "value": "n1-standard-96",
+          },
+        ],
+        "id": "masterType",
+        "learnMore": "https://cloud.google.com/compute/docs/machine-types",
+        "name": "Instance type",
+        "tooltip": "The GCP machine type.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": "n1-standard-4",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "e2-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "e2-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "e2-standard-16",
+                      },
+                    ],
+                    "label": "E2 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "e2-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "e2-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "e2-highmem-16",
+                      },
+                    ],
+                    "label": "E2 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-16",
+                      },
+                    ],
+                    "label": "E2 high-CPU machine types",
+                  },
+                ],
+                "label": "E2 machine types",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2-standard-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "n2-standard-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2-standard-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 320 GiB RAM - General Purpose",
+                        "value": "n2-standard-80",
+                      },
+                    ],
+                    "label": "N2 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2-highmem-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2-highmem-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2-highmem-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 640 GiB RAM - General Purpose",
+                        "value": "n2-highmem-80",
+                      },
+                    ],
+                    "label": "N2 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 48 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 80 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-80",
+                      },
+                    ],
+                    "label": "N2 high-CPU machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2d-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-standard-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "n2d-standard-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2d-standard-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 320 GiB RAM - General Purpose",
+                        "value": "n2d-standard-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2d-standard-96",
+                      },
+                      Object {
+                        "description": "128 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2d-standard-128",
+                      },
+                      Object {
+                        "description": "224 vCPU, 896 GiB RAM - General Purpose",
+                        "value": "n2d-standard-224",
+                      },
+                    ],
+                    "label": "N2D standard machine types with SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 640 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-96",
+                      },
+                    ],
+                    "label": "N2D high-memory machine types with SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 48 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 80 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 96 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-96",
+                      },
+                      Object {
+                        "description": "128 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-128",
+                      },
+                      Object {
+                        "description": "224 vCPU, 224 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-224",
+                      },
+                    ],
+                    "label": "N2D high-CPU machine types with SSD",
+                  },
+                ],
+                "label": "N2 machine types",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "1 vCPU, 3.75 GiB RAM - General Purpose",
+                        "value": "n1-standard-1",
+                      },
+                      Object {
+                        "description": "2 vCPU, 7.50 GiB RAM - General Purpose",
+                        "value": "n1-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 15 GiB RAM - General Purpose",
+                        "value": "n1-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 30 GiB RAM - General Purpose",
+                        "value": "n1-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 60 GiB RAM - General Purpose",
+                        "value": "n1-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 120 GiB RAM - General Purpose",
+                        "value": "n1-standard-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 240 GiB RAM - General Purpose",
+                        "value": "n1-standard-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 360 GiB RAM - General Purpose",
+                        "value": "n1-standard-96",
+                      },
+                    ],
+                    "label": "N1 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 13 GiB RAM - General Purpose",
+                        "value": "n1-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 26 GiB RAM - General Purpose",
+                        "value": "n1-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 52 GiB RAM - General Purpose",
+                        "value": "n1-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 104 GiB RAM - General Purpose",
+                        "value": "n1-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 208 GiB RAM - General Purpose",
+                        "value": "n1-highmem-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 416 GiB RAM - General Purpose",
+                        "value": "n1-highmem-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 624 GiB RAM - General Purpose",
+                        "value": "n1-highmem-96",
+                      },
+                    ],
+                    "label": "N1 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 1.80 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 3.60 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 7.20 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 14.4 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 28.8 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 57.6 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 86.4 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-96",
+                      },
+                    ],
+                    "label": "N1 high-CPU machine types",
+                  },
+                ],
+                "label": "N1 machine types",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "4 vCPU, 16 GiB RAM - Compute Optimized",
+                "value": "c2-standard-4",
+              },
+              Object {
+                "description": "8 vCPU, 32 GiB RAM - Compute Optimized",
+                "value": "c2-standard-8",
+              },
+              Object {
+                "description": "16 vCPU, 64 GiB RAM - Compute Optimized",
+                "value": "c2-standard-16",
+              },
+              Object {
+                "description": "30 vCPU, 120 GiB RAM - Compute Optimized",
+                "value": "c2-standard-30",
+              },
+              Object {
+                "description": "60 vCPU, 240 GiB RAM - Compute Optimized",
+                "value": "c2-standard-60",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "208 vCPU, 5888 GiB RAM - Memory Optimized",
+                "value": "m2-ultramem-2084",
+              },
+              Object {
+                "description": "416 vCPU, 11,776 GiB RAM - Memory Optimized",
+                "value": "m2-ultramem-4164",
+              },
+              Object {
+                "description": "40 vCPU, 961 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-40",
+              },
+              Object {
+                "description": "80 vCPU, 1922 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-80",
+              },
+              Object {
+                "description": "160 vCPU, 3844 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-160",
+              },
+              Object {
+                "description": "96 vCPU, 1433.6 GiB RAM - Memory Optimized",
+                "value": "m1-megamem-96",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://cloud.google.com/compute/docs/machine-types",
+        "name": "Instance type",
+        "tooltip": "The GCP machine type.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "active": false,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for GCP generates correctly for cluster pools 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster pool details",
+    "type": "step",
+  },
+  Object {
+    "active": "GCP",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "gcp",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster pool name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterPool[0].metadata.name",
+    "tooltip": "The unique name of your cluster pool. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "namespace",
+    "name": "Cluster pool namespace",
+    "placeholder": "Select or create a namespace",
+    "tooltip": "The namespace to create your cluster pool. Multiple cluster pools can be created in the same namespace.",
+    "type": "combobox",
+    "validation": Object {
+      "required": true,
+    },
+  },
+  Object {
+    "id": "size",
+    "initial": "1",
+    "name": "Cluster pool size",
+    "tooltip": "The desired number of clusters for the cluster pool.",
+    "type": "number",
+    "validation": Object {
+      "required": true,
+    },
+  },
+  Object {
+    "id": "runningCount",
+    "initial": "0",
+    "name": "Cluster pool running count",
+    "tooltip": "The desired number of clusters that can be claimed immediately for the cluster pool.",
+    "type": "number",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [
+      "GCP",
+    ],
+    "availableMap": Object {
+      "GCP": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "us-east1",
+    "available": Array [
+      "asia-east1",
+      "asia-east2",
+      "asia-northeast1",
+      "asia-northeast2",
+      "asia-northeast3",
+      "asia-south1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "europe-west6",
+      "northamerica-northeast1",
+      "southamerica-east1",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-west1",
+      "us-west2",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "reverse": "ClusterPool[0].metadata.labels.region",
+    "tooltip": "The GCP region where you deploy your cluster. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "n1-standard-4",
+        "available": Array [
+          Object {
+            "description": "n1-standard-4 4 vCPU - General Purpose",
+            "value": "n1-standard-4",
+          },
+          Object {
+            "description": "n1-standard-8 8 vCPU - General Purpose",
+            "value": "n1-standard-8",
+          },
+          Object {
+            "description": "n1-standard-16 16 vCPU - General Purpose",
+            "value": "n1-standard-16",
+          },
+          Object {
+            "description": "n1-standard-32 32 vCPU - General Purpose",
+            "value": "n1-standard-32",
+          },
+          Object {
+            "description": "n1-standard-64 64 vCPU - General Purpose",
+            "value": "n1-standard-64",
+          },
+          Object {
+            "description": "n1-standard-96 96 vCPU - General Purpose",
+            "value": "n1-standard-96",
+          },
+        ],
+        "id": "masterType",
+        "learnMore": "https://cloud.google.com/compute/docs/machine-types",
+        "name": "Instance type",
+        "tooltip": "The GCP machine type.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": "n1-standard-4",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "e2-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "e2-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "e2-standard-16",
+                      },
+                    ],
+                    "label": "E2 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "e2-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "e2-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "e2-highmem-16",
+                      },
+                    ],
+                    "label": "E2 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-16",
+                      },
+                    ],
+                    "label": "E2 high-CPU machine types",
+                  },
+                ],
+                "label": "E2 machine types",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2-standard-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "n2-standard-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2-standard-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 320 GiB RAM - General Purpose",
+                        "value": "n2-standard-80",
+                      },
+                    ],
+                    "label": "N2 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2-highmem-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2-highmem-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2-highmem-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 640 GiB RAM - General Purpose",
+                        "value": "n2-highmem-80",
+                      },
+                    ],
+                    "label": "N2 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 48 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 80 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-80",
+                      },
+                    ],
+                    "label": "N2 high-CPU machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2d-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-standard-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "n2d-standard-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2d-standard-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 320 GiB RAM - General Purpose",
+                        "value": "n2d-standard-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2d-standard-96",
+                      },
+                      Object {
+                        "description": "128 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2d-standard-128",
+                      },
+                      Object {
+                        "description": "224 vCPU, 896 GiB RAM - General Purpose",
+                        "value": "n2d-standard-224",
+                      },
+                    ],
+                    "label": "N2D standard machine types with SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 640 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-96",
+                      },
+                    ],
+                    "label": "N2D high-memory machine types with SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 48 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 80 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 96 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-96",
+                      },
+                      Object {
+                        "description": "128 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-128",
+                      },
+                      Object {
+                        "description": "224 vCPU, 224 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-224",
+                      },
+                    ],
+                    "label": "N2D high-CPU machine types with SSD",
+                  },
+                ],
+                "label": "N2 machine types",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "1 vCPU, 3.75 GiB RAM - General Purpose",
+                        "value": "n1-standard-1",
+                      },
+                      Object {
+                        "description": "2 vCPU, 7.50 GiB RAM - General Purpose",
+                        "value": "n1-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 15 GiB RAM - General Purpose",
+                        "value": "n1-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 30 GiB RAM - General Purpose",
+                        "value": "n1-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 60 GiB RAM - General Purpose",
+                        "value": "n1-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 120 GiB RAM - General Purpose",
+                        "value": "n1-standard-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 240 GiB RAM - General Purpose",
+                        "value": "n1-standard-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 360 GiB RAM - General Purpose",
+                        "value": "n1-standard-96",
+                      },
+                    ],
+                    "label": "N1 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 13 GiB RAM - General Purpose",
+                        "value": "n1-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 26 GiB RAM - General Purpose",
+                        "value": "n1-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 52 GiB RAM - General Purpose",
+                        "value": "n1-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 104 GiB RAM - General Purpose",
+                        "value": "n1-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 208 GiB RAM - General Purpose",
+                        "value": "n1-highmem-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 416 GiB RAM - General Purpose",
+                        "value": "n1-highmem-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 624 GiB RAM - General Purpose",
+                        "value": "n1-highmem-96",
+                      },
+                    ],
+                    "label": "N1 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 1.80 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 3.60 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 7.20 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 14.4 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 28.8 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 57.6 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 86.4 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-96",
+                      },
+                    ],
+                    "label": "N1 high-CPU machine types",
+                  },
+                ],
+                "label": "N1 machine types",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "4 vCPU, 16 GiB RAM - Compute Optimized",
+                "value": "c2-standard-4",
+              },
+              Object {
+                "description": "8 vCPU, 32 GiB RAM - Compute Optimized",
+                "value": "c2-standard-8",
+              },
+              Object {
+                "description": "16 vCPU, 64 GiB RAM - Compute Optimized",
+                "value": "c2-standard-16",
+              },
+              Object {
+                "description": "30 vCPU, 120 GiB RAM - Compute Optimized",
+                "value": "c2-standard-30",
+              },
+              Object {
+                "description": "60 vCPU, 240 GiB RAM - Compute Optimized",
+                "value": "c2-standard-60",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "208 vCPU, 5888 GiB RAM - Memory Optimized",
+                "value": "m2-ultramem-2084",
+              },
+              Object {
+                "description": "416 vCPU, 11,776 GiB RAM - Memory Optimized",
+                "value": "m2-ultramem-4164",
+              },
+              Object {
+                "description": "40 vCPU, 961 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-40",
+              },
+              Object {
+                "description": "80 vCPU, 1922 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-80",
+              },
+              Object {
+                "description": "160 vCPU, 3844 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-160",
+              },
+              Object {
+                "description": "96 vCPU, 1433.6 GiB RAM - Memory Optimized",
+                "value": "m1-megamem-96",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://cloud.google.com/compute/docs/machine-types",
+        "name": "Instance type",
+        "tooltip": "The GCP machine type.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+]
+`;
+
+exports[`Cluster creation control data for GCP generates correctly with SNO enabled 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "GCP",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "gcp",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "GCP",
+    ],
+    "availableMap": Object {
+      "GCP": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "active": "us-east1",
+    "available": Array [
+      "asia-east1",
+      "asia-east2",
+      "asia-northeast1",
+      "asia-northeast2",
+      "asia-northeast3",
+      "asia-south1",
+      "asia-southeast1",
+      "australia-southeast1",
+      "europe-north1",
+      "europe-west1",
+      "europe-west2",
+      "europe-west3",
+      "europe-west4",
+      "europe-west6",
+      "northamerica-northeast1",
+      "southamerica-east1",
+      "us-central1",
+      "us-east1",
+      "us-east4",
+      "us-west1",
+      "us-west2",
+    ],
+    "cacheUserValueKey": "create.cluster.region",
+    "id": "region",
+    "name": "Region",
+    "reverse": "ClusterDeployment[0].metadata.labels.region",
+    "tooltip": "The GCP region where you deploy your cluster. You can select zones within the region for your control plane and worker pools.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster unless single node is enabled, in which case there will only be one control plane node.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "n1-standard-4",
+        "available": Array [
+          Object {
+            "description": "n1-standard-4 4 vCPU - General Purpose",
+            "value": "n1-standard-4",
+          },
+          Object {
+            "description": "n1-standard-8 8 vCPU - General Purpose",
+            "value": "n1-standard-8",
+          },
+          Object {
+            "description": "n1-standard-16 16 vCPU - General Purpose",
+            "value": "n1-standard-16",
+          },
+          Object {
+            "description": "n1-standard-32 32 vCPU - General Purpose",
+            "value": "n1-standard-32",
+          },
+          Object {
+            "description": "n1-standard-64 64 vCPU - General Purpose",
+            "value": "n1-standard-64",
+          },
+          Object {
+            "description": "n1-standard-96 96 vCPU - General Purpose",
+            "value": "n1-standard-96",
+          },
+        ],
+        "id": "masterType",
+        "learnMore": "https://cloud.google.com/compute/docs/machine-types",
+        "name": "Instance type",
+        "tooltip": "The GCP machine type.",
+        "type": "combobox",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": "n1-standard-4",
+        "available": Array [
+          Object {
+            "children": Array [
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "e2-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "e2-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "e2-standard-16",
+                      },
+                    ],
+                    "label": "E2 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "e2-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "e2-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "e2-highmem-16",
+                      },
+                    ],
+                    "label": "E2 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "e2-highcpu-16",
+                      },
+                    ],
+                    "label": "E2 high-CPU machine types",
+                  },
+                ],
+                "label": "E2 machine types",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2-standard-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "n2-standard-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2-standard-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 320 GiB RAM - General Purpose",
+                        "value": "n2-standard-80",
+                      },
+                    ],
+                    "label": "N2 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2-highmem-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2-highmem-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2-highmem-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 640 GiB RAM - General Purpose",
+                        "value": "n2-highmem-80",
+                      },
+                    ],
+                    "label": "N2 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 48 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 80 GiB RAM - General Purpose",
+                        "value": "n2-highcpu-80",
+                      },
+                    ],
+                    "label": "N2 high-CPU machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2d-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-standard-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 192 GiB RAM - General Purpose",
+                        "value": "n2d-standard-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2d-standard-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 320 GiB RAM - General Purpose",
+                        "value": "n2d-standard-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2d-standard-96",
+                      },
+                      Object {
+                        "description": "128 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2d-standard-128",
+                      },
+                      Object {
+                        "description": "224 vCPU, 896 GiB RAM - General Purpose",
+                        "value": "n2d-standard-224",
+                      },
+                    ],
+                    "label": "N2D standard machine types with SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 256 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 384 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 512 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 640 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 768 GiB RAM - General Purpose",
+                        "value": "n2d-highmem-96",
+                      },
+                    ],
+                    "label": "N2D high-memory machine types with SSD",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 2 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 4 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 8 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 16 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 32 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-32",
+                      },
+                      Object {
+                        "description": "48 vCPU, 48 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-48",
+                      },
+                      Object {
+                        "description": "64 vCPU, 64 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-64",
+                      },
+                      Object {
+                        "description": "80 vCPU, 80 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-80",
+                      },
+                      Object {
+                        "description": "96 vCPU, 96 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-96",
+                      },
+                      Object {
+                        "description": "128 vCPU, 128 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-128",
+                      },
+                      Object {
+                        "description": "224 vCPU, 224 GiB RAM - General Purpose",
+                        "value": "n2d-highcpu-224",
+                      },
+                    ],
+                    "label": "N2D high-CPU machine types with SSD",
+                  },
+                ],
+                "label": "N2 machine types",
+              },
+              Object {
+                "children": Array [
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "1 vCPU, 3.75 GiB RAM - General Purpose",
+                        "value": "n1-standard-1",
+                      },
+                      Object {
+                        "description": "2 vCPU, 7.50 GiB RAM - General Purpose",
+                        "value": "n1-standard-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 15 GiB RAM - General Purpose",
+                        "value": "n1-standard-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 30 GiB RAM - General Purpose",
+                        "value": "n1-standard-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 60 GiB RAM - General Purpose",
+                        "value": "n1-standard-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 120 GiB RAM - General Purpose",
+                        "value": "n1-standard-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 240 GiB RAM - General Purpose",
+                        "value": "n1-standard-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 360 GiB RAM - General Purpose",
+                        "value": "n1-standard-96",
+                      },
+                    ],
+                    "label": "N1 standard machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 13 GiB RAM - General Purpose",
+                        "value": "n1-highmem-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 26 GiB RAM - General Purpose",
+                        "value": "n1-highmem-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 52 GiB RAM - General Purpose",
+                        "value": "n1-highmem-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 104 GiB RAM - General Purpose",
+                        "value": "n1-highmem-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 208 GiB RAM - General Purpose",
+                        "value": "n1-highmem-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 416 GiB RAM - General Purpose",
+                        "value": "n1-highmem-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 624 GiB RAM - General Purpose",
+                        "value": "n1-highmem-96",
+                      },
+                    ],
+                    "label": "N1 high-memory machine types",
+                  },
+                  Object {
+                    "children": Array [
+                      Object {
+                        "description": "2 vCPU, 1.80 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-2",
+                      },
+                      Object {
+                        "description": "4 vCPU, 3.60 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-4",
+                      },
+                      Object {
+                        "description": "8 vCPU, 7.20 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-8",
+                      },
+                      Object {
+                        "description": "16 vCPU, 14.4 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-16",
+                      },
+                      Object {
+                        "description": "32 vCPU, 28.8 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-32",
+                      },
+                      Object {
+                        "description": "64 vCPU, 57.6 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-64",
+                      },
+                      Object {
+                        "description": "96 vCPU, 86.4 GiB RAM - General Purpose",
+                        "value": "n1-highcpu-96",
+                      },
+                    ],
+                    "label": "N1 high-CPU machine types",
+                  },
+                ],
+                "label": "N1 machine types",
+              },
+            ],
+            "label": "General Purpose",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "4 vCPU, 16 GiB RAM - Compute Optimized",
+                "value": "c2-standard-4",
+              },
+              Object {
+                "description": "8 vCPU, 32 GiB RAM - Compute Optimized",
+                "value": "c2-standard-8",
+              },
+              Object {
+                "description": "16 vCPU, 64 GiB RAM - Compute Optimized",
+                "value": "c2-standard-16",
+              },
+              Object {
+                "description": "30 vCPU, 120 GiB RAM - Compute Optimized",
+                "value": "c2-standard-30",
+              },
+              Object {
+                "description": "60 vCPU, 240 GiB RAM - Compute Optimized",
+                "value": "c2-standard-60",
+              },
+            ],
+            "label": "Compute Optimized",
+          },
+          Object {
+            "children": Array [
+              Object {
+                "description": "208 vCPU, 5888 GiB RAM - Memory Optimized",
+                "value": "m2-ultramem-2084",
+              },
+              Object {
+                "description": "416 vCPU, 11,776 GiB RAM - Memory Optimized",
+                "value": "m2-ultramem-4164",
+              },
+              Object {
+                "description": "40 vCPU, 961 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-40",
+              },
+              Object {
+                "description": "80 vCPU, 1922 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-80",
+              },
+              Object {
+                "description": "160 vCPU, 3844 GiB RAM - Memory Optimized",
+                "value": "m1-ultramem-160",
+              },
+              Object {
+                "description": "96 vCPU, 1433.6 GiB RAM - Memory Optimized",
+                "value": "m1-megamem-96",
+              },
+            ],
+            "label": "Memory Optimized",
+          },
+        ],
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "learnMore": "https://cloud.google.com/compute/docs/machine-types",
+        "name": "Instance type",
+        "tooltip": "The GCP machine type.",
+        "type": "treeselect",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": false,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataHypershift.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataHypershift.test.js.snap
@@ -1,0 +1,341 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cluster creation control data for Hypershift generates correctly 1`] = `
+Array [
+  Object {
+    "id": "hypershiftDetailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "Host inventory",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "active": "Hosted",
+    "id": "controlplane",
+    "name": "Control plane type",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "placeholder": "Select a credential",
+    "providerId": "hostinventory",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": false,
+    },
+  },
+  Object {
+    "additionalProps": Object {
+      "promptSshPublicKey": false,
+    },
+    "component": <DetailsForm />,
+    "encodeValues": Array [
+      "pullSecret",
+    ],
+    "id": "hypershift",
+    "mustValidate": true,
+    "providerId": "hypershift",
+    "type": "custom",
+  },
+  Object {
+    "disabled": true,
+    "id": "hypershiftHostsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "component": <HostsForm />,
+    "id": "hypershift-hosts",
+    "mustValidate": true,
+    "providerId": "hypershift",
+    "type": "custom",
+  },
+  Object {
+    "disabled": true,
+    "id": "hyperhisftNetworkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "component": <NetworkForm />,
+    "id": "hypershift-network",
+    "mustValidate": true,
+    "providerId": "hypershift",
+    "type": "custom",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "component": <Warning />,
+    "id": "warning",
+    "type": "custom",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for Hypershift generates correctly for MCE 1`] = `
+Array [
+  Object {
+    "id": "hypershiftDetailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "Host inventory",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "active": "Hosted",
+    "id": "controlplane",
+    "name": "Control plane type",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "placeholder": "Select a credential",
+    "providerId": "hostinventory",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": false,
+    },
+  },
+  Object {
+    "additionalProps": Object {
+      "promptSshPublicKey": false,
+    },
+    "component": <DetailsForm />,
+    "encodeValues": Array [
+      "pullSecret",
+    ],
+    "id": "hypershift",
+    "mustValidate": true,
+    "providerId": "hypershift",
+    "type": "custom",
+  },
+  Object {
+    "disabled": true,
+    "id": "hypershiftHostsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "component": <HostsForm />,
+    "id": "hypershift-hosts",
+    "mustValidate": true,
+    "providerId": "hypershift",
+    "type": "custom",
+  },
+  Object {
+    "disabled": true,
+    "id": "hyperhisftNetworkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "component": <NetworkForm />,
+    "id": "hypershift-network",
+    "mustValidate": true,
+    "providerId": "hypershift",
+    "type": "custom",
+  },
+  Object {
+    "active": false,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "component": <Warning />,
+    "id": "warning",
+    "type": "custom",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataOST.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataOST.test.js.snap
@@ -416,7 +416,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -1037,7 +1037,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -1658,7 +1658,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataOST.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataOST.test.js.snap
@@ -1,0 +1,1864 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cluster creation control data for OST generates correctly 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "OpenStack",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "ost",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "OpenStack",
+    ],
+    "availableMap": Object {
+      "OpenStack": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "m1.xlarge",
+        "id": "masterType",
+        "name": "Instance type",
+        "tooltip": "The OpenStack compute flavor.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": true,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": "m1.xlarge",
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "name": "Instance type",
+        "tooltip": "The OpenStack compute flavor.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": true,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": "",
+    "id": "externalNetworkName",
+    "name": "External network name",
+    "tooltip": "The name for the external OpenStack network.",
+    "type": "text",
+    "validation": Object {
+      "notification": "External network name is required.",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "hidden": [Function],
+    "id": "lbFloatingIP",
+    "name": "LB floating IP",
+    "placeholder": "Enter LB floating IP",
+    "tooltip": "The existing floating IP address on the Load Balancer for the OpenShift cluster.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "hidden": [Function],
+    "id": "apiFloatingIP",
+    "name": "API floating IP",
+    "placeholder": "Enter API floating IP",
+    "tooltip": "The existing floating IP address on the external network for the OpenShift API.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ingressFloatingIP",
+    "name": "Ingress floating IP",
+    "placeholder": "Enter ingress floating IP",
+    "tooltip": "The existing floating IP address on the external network for the ingress port.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": Array [],
+    "id": "externalDNS",
+    "name": "External DNS IP addresses",
+    "placeholder": "Optional: Enter one or more external DNS IP addresses",
+    "tooltip": "The external DNS IP addresses for name resolution on the private network.",
+    "type": "values",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": false,
+    },
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+      "Kuryr",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "disconnectedStep",
+    "title": "Disconnected installation",
+    "type": "step",
+  },
+  Object {
+    "id": "disconnectedInfo",
+    "info": "Restricted networks which do not have direct access to the Internet require a mirror location of the Red Hat Enterprise Linux CoreOS image.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "isDisconnected",
+    "name": "Create disconnected installation",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "clusterOSImage",
+    "name": "Cluster OS image",
+    "tip": "The location of the Red Hat Enterprise Linux CoreOS image in your local registry.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "imageContentSources",
+    "name": "Image Content Sources",
+    "tip": "The imageContentSources values that were generated during mirror registry creation.",
+    "type": "textarea",
+  },
+  Object {
+    "disabled": true,
+    "id": "disconnectedAdditionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "tip": "The contents of the certificate file that you used for your mirror registry, which can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for OST generates correctly for MCE 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "OpenStack",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "ost",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "OpenStack",
+    ],
+    "availableMap": Object {
+      "OpenStack": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "m1.xlarge",
+        "id": "masterType",
+        "name": "Instance type",
+        "tooltip": "The OpenStack compute flavor.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": true,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": "m1.xlarge",
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "name": "Instance type",
+        "tooltip": "The OpenStack compute flavor.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": true,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": "",
+    "id": "externalNetworkName",
+    "name": "External network name",
+    "tooltip": "The name for the external OpenStack network.",
+    "type": "text",
+    "validation": Object {
+      "notification": "External network name is required.",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "hidden": [Function],
+    "id": "lbFloatingIP",
+    "name": "LB floating IP",
+    "placeholder": "Enter LB floating IP",
+    "tooltip": "The existing floating IP address on the Load Balancer for the OpenShift cluster.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "hidden": [Function],
+    "id": "apiFloatingIP",
+    "name": "API floating IP",
+    "placeholder": "Enter API floating IP",
+    "tooltip": "The existing floating IP address on the external network for the OpenShift API.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ingressFloatingIP",
+    "name": "Ingress floating IP",
+    "placeholder": "Enter ingress floating IP",
+    "tooltip": "The existing floating IP address on the external network for the ingress port.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": Array [],
+    "id": "externalDNS",
+    "name": "External DNS IP addresses",
+    "placeholder": "Optional: Enter one or more external DNS IP addresses",
+    "tooltip": "The external DNS IP addresses for name resolution on the private network.",
+    "type": "values",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": false,
+    },
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+      "Kuryr",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "disconnectedStep",
+    "title": "Disconnected installation",
+    "type": "step",
+  },
+  Object {
+    "id": "disconnectedInfo",
+    "info": "Restricted networks which do not have direct access to the Internet require a mirror location of the Red Hat Enterprise Linux CoreOS image.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "isDisconnected",
+    "name": "Create disconnected installation",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "clusterOSImage",
+    "name": "Cluster OS image",
+    "tip": "The location of the Red Hat Enterprise Linux CoreOS image in your local registry.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "imageContentSources",
+    "name": "Image Content Sources",
+    "tip": "The imageContentSources values that were generated during mirror registry creation.",
+    "type": "textarea",
+  },
+  Object {
+    "disabled": true,
+    "id": "disconnectedAdditionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "tip": "The contents of the certificate file that you used for your mirror registry, which can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.",
+    "type": "textarea",
+  },
+  Object {
+    "active": false,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for OST generates correctly with SNO enabled 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "OpenStack",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "ost",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "OpenStack",
+    ],
+    "availableMap": Object {
+      "OpenStack": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster unless single node is enabled, in which case there will only be one control plane node.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "active": "m1.xlarge",
+        "id": "masterType",
+        "name": "Instance type",
+        "tooltip": "The OpenStack compute flavor.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": true,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "active": "m1.xlarge",
+        "cacheUserValueKey": "create.cluster.worker.type",
+        "id": "workerType",
+        "name": "Instance type",
+        "tooltip": "The OpenStack compute flavor.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_.]+",
+          "notification": "Value must be alphanumeric, including periods.",
+          "required": true,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": "",
+    "id": "externalNetworkName",
+    "name": "External network name",
+    "tooltip": "The name for the external OpenStack network.",
+    "type": "text",
+    "validation": Object {
+      "notification": "External network name is required.",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "hidden": [Function],
+    "id": "lbFloatingIP",
+    "name": "LB floating IP",
+    "placeholder": "Enter LB floating IP",
+    "tooltip": "The existing floating IP address on the Load Balancer for the OpenShift cluster.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "hidden": [Function],
+    "id": "apiFloatingIP",
+    "name": "API floating IP",
+    "placeholder": "Enter API floating IP",
+    "tooltip": "The existing floating IP address on the external network for the OpenShift API.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ingressFloatingIP",
+    "name": "Ingress floating IP",
+    "placeholder": "Enter ingress floating IP",
+    "tooltip": "The existing floating IP address on the external network for the ingress port.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": Array [],
+    "id": "externalDNS",
+    "name": "External DNS IP addresses",
+    "placeholder": "Optional: Enter one or more external DNS IP addresses",
+    "tooltip": "The external DNS IP addresses for name resolution on the private network.",
+    "type": "values",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": false,
+    },
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+      "Kuryr",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "disconnectedStep",
+    "title": "Disconnected installation",
+    "type": "step",
+  },
+  Object {
+    "id": "disconnectedInfo",
+    "info": "Restricted networks which do not have direct access to the Internet require a mirror location of the Red Hat Enterprise Linux CoreOS image.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "isDisconnected",
+    "name": "Create disconnected installation",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "clusterOSImage",
+    "name": "Cluster OS image",
+    "tip": "The location of the Red Hat Enterprise Linux CoreOS image in your local registry.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "imageContentSources",
+    "name": "Image Content Sources",
+    "tip": "The imageContentSources values that were generated during mirror registry creation.",
+    "type": "textarea",
+  },
+  Object {
+    "disabled": true,
+    "id": "disconnectedAdditionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "tip": "The contents of the certificate file that you used for your mirror registry, which can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataRHV.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataRHV.test.js.snap
@@ -498,7 +498,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -1153,7 +1153,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -1808,7 +1808,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataRHV.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataRHV.test.js.snap
@@ -1,0 +1,1966 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cluster creation control data for RHV generates correctly 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "RHV",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "encode": Array [
+      "cacertificate",
+    ],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "placeholder": "Select a credential",
+    "providerId": "redhatvirtualization",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": "",
+    "id": "ovirt_cluster_id",
+    "name": "Target cluster ID",
+    "placeholder": "Target cluster ID",
+    "tooltip": "The Cluster where the VMs will be created.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Must enter target cluster ID",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ovirt_storage_domain_id",
+    "name": "Storage domain ID",
+    "placeholder": "Storage domain ID",
+    "tooltip": "The Storage Domain ID where the VM disks will be created.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Must enter storage domain ID",
+      "required": true,
+    },
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "RHV",
+    ],
+    "availableMap": Object {
+      "RHV": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "id": "masterCores",
+        "initial": "4",
+        "name": "Cores",
+        "tooltip": "The number of cores. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterSockets",
+        "initial": "2",
+        "name": "Sockets",
+        "tooltip": "The number of sockets per core. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterMemoryMB",
+        "initial": "16348",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterRootStorage",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Required if you use <machine-pool>.platform.ovirt.osDisk. Size of the disk in GiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "id": "cores",
+        "initial": "4",
+        "name": "Cores",
+        "tooltip": "The number of cores. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "sockets",
+        "initial": "1",
+        "name": "Sockets",
+        "tooltip": "The number of sockets per core. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "memoryMB",
+        "initial": "16348",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "diskSizeGB",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Required if you use <machine-pool>.platform.ovirt.osDisk. Size of the disk in GiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": "",
+    "id": "ovirt_network_name",
+    "name": "oVirt network name",
+    "placeholder": "Enter oVirt network name",
+    "tooltip": "The network name where the VM NICs will be created.",
+    "type": "text",
+    "validation": Object {
+      "notification": "oVirt network name is required.",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "vnicProfileID",
+    "name": "vNIC Profile ID",
+    "placeholder": "Enter vNIC Profile ID",
+    "tooltip": "The vNIC profile ID of the VM network interfaces. This can be inferred if the cluster network has a single profile.",
+    "type": "text",
+    "validation": Object {
+      "notification": "oVirt network name is required.",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "apiVIP",
+    "name": "API VIP",
+    "placeholder": "Enter API VIP",
+    "tooltip": "The Virtual IP to use for internal API communication. The DNS must be preconfigured with an A/AAAA or CNAME record so the api.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ingressVIP",
+    "name": "Ingress VIP",
+    "placeholder": "Enter ingress VIP",
+    "tooltip": "The Virtual IP to use for ingress traffic. The DNS must be preconfigured with an A/AAAA or CNAME record so the *.apps.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for RHV generates correctly for MCE 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "RHV",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "encode": Array [
+      "cacertificate",
+    ],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "placeholder": "Select a credential",
+    "providerId": "redhatvirtualization",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": "",
+    "id": "ovirt_cluster_id",
+    "name": "Target cluster ID",
+    "placeholder": "Target cluster ID",
+    "tooltip": "The Cluster where the VMs will be created.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Must enter target cluster ID",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ovirt_storage_domain_id",
+    "name": "Storage domain ID",
+    "placeholder": "Storage domain ID",
+    "tooltip": "The Storage Domain ID where the VM disks will be created.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Must enter storage domain ID",
+      "required": true,
+    },
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "RHV",
+    ],
+    "availableMap": Object {
+      "RHV": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "id": "masterCores",
+        "initial": "4",
+        "name": "Cores",
+        "tooltip": "The number of cores. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterSockets",
+        "initial": "2",
+        "name": "Sockets",
+        "tooltip": "The number of sockets per core. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterMemoryMB",
+        "initial": "16348",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterRootStorage",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Required if you use <machine-pool>.platform.ovirt.osDisk. Size of the disk in GiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "id": "cores",
+        "initial": "4",
+        "name": "Cores",
+        "tooltip": "The number of cores. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "sockets",
+        "initial": "1",
+        "name": "Sockets",
+        "tooltip": "The number of sockets per core. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "memoryMB",
+        "initial": "16348",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "diskSizeGB",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Required if you use <machine-pool>.platform.ovirt.osDisk. Size of the disk in GiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": "",
+    "id": "ovirt_network_name",
+    "name": "oVirt network name",
+    "placeholder": "Enter oVirt network name",
+    "tooltip": "The network name where the VM NICs will be created.",
+    "type": "text",
+    "validation": Object {
+      "notification": "oVirt network name is required.",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "vnicProfileID",
+    "name": "vNIC Profile ID",
+    "placeholder": "Enter vNIC Profile ID",
+    "tooltip": "The vNIC profile ID of the VM network interfaces. This can be inferred if the cluster network has a single profile.",
+    "type": "text",
+    "validation": Object {
+      "notification": "oVirt network name is required.",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "apiVIP",
+    "name": "API VIP",
+    "placeholder": "Enter API VIP",
+    "tooltip": "The Virtual IP to use for internal API communication. The DNS must be preconfigured with an A/AAAA or CNAME record so the api.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ingressVIP",
+    "name": "Ingress VIP",
+    "placeholder": "Enter ingress VIP",
+    "tooltip": "The Virtual IP to use for ingress traffic. The DNS must be preconfigured with an A/AAAA or CNAME record so the *.apps.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "active": false,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for RHV generates correctly with SNO enabled 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "RHV",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "encode": Array [
+      "cacertificate",
+    ],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "placeholder": "Select a credential",
+    "providerId": "redhatvirtualization",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": "",
+    "id": "ovirt_cluster_id",
+    "name": "Target cluster ID",
+    "placeholder": "Target cluster ID",
+    "tooltip": "The Cluster where the VMs will be created.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Must enter target cluster ID",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ovirt_storage_domain_id",
+    "name": "Storage domain ID",
+    "placeholder": "Storage domain ID",
+    "tooltip": "The Storage Domain ID where the VM disks will be created.",
+    "type": "text",
+    "validation": Object {
+      "notification": "Must enter storage domain ID",
+      "required": true,
+    },
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "RHV",
+    ],
+    "availableMap": Object {
+      "RHV": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "id": "masterCores",
+        "initial": "4",
+        "name": "Cores",
+        "tooltip": "The number of cores. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterSockets",
+        "initial": "2",
+        "name": "Sockets",
+        "tooltip": "The number of sockets per core. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterMemoryMB",
+        "initial": "16348",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterRootStorage",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Required if you use <machine-pool>.platform.ovirt.osDisk. Size of the disk in GiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "id": "cores",
+        "initial": "4",
+        "name": "Cores",
+        "tooltip": "The number of cores. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "sockets",
+        "initial": "1",
+        "name": "Sockets",
+        "tooltip": "The number of sockets per core. Total virtual CPUs (vCPUs) is cores * sockets.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "memoryMB",
+        "initial": "16348",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "diskSizeGB",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Required if you use <machine-pool>.platform.ovirt.osDisk. Size of the disk in GiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": "",
+    "id": "ovirt_network_name",
+    "name": "oVirt network name",
+    "placeholder": "Enter oVirt network name",
+    "tooltip": "The network name where the VM NICs will be created.",
+    "type": "text",
+    "validation": Object {
+      "notification": "oVirt network name is required.",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "vnicProfileID",
+    "name": "vNIC Profile ID",
+    "placeholder": "Enter vNIC Profile ID",
+    "tooltip": "The vNIC profile ID of the VM network interfaces. This can be inferred if the cluster network has a single profile.",
+    "type": "text",
+    "validation": Object {
+      "notification": "oVirt network name is required.",
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "apiVIP",
+    "name": "API VIP",
+    "placeholder": "Enter API VIP",
+    "tooltip": "The Virtual IP to use for internal API communication. The DNS must be preconfigured with an A/AAAA or CNAME record so the api.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ingressVIP",
+    "name": "Ingress VIP",
+    "placeholder": "Enter ingress VIP",
+    "tooltip": "The Virtual IP to use for ingress traffic. The DNS must be preconfigured with an A/AAAA or CNAME record so the *.apps.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataVMW.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataVMW.test.js.snap
@@ -1,0 +1,1963 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Cluster creation control data for VMW generates correctly 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "vSphere",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "encode": Array [
+      "cacertificate",
+    ],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "vmw",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list. Only versions 4.5, and later, are supported for VMware vSphere.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "vSphere",
+    ],
+    "availableMap": Object {
+      "vSphere": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "id": "masterCoresPerSocket",
+        "initial": "2",
+        "name": "Cores per socket",
+        "tooltip": "Cores per socket",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterCpus",
+        "initial": "4",
+        "name": "CPUs",
+        "tooltip": "CPUs",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterMemoryMB",
+        "initial": "16384",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterRootStorage",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Disk size (GiB)",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "id": "coresPerSocket",
+        "initial": "2",
+        "name": "Cores per socket",
+        "tooltip": "Cores per socket",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "cpus",
+        "initial": "4",
+        "name": "CPUs",
+        "tooltip": "CPUs",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "memoryMB",
+        "initial": "16384",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "diskSizeGB",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Disk size (GiB)",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": "",
+    "id": "networkName",
+    "name": "vSphere network name",
+    "placeholder": "vSphere network name",
+    "tooltip": "The name of the vSphere network to use.",
+    "type": "text",
+    "validation": Object {
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "apiVIP",
+    "name": "API VIP",
+    "placeholder": "Enter API VIP",
+    "tooltip": "The Virtual IP to use for internal API communication. The DNS must be preconfigured with an A/AAAA or CNAME record so the api.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ingressVIP",
+    "name": "Ingress VIP",
+    "placeholder": "Enter ingress VIP",
+    "tooltip": "The Virtual IP to use for ingress traffic. The DNS must be preconfigured with an A/AAAA or CNAME record so the *.apps.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "disconnectedStep",
+    "title": "Disconnected installation",
+    "type": "step",
+  },
+  Object {
+    "id": "disconnectedInfo",
+    "info": "Restricted networks which do not have direct access to the Internet require a mirror location of the Red Hat Enterprise Linux CoreOS image.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "isDisconnected",
+    "name": "Create disconnected installation",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "imageContentSources",
+    "name": "Image Content Sources",
+    "tip": "The imageContentSources values that were generated during mirror registry creation.",
+    "type": "textarea",
+  },
+  Object {
+    "disabled": true,
+    "id": "disconnectedAdditionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "tip": "The contents of the certificate file that you used for your mirror registry, which can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for VMW generates correctly for MCE 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "vSphere",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "encode": Array [
+      "cacertificate",
+    ],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "vmw",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list. Only versions 4.5, and later, are supported for VMware vSphere.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "vSphere",
+    ],
+    "availableMap": Object {
+      "vSphere": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "id": "masterCoresPerSocket",
+        "initial": "2",
+        "name": "Cores per socket",
+        "tooltip": "Cores per socket",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterCpus",
+        "initial": "4",
+        "name": "CPUs",
+        "tooltip": "CPUs",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterMemoryMB",
+        "initial": "16384",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterRootStorage",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Disk size (GiB)",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "id": "coresPerSocket",
+        "initial": "2",
+        "name": "Cores per socket",
+        "tooltip": "Cores per socket",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "cpus",
+        "initial": "4",
+        "name": "CPUs",
+        "tooltip": "CPUs",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "memoryMB",
+        "initial": "16384",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "diskSizeGB",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Disk size (GiB)",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": "",
+    "id": "networkName",
+    "name": "vSphere network name",
+    "placeholder": "vSphere network name",
+    "tooltip": "The name of the vSphere network to use.",
+    "type": "text",
+    "validation": Object {
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "apiVIP",
+    "name": "API VIP",
+    "placeholder": "Enter API VIP",
+    "tooltip": "The Virtual IP to use for internal API communication. The DNS must be preconfigured with an A/AAAA or CNAME record so the api.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ingressVIP",
+    "name": "Ingress VIP",
+    "placeholder": "Enter ingress VIP",
+    "tooltip": "The Virtual IP to use for ingress traffic. The DNS must be preconfigured with an A/AAAA or CNAME record so the *.apps.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "disconnectedStep",
+    "title": "Disconnected installation",
+    "type": "step",
+  },
+  Object {
+    "id": "disconnectedInfo",
+    "info": "Restricted networks which do not have direct access to the Internet require a mirror location of the Red Hat Enterprise Linux CoreOS image.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "isDisconnected",
+    "name": "Create disconnected installation",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "imageContentSources",
+    "name": "Image Content Sources",
+    "tip": "The imageContentSources values that were generated during mirror registry creation.",
+    "type": "textarea",
+  },
+  Object {
+    "disabled": true,
+    "id": "disconnectedAdditionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "tip": "The contents of the certificate file that you used for your mirror registry, which can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.",
+    "type": "textarea",
+  },
+  Object {
+    "active": false,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;
+
+exports[`Cluster creation control data for VMW generates correctly with SNO enabled 1`] = `
+Array [
+  Object {
+    "id": "detailStep",
+    "title": "Cluster details",
+    "type": "step",
+  },
+  Object {
+    "active": "vSphere",
+    "id": "infrastructure",
+    "name": "Infrastructure",
+    "type": "reviewinfo",
+  },
+  Object {
+    "available": Array [],
+    "encode": Array [
+      "cacertificate",
+    ],
+    "footer": <CreateCredentialModal
+      handleModalToggle={[MockFunction]}
+    />,
+    "id": "connection",
+    "name": "Infrastructure provider credential",
+    "onSelect": [Function],
+    "placeholder": "Select a credential",
+    "providerId": "vmw",
+    "tooltip": "The settings that are required for the selected provider. You can select an existing connection, or add a new connection. Cannot be changed after creation.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Select a connection",
+      "required": true,
+    },
+  },
+  Object {
+    "id": "name",
+    "name": "Cluster name",
+    "placeholder": "Enter cluster name",
+    "reverse": "ClusterDeployment[0].metadata.name",
+    "tooltip": "The unique name of your cluster. The value must be a string that contains lowercase alphanumeric values, such as dev. Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "constraint": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$",
+      "notification": "The value must be a valid DNS label that consists of up to 63 lowercase alphanumeric characters. The character '-' is also permitted, as long as it does not appear in the first or last position.",
+      "required": true,
+    },
+  },
+  Object {
+    "available": Array [],
+    "id": "clusterSet",
+    "name": "Cluster set",
+    "placeholder": "Select a cluster set",
+    "tooltip": "A ManagedClusterSet is a group of managed clusters. With a ManagedClusterSet, you can manage access to all of the managed clusters in the group together. Clusters from the pool will be added to this set. After the cluster pool is created, the cluster set cannot be changed.",
+    "type": "singleselect",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "id": "baseDomain",
+    "name": "Base DNS domain",
+    "placeholder": "Enter base DNS domain",
+    "tip": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation.",
+    "tooltip": "The base domain of your provider, which is used to create routes to your OpenShift Container Platform cluster components. It is configured in your cloud provider's DNS as a Start Of Authority record (SOA). Cannot be changed after creation.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "id": "fips",
+    "name": "FIPS",
+    "tip": "Use the Federal Information Processing Standards (FIPS) modules provided with Red Hat Enterprise Linux CoreOS instead of the default Kubernetes cryptography suite.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "id": "showSecrets",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
+    "fetchAvailable": Object {
+      "emptyDesc": "No default images. Enter a release image path.",
+      "loadingDesc": "Loading release image sets...",
+      "query": [Function],
+      "setAvailable": [Function],
+      "setAvailableMap": [Function],
+    },
+    "id": "imageSet",
+    "name": "Release image",
+    "onSelect": [Function],
+    "placeholder": "Select or enter a release image",
+    "simplified": [Function],
+    "tooltip": "URL to the OpenShift install image set to use. Available images are listed, or you can enter your own path to add an image to the list. Only versions 4.5, and later, are supported for VMware vSphere.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Select a release image",
+      "required": true,
+    },
+  },
+  Object {
+    "active": false,
+    "hidden": true,
+    "id": "singleNodeFeatureFlag",
+    "type": "checkbox",
+  },
+  Object {
+    "active": false,
+    "hidden": [Function],
+    "icon": <DevPreviewLabel />,
+    "id": "singleNode",
+    "name": "Single Node OpenShift",
+    "onSelect": [Function],
+    "tooltip": "To enable a single node OpenShift cluster with one control plane node and zero worker nodes. Only available in OpenShift 4.8 and higher.",
+    "type": "checkbox",
+  },
+  Object {
+    "active": Array [],
+    "id": "additional",
+    "name": "Additional labels",
+    "tip": "Use labels to organize and place application subscriptions and policies on this cluster. The placement of resources are controlled by label selectors. If your cluster has the labels that match the resource placement’s label selector, the resource will be installed on your cluster after creation.",
+    "type": "labels",
+  },
+  Object {
+    "active": Array [
+      "vSphere",
+    ],
+    "availableMap": Object {
+      "vSphere": Object {
+        "replacements": Object {
+          "install-config": Object {
+            "encode": true,
+            "newTab": true,
+            "template": [Function],
+          },
+        },
+      },
+    },
+    "hasReplacements": true,
+    "id": "infrastructure",
+    "type": "hidden",
+  },
+  Object {
+    "id": "nodePoolsStep",
+    "title": "Node pools",
+    "type": "step",
+  },
+  Object {
+    "id": "nodes",
+    "info": "The instance type and quantity of control plane and worker nodes to create for your cluster. Additional worker nodes can be added after the cluster is created.",
+    "type": "title",
+  },
+  Object {
+    "available": Array [
+      "amd64",
+    ],
+    "cacheUserValueKey": "create.cluster.architecture",
+    "id": "architecture",
+    "name": "CPU architecture",
+    "placeholder": "Enter CPU architecture",
+    "tooltip": "Determines the CPU instruction set architecture of the machines in the pool. Only set this value when the architecture of the managed cluster is different from the architecture of the hub.",
+    "type": "combobox",
+    "validation": Object {
+      "notification": "Value must be alphanumeric.",
+      "required": false,
+      "tester": /\\^\\[A-Za-z0-9-_\\]\\+\\$/,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "masterPool",
+        "info": "Three control plane nodes will be created to control this cluster unless single node is enabled, in which case there will only be one control plane node.",
+        "subtitle": "Control plane pool",
+        "type": "section",
+      },
+      Object {
+        "id": "masterCoresPerSocket",
+        "initial": "2",
+        "name": "Cores per socket",
+        "tooltip": "Cores per socket",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterCpus",
+        "initial": "4",
+        "name": "CPUs",
+        "tooltip": "CPUs",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterMemoryMB",
+        "initial": "16384",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "masterRootStorage",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Disk size (GiB)",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "id": "masterPool",
+    "onlyOne": true,
+    "type": "group",
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "collapsed": true,
+        "id": "workerPool",
+        "info": "One or more worker nodes will be created to run the container workloads in this cluster.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "worker",
+        "id": "workerName",
+        "name": "Pool name",
+        "placeholder": "Enter pool name",
+        "tooltip": "The name for your worker pool.",
+        "type": "text",
+        "validation": Object {
+          "constraint": "[A-Za-z0-9-_]+",
+          "notification": "Value must be alphanumeric.",
+          "required": true,
+        },
+      },
+      Object {
+        "id": "coresPerSocket",
+        "initial": "2",
+        "name": "Cores per socket",
+        "tooltip": "Cores per socket",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "cpus",
+        "initial": "4",
+        "name": "CPUs",
+        "tooltip": "CPUs",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "memoryMB",
+        "initial": "16384",
+        "name": "Memory (MiB)",
+        "tooltip": "Optional. Memory of the VM in MiB.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "id": "diskSizeGB",
+        "initial": "120",
+        "name": "Disk size (GiB)",
+        "tooltip": "Disk size (GiB)",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "cacheUserValueKey": "create.cluster.compute.node.count",
+        "id": "computeNodeCount",
+        "initial": "3",
+        "name": "Node count",
+        "tooltip": "The number of nodes in this node pool.",
+        "type": "number",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+    ],
+    "hidden": [Function],
+    "id": "workerPools",
+    "prompts": Object {
+      "addPrompt": "Add worker pool",
+      "baseName": "worker",
+      "deletePrompt": "Delete node pool",
+      "nameId": "workerName",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "networkStep",
+    "title": "Networking",
+    "type": "step",
+  },
+  Object {
+    "active": "",
+    "id": "networkName",
+    "name": "vSphere network name",
+    "placeholder": "vSphere network name",
+    "tooltip": "The name of the vSphere network to use.",
+    "type": "text",
+    "validation": Object {
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "apiVIP",
+    "name": "API VIP",
+    "placeholder": "Enter API VIP",
+    "tooltip": "The Virtual IP to use for internal API communication. The DNS must be preconfigured with an A/AAAA or CNAME record so the api.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "active": "",
+    "id": "ingressVIP",
+    "name": "Ingress VIP",
+    "placeholder": "Enter ingress VIP",
+    "tooltip": "The Virtual IP to use for ingress traffic. The DNS must be preconfigured with an A/AAAA or CNAME record so the *.apps.<cluster name>.<Base DNS domain> path resolves correctly.",
+    "type": "text",
+    "validation": Object {
+      "contextTester": [Function],
+      "required": true,
+    },
+  },
+  Object {
+    "id": "networkInfo",
+    "info": "Configure network access for your cluster. One network is created by default.",
+    "type": "title",
+  },
+  Object {
+    "active": "OVNKubernetes",
+    "available": Array [
+      "OpenShiftSDN",
+      "OVNKubernetes",
+    ],
+    "id": "networkType",
+    "name": "Network type",
+    "tooltip": "The pod network provider plug-in to deploy. OVNKubernetes is required for IPv6. The default value is OpenShiftSDN.",
+    "type": "singleselect",
+    "validation": Object {
+      "notification": "Value must be a valid security key.",
+      "required": true,
+    },
+  },
+  Object {
+    "controlData": Array [
+      Object {
+        "collapsable": true,
+        "id": "networkGroup",
+        "info": "Specify at least one network. Multiple are required for IPv6.",
+        "subtitle": [Function],
+        "type": "section",
+      },
+      Object {
+        "active": "10.128.0.0/14",
+        "id": "clusterNetwork",
+        "name": "Cluster network CIDR",
+        "placeholder": "Enter cluster network CIDR",
+        "tooltip": "A block of IP addresses from which pod IP addresses are allocated. The OpenShiftSDN network plug-in supports multiple cluster networks. The address blocks for multiple cluster networks must not overlap. Select address pools large enough to fit your anticipated workload. The default value is 10.128.0.0/14.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "23",
+        "id": "hostPrefix",
+        "name": "Network host prefix",
+        "placeholder": "Enter network host prefix",
+        "tooltip": "The subnet prefix length to assign to each individual node. For example, if hostPrefix is set to 23, then each node is assigned a /23 subnet out of the given CIDR, allowing for 510 (2^(32 - 23) - 2) pod IP addresses. The default is 23.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be integer.",
+          "required": true,
+          "tester": /\\^\\\\d\\+\\$/,
+        },
+      },
+      Object {
+        "active": "172.30.0.0/16",
+        "id": "serviceNetwork",
+        "name": "Service network CIDR",
+        "placeholder": "Enter service network CIDR",
+        "tooltip": "A block of IP addresses for services. OpenShiftSDN allows only one serviceNetwork block. The address block must not overlap any other network block. The default value is 172.30.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+      Object {
+        "active": "10.0.0.0/16",
+        "id": "machineCIDR",
+        "name": "Machine CIDR",
+        "placeholder": "Enter machine CIDR",
+        "tooltip": "A block of IP addresses used by the OpenShift Container Platform hosts. The address block must not overlap any other network block. The default value is 10.0.0.0/16.",
+        "type": "text",
+        "validation": Object {
+          "notification": "Value must be a valid IPv4 or IPv6 CIDR.",
+          "required": true,
+          "tester": Object {
+            "test": [Function],
+          },
+        },
+      },
+    ],
+    "id": "networks",
+    "prompts": Object {
+      "addPrompt": "Add network",
+      "deletePrompt": "Delete node pool",
+    },
+    "type": "group",
+  },
+  Object {
+    "id": "proxyStep",
+    "title": "Proxy",
+    "type": "step",
+  },
+  Object {
+    "id": "proxyInfo",
+    "info": "Production environments can deny direct access to the Internet and instead have an HTTP or HTTPS proxy available. You can configure a new OpenShift Container Platform cluster to use a proxy by configuring the proxy settings.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "hasProxy",
+    "name": "Use proxy",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "httpProxy",
+    "name": "HTTP proxy",
+    "tip": "Requires this format: http://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "disabled": true,
+    "id": "httpsProxy",
+    "name": "HTTPS proxy",
+    "tip": "Requires this format: https://<username>:<pswd>@<ip>:<port>",
+    "type": "text",
+    "validation": Object {
+      "notification": "Value must be a valid URL format.",
+      "required": true,
+      "tester": Object {
+        "test": [Function],
+      },
+    },
+  },
+  Object {
+    "active": Array [],
+    "disabled": true,
+    "id": "noProxy",
+    "name": "No proxy",
+    "tip": "Add a comma-separated list of sites that bypass the proxy. The hub API server address must be included in this list. By default, all cluster egress traffic is sent through the proxy, including calls to hosting and cloud provider APIs.",
+    "type": "values",
+  },
+  Object {
+    "disabled": true,
+    "id": "additionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "type": "textarea",
+  },
+  Object {
+    "id": "disconnectedStep",
+    "title": "Disconnected installation",
+    "type": "step",
+  },
+  Object {
+    "id": "disconnectedInfo",
+    "info": "Restricted networks which do not have direct access to the Internet require a mirror location of the Red Hat Enterprise Linux CoreOS image.",
+    "type": "title",
+  },
+  Object {
+    "active": false,
+    "id": "isDisconnected",
+    "name": "Create disconnected installation",
+    "onSelect": [Function],
+    "type": "checkbox",
+  },
+  Object {
+    "disabled": true,
+    "id": "imageContentSources",
+    "name": "Image Content Sources",
+    "tip": "The imageContentSources values that were generated during mirror registry creation.",
+    "type": "textarea",
+  },
+  Object {
+    "disabled": true,
+    "id": "disconnectedAdditionalTrustBundle",
+    "name": "Additional trust bundle",
+    "placeholder": "-----BEGIN CERTIFICATE-----
+<MY_TRUSTED_CA_CERT>
+-----END CERTIFICATE-----",
+    "tip": "The contents of the certificate file that you used for your mirror registry, which can be an existing, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.",
+    "type": "textarea",
+  },
+  Object {
+    "active": true,
+    "id": "includeKlusterletAddonConfig",
+    "type": "hidden",
+  },
+  Object {
+    "id": "automationStep",
+    "title": "Automation",
+    "type": "step",
+  },
+  Object {
+    "id": "chooseTemplate",
+    "info": "Optional: Choose an automation template to run Ansible jobs at different stages of the cluster lifecycle.",
+    "type": "title",
+  },
+  Object {
+    "component": <AutomationProviderHint
+      className="creation-view-controls-hint"
+      component="hint"
+    />,
+    "id": "automationProviderHint",
+    "type": "custom",
+  },
+  Object {
+    "id": "templateName",
+    "name": "Automation template",
+    "onSelect": [Function],
+    "placeholder": "Select an automation template",
+    "prompts": Object {
+      "icon": <ExternalLinkAltIcon
+        color="currentColor"
+        noVerticalAlign={false}
+        size="sm"
+      />,
+      "id": "add-automation-template",
+      "positionBottomRight": true,
+      "prompt": "Add automation template",
+      "type": "link",
+      "url": "/multicloud/infrastructure/automations/add",
+    },
+    "tooltip": "Only templates with valid Ansible Automation Platform credentials are listed.",
+    "type": "combobox",
+    "validation": Object {
+      "required": false,
+    },
+  },
+  Object {
+    "component": <TemplateLinkOutControl />,
+    "id": "curatorLinkOut",
+    "type": "custom",
+  },
+  Object {
+    "component": <TemplateSummaryControl />,
+    "id": "curatorSummary",
+    "type": "custom",
+  },
+  Object {
+    "active": "",
+    "id": "clusterCuratorSpec",
+    "reverse": [Function],
+    "type": "hidden",
+  },
+  Object {
+    "active": Array [],
+    "hidden": true,
+    "id": "supportedCurations",
+    "type": "values",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-install",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-upgrade",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-scale",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+]
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataVMW.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataVMW.test.js.snap
@@ -463,7 +463,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -1117,7 +1117,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },
@@ -1771,7 +1771,7 @@ Array [
     "id": "networks",
     "prompts": Object {
       "addPrompt": "Add network",
-      "deletePrompt": "Delete node pool",
+      "deletePrompt": "Delete network",
     },
     "type": "group",
   },


### PR DESCRIPTION
Convert cluster creation tests to capture snapshots so that control data can be refactored without introducing regressions.