### PR TITLE
Allow copied yaml to be edited in the create policy wizard

### DIFF
--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -23,6 +23,7 @@ export interface SyncEditorProps extends HTMLProps<HTMLPreElement> {
     secrets?: (string | string[])[]
     filters?: (string | string[])[]
     immutables?: (string | string[])[]
+    editableUidSiblings?: boolean
     syncs?: unknown
     readonly?: boolean
     mock?: boolean
@@ -39,6 +40,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
         schema,
         secrets,
         immutables,
+        editableUidSiblings,
         code,
         syncs,
         filters,
@@ -320,7 +322,8 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
                 readonly === true,
                 userEdits,
                 validationRef.current,
-                model.getValue()
+                model.getValue(),
+                editableUidSiblings
             )
             setProhibited(protectedRanges)
             setFilteredRows(filteredRows)
@@ -420,7 +423,8 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
                 immutables,
                 readonly === true,
                 validationRef.current,
-                value
+                value,
+                editableUidSiblings
             )
             setLastUnredactedChange(unredactedChange)
             setProhibited(protectedRanges)

--- a/frontend/src/components/SyncEditor/process.test.js
+++ b/frontend/src/components/SyncEditor/process.test.js
@@ -1,0 +1,36 @@
+/* Copyright Contributors to the Open Cluster Management project */
+'use strict'
+
+import { processUser } from './process'
+
+describe('Test process.ts', () => {
+    afterAll(() => {
+        jest.resetAllMocks()
+    })
+
+    const policyYamlWithUid =
+        'apiVersion: policy.open-cluster-management.io/v1\n' +
+        'kind: Policy\n' +
+        'metadata:\n' +
+        '  name: foobar\n' +
+        '  namespace: default\n' +
+        '  uid: 9f7de1f1-b46f-47df-8ef4-0930aecc5902\n' +
+        'spec:\n' +
+        '  disabled: false\n'
+
+    const processUserWrapper = (monacoRef, yaml, editableUidSiblings) => {
+        return processUser(monacoRef, yaml, [], [], false, [], [], [], false, [], yaml, editableUidSiblings)
+    }
+
+    it('should not have any protected ranges when Uid siblings are editable', () => {
+        const monacoRef = { current: { Range: jest.fn() } }
+        const { protectedRanges } = processUserWrapper(monacoRef, policyYamlWithUid, true)
+        expect(protectedRanges).toEqual([])
+    })
+
+    it('should have protected ranges when Uid siblings are not editable', () => {
+        const monacoRef = { current: { Range: jest.fn() } }
+        const { protectedRanges } = processUserWrapper(monacoRef, policyYamlWithUid, false)
+        expect(protectedRanges).toHaveLength(3) // name, namespace, and uid
+    })
+})

--- a/frontend/src/components/SyncEditor/process.ts
+++ b/frontend/src/components/SyncEditor/process.ts
@@ -52,7 +52,8 @@ export const processForm = (
     readonly: boolean,
     userEdits: ChangeType[],
     validators: any,
-    currentEditorValue: string
+    currentEditorValue: string,
+    editableUidSiblings: boolean | undefined
 ) => {
     // get yaml, documents, resource, mapped
     let yaml = code || ''
@@ -99,7 +100,8 @@ export const processForm = (
             readonly,
             validators,
             currentEditorValue,
-            false
+            false,
+            editableUidSiblings
         ),
     }
 }
@@ -115,7 +117,8 @@ export const processUser = (
     immutables: (string | string[])[] | undefined,
     readonly: boolean,
     validators: any,
-    currentEditorValue: string
+    currentEditorValue: string,
+    editableUidSiblings: boolean | undefined
 ) => {
     // get yaml, documents, resource, mapped
     const documents: any[] = YAML.parseAllDocuments(yaml, { prettyErrors: true, keepCstNodes: true })
@@ -142,7 +145,8 @@ export const processUser = (
             readonly,
             validators,
             currentEditorValue,
-            true
+            true,
+            editableUidSiblings
         ),
     }
 }
