### PR TITLE
MGMT-12072: Remove onFormSaveError() mock handler

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAgentModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAgentModal.tsx
@@ -15,7 +15,6 @@ const EditAgentModal: React.FC<{
         usedHostnames={usedHostnames}
         onClose={() => setAgent(undefined)}
         onSave={onSaveAgent}
-        onFormSaveError={() => {}}
     />
 )
 


### PR DESCRIPTION
So far optional, it's being removed in the ai-ui-lib.

Related to: https://github.com/openshift-assisted/assisted-ui-lib/pull/1810/