### PR TITLE
Only display the onboarding modal if there are no existing clusters(except local-cluster).

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -73,7 +73,9 @@ export default function ManagedClusters() {
 
     const onBoardingModalID = `${window.location.href}/clusteronboardingmodal`
     const [openOnboardingModal, setOpenOnboardingModal] = useState<boolean>(
-        localStorage.getItem(onBoardingModalID) ? localStorage.getItem(onBoardingModalID) === 'show' : true
+        localStorage.getItem(onBoardingModalID)
+            ? localStorage.getItem(onBoardingModalID) === 'show'
+            : clusters.length === 1
     )
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -75,7 +75,7 @@ export default function ManagedClusters() {
     const [openOnboardingModal, setOpenOnboardingModal] = useState<boolean>(
         localStorage.getItem(onBoardingModalID)
             ? localStorage.getItem(onBoardingModalID) === 'show'
-            : clusters.length === 1
+            : clusters.length === 6 && clusters.find((lc) => lc.name === 'local-cluster') !== undefined //Check if one cluster exists and it is local-cluster
     )
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -75,7 +75,7 @@ export default function ManagedClusters() {
     const [openOnboardingModal, setOpenOnboardingModal] = useState<boolean>(
         localStorage.getItem(onBoardingModalID)
             ? localStorage.getItem(onBoardingModalID) === 'show'
-            : clusters.length === 6 && clusters.find((lc) => lc.name === 'local-cluster') !== undefined //Check if one cluster exists and it is local-cluster
+            : clusters.length === 1 && clusters.find((lc) => lc.name === 'local-cluster') !== undefined //Check if one cluster exists and it is local-cluster
     )
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Signed-off-by: Omar Farag <ofarag@redhat.com>

Closes https://issues.redhat.com/browse/ACM-2480

Before: Onboarding Modal would show even with multiple clusters
![image](https://user-images.githubusercontent.com/15898988/208538337-c942e30b-7545-4144-a6ed-0e5970d41853.png)

Now: Only shows when one cluster (local-cluster) exists