@@ -161,7 +165,8 @@ const process = (
     readonly: boolean,
     validators: any,
     currentEditorValue: string,
-    editorHasFocus: boolean
+    editorHasFocus: boolean,
+    editableUidSiblings: boolean | undefined
 ) => {
     // restore hidden secret values
     let { mappings, parsed, resources, paths } = getMappings(documents)
@@ -231,7 +236,7 @@ const process = (
     const protectedRanges: any[] = []
     if (!isEmpty(parsed)) {
         const allImmutables = immutables ? getMatchingValues(immutables, paths) : []
-        const uidSiblings = getUidSiblings(paths, mappings)
+        const uidSiblings = editableUidSiblings ? [] : getUidSiblings(paths, mappings)
         ;[...allSecrets, ...uidSiblings, ...allImmutables].forEach((value) => {
             if (value && value.$p) {
                 const range = get(mappings, getPathArray(value.$p))

--- a/frontend/src/components/SyncEditor/validation.ts
+++ b/frontend/src/components/SyncEditor/validation.ts
@@ -108,7 +108,7 @@ export function validate(
         requiredTypes[kind]--
         let d: number = get(kindMap, kind, 0)
         // determine validation for this resource
-        let validator = validators[0].validator
+        let validator = validators[0]?.validator
         if (validators.length > 1) {
             validator = validatorMap[kind]?.validator
             if (!validator && kind) {

--- a/frontend/src/routes/Governance/policies/CreatePolicy.tsx
+++ b/frontend/src/routes/Governance/policies/CreatePolicy.tsx
@@ -24,6 +24,7 @@ export function WizardSyncEditor() {
             onEditorChange={(changes: { resources: any[] }): void => {
                 update(changes?.resources)
             }}
+            editableUidSiblings={true}
         />
     )
 }

--- a/frontend/src/routes/Governance/policies/CreatePolicy.tsx
+++ b/frontend/src/routes/Governance/policies/CreatePolicy.tsx
@@ -33,7 +33,7 @@ function getWizardSyncEditor() {
     return <WizardSyncEditor />
 }
 
-export function CreatePolicy() {
+export function CreatePolicy(props: { initialResources?: IResource[] }) {
     const { t } = useTranslation()
     const {
         managedClusterSetBindingsState,
@@ -69,6 +69,7 @@ export function CreatePolicy() {
             policies={policies}
             clusters={managedClusters}
             yamlEditor={getWizardSyncEditor}
+            resources={props.initialResources}
             namespaces={namespaceNames}
             placements={placements}
             placementRules={placementRules}

--- a/frontend/src/wizards/Policy/PolicyWizard.tsx
+++ b/frontend/src/wizards/Policy/PolicyWizard.tsx
@@ -131,7 +131,7 @@ export function PolicyWizard(props: {
                         )}
 
                         <ItemContext.Consumer>
-                            {(item: IResource) => (
+                            {() => (
                                 <Fragment>
                                     <WizTextInput
                                         id="name"
@@ -140,7 +140,7 @@ export function PolicyWizard(props: {
                                         placeholder={t('Enter the name')}
                                         required
                                         validation={validatePolicyName}
-                                        readonly={item.metadata?.uid !== undefined}
+                                        readonly={props.editMode === EditMode.Edit}
                                     />
                                     <WizSingleSelect
                                         id="namespace"
@@ -152,7 +152,7 @@ export function PolicyWizard(props: {
                                         )}
                                         options={props.namespaces}
                                         required
-                                        readonly={item.metadata?.uid !== undefined}
+                                        readonly={props.editMode === EditMode.Edit}
                                     />
                                 </Fragment>
                             )}


### PR DESCRIPTION
Previously, if you copied in YAML from another policy you had already created (ie copied from the "Edit Policy" page), you were unable to edit many of the fields. Now, you can edit those fields as needed.