### PR TITLE
ACM-1947: Hide cluster claim name for hosted clusters and hub

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
@@ -329,14 +329,14 @@ export function ClusterOverviewPageContent(props: {
         leftItems.splice(5, 0, clusterProperties.channel)
     }
 
-    // clusterClaim should not be shown for stand alone clusters not from a clusterpool and not for hosted control planes.
+    // clusterClaim should not be shown for stand alone clusters not from a clusterpool
     if (
-        (clusterProperties.clusterControlPlaneType?.value === t('Standalone') &&
-            clusterProperties.clusterPool?.value === undefined) ||
-        clusterProperties.clusterControlPlaneType?.value === t('Hosted') ||
-        clusterProperties.clusterControlPlaneType?.value === t('Hub, Hosted')
+        (clusterProperties.clusterControlPlaneType?.value === t('Standalone') ||
+            clusterProperties.clusterControlPlaneType?.value === t('Hub')) &&
+        clusterProperties.clusterPool?.value === undefined
     ) {
         leftItems.splice(2, 1)
+        rightItems.splice(6, 1)
     }
 
     if (
@@ -392,6 +392,14 @@ export function ClusterOverviewPageContent(props: {
         leftItems.splice(7, 0, clusterProperties.acmDistribution)
         leftItems.splice(8, 0, clusterProperties.acmChannel)
         rightItems.splice(2, 0, clusterProperties.acmConsoleUrl)
+    }
+
+    // clusterClaim should not be shown for hosted control planes.
+    if (
+        clusterProperties.clusterControlPlaneType?.value === t('Hosted') ||
+        clusterProperties.clusterControlPlaneType?.value === t('Hub, Hosted')
+    ) {
+        leftItems.splice(2, 1)
     }
 
     let details = <ProgressStepBar />


### PR DESCRIPTION
Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>

This PR is for hiding the Cluster Claim name row in the clusterOverview page when the cluster is a standalone cluster with no cluster pool or is a hosted control plane. This is for patching a missed part of https://github.com/stolostron/console/pull/2364, where the hosted cluster was still being shown. 
![Screenshot from 2023-01-06 10-57-29](https://user-images.githubusercontent.com/17188326/211052249-0ee2e3af-94e6-4af0-ae34-bc4193e5c711.png)
![Screenshot from 2023-01-06 10-57-56](https://user-images.githubusercontent.com/17188326/211052278-a0b1136b-8d87-4efe-b599-450d4aa63634.png)
As well removes the Cluster pool row when they are not from a cluster pool:
![Screenshot from 2023-01-06 11-02-38](https://user-images.githubusercontent.com/17188326/211052681-97c68e7d-9900-4418-b70b-c3d49b23a00e.png)

Addresses:
 - https://issues.redhat.com/browse/ACM-1947