### PR TITLE
ACM-2660 Hide "Update automation template" for hosted clusters

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.test.tsx
@@ -20,7 +20,14 @@ import { RecoilRoot } from 'recoil'
 import { MemoryRouter } from 'react-router'
 import { nockCreate, nockIgnoreApiPaths, nockIgnoreRBAC, nockPatch, nockRBAC } from '../../../../../lib/nock-util'
 import { rbacCreate, rbacDelete, rbacPatch } from '../../../../../lib/rbac-util'
-import { clickByLabel, clickByText, waitForNock, waitForNocks, waitForText } from '../../../../../lib/test-util'
+import {
+    clickByLabel,
+    clickByText,
+    waitForNock,
+    waitForNocks,
+    waitForNotText,
+    waitForText,
+} from '../../../../../lib/test-util'
 import { ClusterActionDropdown } from './ClusterActionDropdown'
 import { NavigationPath } from '../../../../../NavigationPath'
 
@@ -197,6 +204,15 @@ describe('ClusterActionDropdown', () => {
         await clickByText('Resume cluster')
         await clickByText('Resume')
         await waitForNock(nockPatch)
+    })
+
+    test('update automation template should not be shown for hosted cluster', async () => {
+        const cluster = JSON.parse(JSON.stringify(mockCluster))
+        cluster.isHostedCluster = true
+        render(<Component cluster={cluster} />)
+        await clickByLabel('Actions')
+        await waitForText('Detach cluster')
+        await waitForNotText('Update automation template')
     })
 })
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
@@ -140,6 +140,11 @@ export function getClusterActions(cluster: Cluster) {
     ) {
         actionIds = actionIds.filter((id) => id !== 'ai-scale-up')
     }
+
+    // Remove "Update automation template" for hosted clusters
+    if (cluster.isHostedCluster) {
+        actionIds = actionIds.filter((id) => id !== 'update-automation-template')
+    }
     return actionIds
 }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.test.tsx
@@ -252,6 +252,50 @@ const mockClusterRoks: Cluster = {
     isRegionalHubCluster: false,
 }
 
+const mockClusterHosted: Cluster = {
+    name: 'cluster-5-hosted',
+    displayName: 'cluster-5-hosted',
+    namespace: 'cluster-5-hosted',
+    uid: 'cluster-5-hosted',
+    status: ClusterStatus.ready,
+    isHive: false,
+    provider: Provider.aws,
+    distribution: {
+        k8sVersion: '1.24',
+        ocp: {
+            availableUpdates: [],
+            desiredVersion: '4.11.17',
+            upgradeFailed: false,
+            version: '4.11.17',
+        },
+        displayVersion: 'Openshift 4.11.17',
+        isManagedOpenShift: false,
+        upgradeInfo: {
+            upgradeFailed: false,
+            isUpgrading: false,
+            isReadyUpdates: false,
+            isReadySelectChannels: false,
+            availableUpdates: [],
+            currentVersion: '4.11.17',
+            desiredVersion: '4.11.17',
+            latestJob: {},
+        },
+    },
+    hive: {
+        isHibernatable: false,
+        secrets: {},
+    },
+    isManaged: true,
+    isCurator: false,
+    isHostedCluster: true,
+    isSNOCluster: false,
+    owner: {},
+    kubeadmin: '',
+    kubeconfig: '',
+    isHypershift: true,
+    isRegionalHubCluster: false,
+}
+
 const providerConnectionAnsible: ProviderConnection = {
     apiVersion: ProviderConnectionApiVersion,
     kind: ProviderConnectionKind,
@@ -346,6 +390,7 @@ const mockClusters: Array<Cluster> = [
     mockClusterNonOCP,
     mockClusterPending,
     mockClusterRoks,
+    mockClusterHosted,
 ]
 
 describe('UpdateAutomationModal', () => {
@@ -374,7 +419,7 @@ describe('UpdateAutomationModal', () => {
         render(<Component />)
 
         // Show alert with automation support message
-        await waitForText('4 clusters cannot be edited')
+        await waitForText('5 clusters cannot be edited')
         await waitFor(() =>
             expect(screen.getByTestId('view-selected').getAttribute('aria-disabled')).not.toEqual('false')
         )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.tsx
@@ -101,7 +101,8 @@ export function UpdateAutomationModal(props: {
             isReady &&
             !isUpgrading &&
             !isRoks &&
-            !isCloudLabelSet
+            !isCloudLabelSet &&
+            !cluster.isHostedCluster
         )
     }
 


### PR DESCRIPTION
For hosted clusters:
- Remove "Update automation template" from cluster actions
- Mark them not-updatable for bulk action "Update automation template"

https://issues.redhat.com/browse/ACM-2660