### PR TITLE
Handle policy sets that are not placed on a cluster

### DIFF
--- a/frontend/src/resources/placement-decision.ts
+++ b/frontend/src/resources/placement-decision.ts
@@ -12,7 +12,7 @@ export interface PlacementDecision extends IResource {
     apiVersion: PlacementDecisionApiVersionType
     kind: PlacementDecisionKindType
     metadata: Metadata
-    status: PlacementDecisionStatus
+    status?: PlacementDecisionStatus
 }
 
 export interface PlacementDecisionStatus {

--- a/frontend/src/routes/Governance/common/util.tsx
+++ b/frontend/src/routes/Governance/common/util.tsx
@@ -122,7 +122,7 @@ export function getPolicyComplianceForPolicySet(
 
     const policyCompliance: PolicyCompliance[] = []
     for (const placementDecision of policySetPlacementDecisions) {
-        for (const decision of placementDecision.status.decisions) {
+        for (const decision of placementDecision.status?.decisions || []) {
             for (const policy of policySetPolicies) {
                 const policyIdx = policyCompliance.findIndex((p) => p.policyName === policy.metadata.name!)
                 const policyClusterStatus = policy.status?.status?.find(
@@ -213,7 +213,7 @@ export function getClustersComplianceForPolicySet(
     const policySetPolicies = getPolicySetPolicies(policies, policySet)
     const clustersCompliance: Record<string, 'Compliant' | 'NonCompliant' | 'Pending' | 'Unknown'> = {}
     for (const placementDecision of policySetPlacementDecisions) {
-        for (const decision of placementDecision.status.decisions) {
+        for (const decision of placementDecision.status?.decisions || []) {
             if (clustersCompliance[decision.clusterName] === 'NonCompliant') {
                 continue
             }

--- a/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
+++ b/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
@@ -238,7 +238,7 @@ export function PolicySetDetailSidebar(props: { policySet: PolicySet }) {
         (policy: Policy) => {
             return decision.length
                 ? policy?.status?.status?.filter((status) => {
-                      return decision[0].status.decisions.find(
+                      return (decision[0].status?.decisions || []).find(
                           (decisionStatus) => decisionStatus.clusterName === status.clustername
                       )
                   })


### PR DESCRIPTION
When there are no placement decisions associated with the policy set or the policies within it, the console would crash when viewing the details of the policy set.