### PR TITLE
Add setting to disable resource watching and the events API

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -24,6 +24,8 @@ import { search } from './routes/search'
 import { serve } from './routes/serve'
 import { username } from './routes/username'
 
+const eventsEnabled = process.env.DISABLE_EVENTS !== 'true'
+
 // Router defaults to max param length of 100 - We need to override to 500 to handle resources with very long names
 // If the route exceeds 500 chars the route will not be found from this fn: router.find()
 export const router = Router<Router.HTTPVersion.V2>({ maxParamLength: 500 })
@@ -41,7 +43,9 @@ router.get(`/login`, login)
 router.get(`/login/callback`, loginCallback)
 router.get(`/logout`, logout)
 router.get(`/logout/`, logout)
-router.get(`/events`, events)
+if (eventsEnabled) {
+    router.get(`/events`, events)
+}
 router.post(`/proxy/search`, search)
 router.get(`/authenticated`, authenticated)
 router.post(`/ansibletower`, ansibleTower)
@@ -77,7 +81,9 @@ export async function requestHandler(req: Http2ServerRequest, res: Http2ServerRe
 
 export function start(): Promise<Http2Server | undefined> {
     loadSettings()
-    startWatching()
+    if (eventsEnabled) {
+        startWatching()
+    }
     return startServer({ requestHandler })
 }
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,4 @@
 /* Copyright Contributors to the Open Cluster Management project */
-
-/* istanbul ignore file */
 import Router from 'find-my-way'
 import { Http2Server, Http2ServerRequest, Http2ServerResponse } from 'http2'
 import { loadSettings, stopSettingsWatch } from './lib/config'

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -41,7 +41,7 @@ router.all(`/apis/*`, proxy)
 router.all(`/apiPaths`, apiPaths)
 router.all(`/version`, proxy)
 router.all(`/version/`, proxy)
-if (isDevelopment) {
+if (!isProduction) {
     router.get(`/login`, login)
     router.get(`/login/callback`, loginCallback)
     router.get(`/logout`, logout)
@@ -54,7 +54,7 @@ router.post(`/proxy/search`, search)
 router.get(`/authenticated`, authenticated)
 router.post(`/ansibletower`, ansibleTower)
 router.get(`/*`, serve)
-if (isDevelopment) {
+if (!isProduction) {
     router.get('/configure', configure)
     router.get('/username', username)
 }

--- a/backend/src/lib/multi-cluster-hub.ts
+++ b/backend/src/lib/multi-cluster-hub.ts
@@ -2,7 +2,7 @@
 
 import { jsonRequest } from './json-request'
 import { logger } from './logger'
-import { getServiceAccountToken } from '../routes/liveness'
+import { getServiceAccountToken } from '../routes/serviceAccountToken'
 
 // Type returned by /apis/authentication.k8s.io/v1/tokenreviews
 interface MultiClusterHub {

--- a/backend/src/routes/apiPaths.ts
+++ b/backend/src/routes/apiPaths.ts
@@ -5,7 +5,7 @@ import { jsonRequest } from '../lib/json-request'
 import { logger } from '../lib/logger'
 import { respondInternalServerError, unauthorized } from '../lib/respond'
 import { getToken, isAuthenticated } from '../lib/token'
-import { getServiceAccountToken } from './liveness'
+import { getServiceAccountToken } from './serviceAccountToken'
 
 interface APIPathResponse {
     paths: string[]

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -14,7 +14,7 @@ import { unauthorized } from '../lib/respond'
 import { ServerSideEvent, ServerSideEvents } from '../lib/server-side-events'
 import { getToken } from '../lib/token'
 import { IResource } from '../resources/resource'
-import { getServiceAccountToken } from './liveness'
+import { getServiceAccountToken } from './serviceAccountToken'
 
 const { map, split } = eventStream
 const pipeline = promisify(Stream.pipeline)

--- a/backend/src/routes/liveness.ts
+++ b/backend/src/routes/liveness.ts
@@ -1,5 +1,4 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { readFileSync } from 'fs'
 import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
 import { Agent } from 'https'
 import { FetchError } from 'node-fetch'
@@ -7,6 +6,7 @@ import { fetchRetry } from '../lib/fetch-retry'
 import { logger } from '../lib/logger'
 import { respondInternalServerError, respondOK } from '../lib/respond'
 import { getOauthInfoPromise } from './oauth'
+import { getServiceAccountToken } from './serviceAccountToken'
 const { HTTP2_HEADER_AUTHORIZATION } = constants
 
 // The kubelet uses liveness probes to know when to restart a container.
@@ -26,33 +26,13 @@ export function setDead(): void {
     }
 }
 
-export function getServiceAccountToken(): string {
-    if (serviceAccountToken === undefined) {
-        try {
-            serviceAccountToken = readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf-8')
-        } catch (err: unknown) {
-            serviceAccountToken = process.env.TOKEN
-            if (!serviceAccountToken) {
-                if (err instanceof Error) {
-                    logger.error('Error reading service account token', err && err.message)
-                } else {
-                    logger.error({ msg: 'Error reading service account token', err: err })
-                }
-                process.exit(1)
-            }
-        }
-    }
-    return serviceAccountToken
-}
-let serviceAccountToken: string
-
 const agent = new Agent({ rejectUnauthorized: false })
 
 export async function apiServerPing(): Promise<void> {
     const msg = 'kube api server ping failed'
     try {
         const response = await fetchRetry(process.env.CLUSTER_API_URL + '/apis', {
-            headers: { [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${serviceAccountToken}` },
+            headers: { [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${getServiceAccountToken()}` },
             agent,
         })
         if (response.status !== 200) {

--- a/backend/src/routes/serviceAccountToken.ts
+++ b/backend/src/routes/serviceAccountToken.ts
@@ -1,0 +1,25 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { readFileSync } from 'fs'
+import { logger } from '../lib/logger'
+
+export let serviceAccountToken: string
+
+export function getServiceAccountToken(): string {
+    if (serviceAccountToken === undefined) {
+        try {
+            serviceAccountToken = readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf-8')
+        } catch (err: unknown) {
+            serviceAccountToken = process.env.TOKEN
+            if (!serviceAccountToken) {
+                if (err instanceof Error) {
+                    logger.error('Error reading service account token', err && err.message)
+                } else {
+                    logger.error({ msg: 'Error reading service account token', err: err })
+                }
+                process.exit(1)
+            }
+        }
+    }
+    return serviceAccountToken
+}

--- a/backend/src/routes/serviceAccountToken.ts
+++ b/backend/src/routes/serviceAccountToken.ts
@@ -11,6 +11,7 @@ export function getServiceAccountToken(): string {
             serviceAccountToken = readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf-8')
         } catch (err: unknown) {
             serviceAccountToken = process.env.TOKEN
+            /* istanbul ignore if */
             if (!serviceAccountToken) {
                 if (err instanceof Error) {
                     logger.error('Error reading service account token', err && err.message)

--- a/backend/src/routes/username.ts
+++ b/backend/src/routes/username.ts
@@ -5,7 +5,7 @@ import { jsonPost } from '../lib/json-request'
 import { logger } from '../lib/logger'
 import { respondInternalServerError, unauthorized } from '../lib/respond'
 import { getToken } from '../lib/token'
-import { getServiceAccountToken } from './liveness'
+import { getServiceAccountToken } from './serviceAccountToken'
 
 // Type returned by /apis/authentication.k8s.io/v1/tokenreviews
 interface TokenReview {

--- a/backend/test/routes/liveness.test.ts
+++ b/backend/test/routes/liveness.test.ts
@@ -1,0 +1,20 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { request } from '../mock-request'
+import nock from 'nock'
+import { apiServerPing, setDead } from '../../src/routes/liveness'
+
+describe(`liveness Route`, function () {
+    it(`GET /livenessProbe should return status code 200`, async function () {
+        nock(process.env.CLUSTER_API_URL).get('/.well-known/oauth-authorization-server').reply(200, {
+            authorization_endpoint: 'https://oauth-openshift.apps.example.com/oauth/token',
+        })
+        const res = await request('GET', '/livenessProbe')
+        expect(res.statusCode).toEqual(200)
+    })
+    it(`GET /livenessProbe should return status code 500 if dead`, async function () {
+        nock(process.env.CLUSTER_API_URL).get('/apis').reply(401)
+        await apiServerPing()
+        const res = await request('GET', '/livenessProbe')
+        expect(res.statusCode).toEqual(500)
+    })
+})

--- a/backend/test/routes/liveness.test.ts
+++ b/backend/test/routes/liveness.test.ts
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { request } from '../mock-request'
 import nock from 'nock'
-import { apiServerPing, setDead } from '../../src/routes/liveness'
+import { apiServerPing } from '../../src/routes/liveness'
 
 describe(`liveness Route`, function () {
     it(`GET /livenessProbe should return status code 200`, async function () {

--- a/setup.sh
+++ b/setup.sh
@@ -20,9 +20,6 @@ echo OAUTH2_CLIENT_SECRET=$OAUTH2_CLIENT_SECRET >> ./backend/.env
 OAUTH2_REDIRECT_URL=https://localhost:3000/multicloud/login/callback
 echo OAUTH2_REDIRECT_URL=$OAUTH2_REDIRECT_URL >> ./backend/.env
 
-BACKEND_URL=https://localhost:4000
-echo BACKEND_URL=$BACKEND_URL >> ./backend/.env
-
 FRONTEND_URL=https://localhost:3000
 echo FRONTEND_URL=$FRONTEND_URL >> ./backend/.env
 


### PR DESCRIPTION
https://github.com/stolostron/backlog/issues/22342

Adds environment variable switch to disable resource watching and the events API in the console backend. ACM plugin data fetching is shared with MCE in 2.7, so there is no reason for the ACM pods to consume memory and CPU watching resources for data that will never be queried.