### PR TITLE
Show updates only beside updatable resources

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -571,6 +571,7 @@ export function useClusterDistributionColumn(
                 hostedCluster={hostedClusters.find(
                     (hc) => cluster.namespace === hc.metadata?.namespace && cluster.name === hc.metadata?.name
                 )}
+                resource={'managedclusterpage'}
             />
         ),
     }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
@@ -739,6 +739,7 @@ describe('DistributionField hypershift clusters', () => {
                     clusterCurator={clusterCurator}
                     nodepool={nodepool}
                     hostedCluster={hostedCluster}
+                    resource={'managedclusterpage'}
                 />
             </RecoilRoot>
         )
@@ -803,63 +804,6 @@ describe('DistributionField hypershift clusters', () => {
             undefined,
             undefined,
             undefined
-        )
-        expect(queryAllByText('Upgrade available').length).toBe(1)
-    })
-
-    it('should render distribution info for hypershift, only nodepool has updates', async () => {
-        const mockCluster: Cluster = {
-            name: 'hypershift-cluster1',
-            displayName: 'hypershift-cluster1',
-            namespace: 'clusters',
-            uid: 'hypershift-cluster1-uid',
-            provider: undefined,
-            status: ClusterStatus.ready,
-            distribution: {
-                ocp: {
-                    version: '4.11.12',
-                    availableUpdates: [],
-                    desiredVersion: '4.11.12',
-                    upgradeFailed: false,
-                },
-                isManagedOpenShift: false,
-            },
-            labels: { abc: '123' },
-            nodes: undefined,
-            kubeApiServer: '',
-            consoleURL: '',
-            hive: {
-                isHibernatable: true,
-                clusterPool: undefined,
-                secrets: {
-                    installConfig: '',
-                },
-            },
-            hypershift: {
-                agent: false,
-                hostingNamespace: 'clusters',
-                nodePools: mockNodepools,
-                secretNames: ['feng-hs-bug-ssh-key', 'feng-hs-bug-pull-secret'],
-            },
-            isHive: false,
-            isManaged: true,
-            isCurator: true,
-            isHostedCluster: true,
-            isHypershift: true,
-            isSNOCluster: false,
-            owner: {},
-            kubeadmin: '',
-            kubeconfig: '',
-            isRegionalHubCluster: false,
-        }
-        const { queryAllByText } = await renderDistributionInfoField(
-            mockCluster,
-            true,
-            false,
-            undefined,
-            undefined,
-            undefined,
-            false
         )
         expect(queryAllByText('Upgrade available').length).toBe(1)
     })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -101,31 +101,6 @@ export function DistributionField(props: {
         props.cluster?.isHypershift,
     ])
 
-    // const nodepoolsHasUpdates: boolean = useMemo(() => {
-    //     // let updateAvailable = false
-    //     // if (props.cluster?.hypershift?.nodePools && props.cluster?.hypershift?.nodePools.length > 0) {
-    //     //     for (let i = 0; i < props.cluster?.hypershift?.nodePools.length; i++) {
-    //     //         if (
-    //     //             (props.cluster?.hypershift?.nodePools[i].status?.version || '') <
-    //     //             (props.cluster.distribution?.ocp?.version || '')
-    //     //         ) {
-    //     //             updateAvailable = true
-    //     //             break
-    //     //         }
-    //     //     }
-    //     // }
-
-    //     if (props.nodepool?.status?.version && props.cluster?.distribution?.ocp?.version) {
-    //         if ((props.nodepool?.status?.version || '') <
-    //                  (props.cluster.distribution?.ocp?.version || '')) {
-    //             return true
-    //         }
-
-    //     }
-    //     return false
-    //     //return updateAvailable
-    // }, [props.cluster?.distribution?.ocp?.version, props.cluster?.hypershift?.nodePools])
-
     const isUpdateAvailable: boolean = useMemo(() => {
         //if nodepool table
         if (props.resource != null && props.resource === 'nodepool') {
@@ -149,6 +124,12 @@ export function DistributionField(props: {
                     }
                 }
             }
+
+            //if no nodepool has updates, still check if hcp has updates
+            if (!updateAvailable) {
+                return Object.keys(hypershiftAvailableUpdates).length > 0
+            }
+
             return updateAvailable
         } else if (props.resource != null && props.resource === 'hostedcluster') {
             //if hosted cluster progress - cluster and hostedcluster

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HostedClusterProgress.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HostedClusterProgress.tsx
@@ -46,6 +46,7 @@ const HostedClusterProgress = ({ hostedCluster }: HostedClusterProgressProps) =>
                                 cluster={cluster}
                                 clusterCurator={undefined}
                                 hostedCluster={hostedCluster}
+                                resource={'hostedcluster'}
                             />
                         </StackItem>
                         <StackItem className="nodepool-progress-item__body">

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsTable.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsTable.tsx
@@ -119,7 +119,9 @@ const NodePoolsTable = ({ nodePools, clusterImages }: NodePoolsTableProps): JSX.
                 header: t('table.distribution'),
                 sort: 'status.version',
                 search: 'status.version',
-                cell: (nodepool: NodePool) => <DistributionField cluster={cluster} nodepool={nodepool} />,
+                cell: (nodepool: NodePool) => (
+                    <DistributionField cluster={cluster} nodepool={nodepool} resource={'nodepool'} />
+                ),
             }
         )
         if (hostedCluster?.spec?.platform?.type === HypershiftCloudPlatformType.AWS) {


### PR DESCRIPTION
Signed-off-by: Omar Farag <ofarag@redhat.com>

Work on the issue where `Upgrade available` would be displayed alongside non-upgradable resources which may cause confusion. See https://issues.redhat.com/browse/ACM-2331


Scenario 1 - not all nodepools are upgradable:

- Before: All Nodepools and CP show as upgradable even though only 1 nodepool is upgradable 
![image](https://user-images.githubusercontent.com/15898988/207725794-a81c7369-130e-409b-a306-57a034011740.png)



- After: Only upgradable nodepool shows as upgradable ![image](https://user-images.githubusercontent.com/15898988/207711713-0c4eba62-ce37-4c58-af1b-b919f9a5d2a9.png)

Only show updatable nodepool - main page still shows upgradable since either nodepools or hcp on the cluster page are upgradable:

Scenario 2 - Nodepool is not at latest version but cannot be upgraded past the version of the CP:

- Before: Nodepool would show upgradable, but would require CP upgrade first ![image](https://user-images.githubusercontent.com/15898988/207722628-2df326f5-c8ea-4d8a-be29-d177130ba757.png)

- After: Nodepool won't show upgradable unless its version is less than that of CP 
![image](https://user-images.githubusercontent.com/15898988/207722043-b364704a-1970-477d-b34e-92c22dfd374a.png)




