### PR TITLE
Optimize onboarding modal colour scheme for dark mode

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.css
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.css
@@ -1,7 +1,3 @@
-.pf-c-expandable-section__toggle-text {
-    color: #000000;
-}
-
 .pf-c-modal-box__footer {
     padding: 0px;
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/OnboardingModal.tsx
@@ -58,7 +58,6 @@ export function OnboardingModal(props: IOnboardingModalProps) {
                 <AcmExpandableSection
                     label={t('Want to learn more?')}
                     style={{
-                        backgroundColor: '#F0F0F0',
                         width: '100%',
                         height: '100%',
                         padding: '16px 16px 16px 36px',
@@ -93,19 +92,19 @@ export function OnboardingModal(props: IOnboardingModalProps) {
                 </GridItem>
                 <GridItem span={9}>
                     <div>
-                        <span style={{ color: '#393F44', fontSize: '24px' }}>
+                        <span style={{ fontSize: '24px' }}>
                             <Trans
                                 i18nKey="Managing clusters <bold>just got easier</bold>"
                                 components={{ bold: <strong /> }}
                             />
                         </span>
                     </div>
-                    <div style={{ color: '#6A6E73', fontSize: '14px', paddingTop: '8px' }}>
+                    <div style={{ fontSize: '14px', paddingTop: '8px' }}>
                         {t(
                             'Create and manage a fleet of clusters with ease using this all clusters view. To access a single cluster you can select it from the cluster list table.'
                         )}
                     </div>
-                    <div style={{ color: '#151515', fontSize: '16px', paddingTop: '48px' }}>
+                    <div style={{ fontSize: '16px', paddingTop: '48px' }}>
                         {t('How would you like to create your cluster?')}
                     </div>
                 </GridItem>
@@ -116,7 +115,7 @@ export function OnboardingModal(props: IOnboardingModalProps) {
                     <GridItem key={card.id} span={4}>
                         <Link key={card.id} to={card.link} style={{ color: 'inherit', textDecoration: 'none' }}>
                             <Card id={card.id} key={card.id} isSelectable isFlat>
-                                <CardBody style={{ minHeight: '160px', borderColor: '#D2D2D2', color: '#151515' }}>
+                                <CardBody style={{ minHeight: '160px' }}>
                                     <div
                                         style={{
                                             position: 'absolute',


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

This PR removes hard-coded custom CSS colours to follow theme switching between light and dark mode for the onboarding modal.

Before:
![Screenshot from 2022-12-13 10-32-26](https://user-images.githubusercontent.com/17188326/207375818-f32ae333-06bd-4a6b-a11f-0b56e13db563.png)
![Screenshot from 2022-12-13 10-33-07](https://user-images.githubusercontent.com/17188326/207375944-ce1c8f8c-1eca-497e-a4b7-5d1a59ce929e.png)

After:
![Screenshot from 2022-12-13 10-37-57](https://user-images.githubusercontent.com/17188326/207377336-1382673b-25e3-48b0-a7f0-7f71902681fb.png)
![Screenshot from 2022-12-13 10-38-19](https://user-images.githubusercontent.com/17188326/207377350-7aebaf25-f2dc-4155-97b1-fb2d03215806.png)


Addresses:
 - https://issues.redhat.com/browse/ACM-2229