### PR TITLE
Update openshift-assisted-ui-lib to v2.7.8-cim

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -53,7 +53,7 @@
                 "moment-timezone": "^0.5.37",
                 "monaco-editor": "0.33.0",
                 "object-hash": "3.0.0",
-                "openshift-assisted-ui-lib": "2.7.7-cim",
+                "openshift-assisted-ui-lib": "2.7.8-cim",
                 "ramda": "0.28.0",
                 "react-error-boundary": "3.1.4",
                 "react-masonry-css": "1.0.16",
@@ -32075,9 +32075,9 @@
             }
         },
         "node_modules/openshift-assisted-ui-lib": {
-            "version": "2.7.7-cim",
-            "resolved": "https://registry.npmjs.org/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.7-cim.tgz",
-            "integrity": "sha512-24mqfNqEevHi+cOtozIIDJQZIDxXM7F4OuHEnzopAzJKfuZAuJzIX0rCGwZ/S1wiKXY7BqGzUjLRQ+IDkar4xQ==",
+            "version": "2.7.8-cim",
+            "resolved": "https://registry.npmjs.org/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.8-cim.tgz",
+            "integrity": "sha512-YAZ6OoKnaROcp8VnpvGysPU6kgN1/m6N/lo8RbVVmlIyHvhfDCIvpn/P/SrvE0eTkMkMGmRPdvENs+LYqW6ARw==",
             "dependencies": {
                 "axios-case-converter": "^0.8.1",
                 "cidr-tools": "^4.3.0",
@@ -65465,9 +65465,9 @@
             }
         },
         "openshift-assisted-ui-lib": {
-            "version": "2.7.7-cim",
-            "resolved": "https://registry.npmjs.org/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.7-cim.tgz",
-            "integrity": "sha512-24mqfNqEevHi+cOtozIIDJQZIDxXM7F4OuHEnzopAzJKfuZAuJzIX0rCGwZ/S1wiKXY7BqGzUjLRQ+IDkar4xQ==",
+            "version": "2.7.8-cim",
+            "resolved": "https://registry.npmjs.org/openshift-assisted-ui-lib/-/openshift-assisted-ui-lib-2.7.8-cim.tgz",
+            "integrity": "sha512-YAZ6OoKnaROcp8VnpvGysPU6kgN1/m6N/lo8RbVVmlIyHvhfDCIvpn/P/SrvE0eTkMkMGmRPdvENs+LYqW6ARw==",
             "requires": {
                 "axios-case-converter": "^0.8.1",
                 "cidr-tools": "^4.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -73,7 +73,7 @@
         "moment-timezone": "^0.5.37",
         "monaco-editor": "0.33.0",
         "object-hash": "3.0.0",
-        "openshift-assisted-ui-lib": "2.7.7-cim",
+        "openshift-assisted-ui-lib": "2.7.8-cim",
         "ramda": "0.28.0",
         "react-error-boundary": "3.1.4",
         "react-masonry-css": "1.0.16",


### PR DESCRIPTION
Includes latest translation updates

Fixes MGMT-12940, MGMT-12928, MGMT-12929

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>