### PR TITLE
ACM-2361 Enable addons for AWS Hypershift clusters on import 

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterDetails.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterDetails.test.tsx
@@ -85,6 +85,12 @@ import {
     Secret,
     SecretApiVersion,
     SecretKind,
+    Namespace,
+    NamespaceApiVersion,
+    NamespaceKind,
+    KlusterletAddonConfig,
+    KlusterletAddonConfigApiVersion,
+    KlusterletAddonConfigKind,
 } from '../../../../../resources'
 import {
     MultiClusterEngine,
@@ -890,6 +896,47 @@ const mockManagedClusterAddOns: ManagedClusterAddOn[] = [
     mockManagedClusterAddOnSearch,
 ]
 
+const mockKlusterletAddonConfig: KlusterletAddonConfig = {
+    apiVersion: KlusterletAddonConfigApiVersion,
+    kind: KlusterletAddonConfigKind,
+    metadata: {
+        name: 'hostedCluster1',
+        namespace: 'hostedCluster1',
+    },
+    spec: {
+        clusterName: 'hostedCluster1',
+        clusterNamespace: 'hostedCluster1',
+        clusterLabels: {
+            cloud: 'Amazon',
+            vendor: 'Openshift',
+        },
+        applicationManager: {
+            enabled: false,
+            argocdCluster: false,
+        },
+        policyController: {
+            enabled: true,
+        },
+        searchCollector: {
+            enabled: true,
+        },
+        certPolicyController: {
+            enabled: true,
+        },
+        iamPolicyController: {
+            enabled: true,
+        },
+    },
+}
+
+const mockNamespace: Namespace = {
+    apiVersion: NamespaceApiVersion,
+    kind: NamespaceKind,
+    metadata: {
+        name: 'hostedCluster1',
+    },
+}
+
 const mockHostedCluster1: HostedClusterK8sResource = {
     apiVersion: HostedClusterApiVersion,
     kind: HostedClusterKind,
@@ -1508,6 +1555,8 @@ describe('ClusterDetails with not found', () => {
 
         const mockImportHostedCluster = [
             nockCreate(createManagedcluster1, createManagedcluster1),
+            nockCreate(mockKlusterletAddonConfig, mockKlusterletAddonConfig),
+            nockCreate(mockNamespace, mockNamespace),
             nockPatch(mockHostedCluster1 as IResource, [
                 {
                     op: 'replace',
@@ -1519,12 +1568,12 @@ describe('ClusterDetails with not found', () => {
                 },
             ]),
         ]
+
         userEvent.click(
             screen.getByRole('button', {
                 name: /import cluster/i,
             })
         )
-
         await waitForNocks(mockImportHostedCluster)
     })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftImportCommand.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftImportCommand.tsx
@@ -12,6 +12,9 @@ import {
     ManagedCluster,
     ManagedClusterApiVersion,
     ManagedClusterKind,
+    KlusterletAddonConfigApiVersion,
+    KlusterletAddonConfigKind,
+    KlusterletAddonConfig,
     patchResource,
     unpackSecret,
 } from '../../../../../resources'
@@ -77,6 +80,39 @@ export const HypershiftImportCommand = (props: { selectedHostedClusterResource: 
             },
         }
 
+        const klusterletAddonConfig: KlusterletAddonConfig = {
+            apiVersion: KlusterletAddonConfigApiVersion,
+            kind: KlusterletAddonConfigKind,
+            metadata: {
+                name: hdName,
+                namespace: hdNamespace,
+            },
+            spec: {
+                clusterName: hdName!,
+                clusterNamespace: hdNamespace!,
+                clusterLabels: {
+                    cloud: 'Amazon',
+                    vendor: 'Openshift',
+                },
+                applicationManager: {
+                    enabled: false,
+                    argocdCluster: false,
+                },
+                policyController: {
+                    enabled: true,
+                },
+                searchCollector: {
+                    enabled: true,
+                },
+                certPolicyController: {
+                    enabled: true,
+                },
+                iamPolicyController: {
+                    enabled: true,
+                },
+            },
+        }
+
         const updateAnnotations = {
             'cluster.open-cluster-management.io/managedcluster-name': hdName,
             'cluster.open-cluster-management.io/hypershiftdeployment': `${hdNamespace}/${hdName}`,
@@ -102,6 +138,8 @@ export const HypershiftImportCommand = (props: { selectedHostedClusterResource: 
         patchResource(selectedHostedClusterResource as IResource, [
             { op: 'replace', path: '/metadata/annotations', value: updateAnnotations },
         ])
+
+        createResource(klusterletAddonConfig as IResource)
     }
 
     if (!v1ImportCommand && cluster?.isHypershift && HostedClusterReadyStatus?.status === 'True') {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftImportCommand.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftImportCommand.tsx
@@ -17,6 +17,9 @@ import {
     KlusterletAddonConfig,
     patchResource,
     unpackSecret,
+    Namespace,
+    NamespaceApiVersion,
+    NamespaceKind,
 } from '../../../../../resources'
 import { AcmAlert, AcmButton, AcmToastContext } from '../../../../../ui-components'
 import { ClusterContext } from '../ClusterDetails/ClusterDetails'
@@ -85,11 +88,11 @@ export const HypershiftImportCommand = (props: { selectedHostedClusterResource: 
             kind: KlusterletAddonConfigKind,
             metadata: {
                 name: hdName,
-                namespace: hdNamespace,
+                namespace: hdName,
             },
             spec: {
                 clusterName: hdName!,
-                clusterNamespace: hdNamespace!,
+                clusterNamespace: hdName!,
                 clusterLabels: {
                     cloud: 'Amazon',
                     vendor: 'Openshift',
@@ -110,6 +113,14 @@ export const HypershiftImportCommand = (props: { selectedHostedClusterResource: 
                 iamPolicyController: {
                     enabled: true,
                 },
+            },
+        }
+
+        const clusterNameSpace: Namespace = {
+            apiVersion: NamespaceApiVersion,
+            kind: NamespaceKind,
+            metadata: {
+                name: hdName,
             },
         }
 
@@ -138,6 +149,11 @@ export const HypershiftImportCommand = (props: { selectedHostedClusterResource: 
         patchResource(selectedHostedClusterResource as IResource, [
             { op: 'replace', path: '/metadata/annotations', value: updateAnnotations },
         ])
+
+        //Create namespace for addons if it doesn't already exist
+        try {
+            createResource(clusterNameSpace as IResource)
+        } catch (err) {}
 
         createResource(klusterletAddonConfig as IResource)
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-2361

Creates KlusterletAddonConfig for the managed cluster to enable addons