### PR TITLE
Skip search query when OCP apps are filtered out

### DIFF
--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -27,6 +27,7 @@ export type SearchQuery = {
     input: {
       filters: { property: string; values: string[] | string }[]
       relatedKinds?: string[]
+      limit?: number
     }[]
   }
   query: string
@@ -89,11 +90,25 @@ export function queryOCPAppResources(): IRequestResult<ISearchResult> {
               values: ['cronjob', 'daemonset', 'deployment', 'deploymentconfig', 'job', 'statefulset'],
             },
           ],
+          limit: 6500, // search said not to use unlimited results so use this for now until pagination is available
         },
       ],
     },
     query: searchFilterQuery,
   })
+}
+
+// Used when need to maintain same number of hooks called
+export function queryEmpty(): IRequestResult<ISearchResult> {
+  const abortController = new AbortController()
+  return {
+    promise: Promise.resolve<ISearchResult>({
+      data: {
+        searchResult: [],
+      },
+    }),
+    abort: () => abortController.abort(),
+  }
 }
 
 export function useSearchParams() {

--- a/frontend/src/routes/Applications/Application.sharedmocks.tsx
+++ b/frontend/src/routes/Applications/Application.sharedmocks.tsx
@@ -364,6 +364,7 @@ export const mockSearchQueryOCPApplications = {
             values: ['cronjob', 'daemonset', 'deployment', 'deploymentconfig', 'job', 'statefulset'],
           },
         ],
+        limit: 6500,
       },
     ],
   },

--- a/frontend/src/routes/Applications/ApplicationsPage.tsx
+++ b/frontend/src/routes/Applications/ApplicationsPage.tsx
@@ -53,7 +53,7 @@ export default function ApplicationsPage() {
       }
     }
     if (!loadingOCPResources) {
-      stopPollingOCPResources
+      stopPollingOCPResources()
     }
   }, [applicationsMatch, loadingOCPResources, startPolling, startPollingOCPResources, stopPollingOCPResources])
 

--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -737,9 +737,16 @@ export default function ApplicationsOverview() {
               const isFlux = isFluxApplication(item.label)
               switch (value) {
                 case 'openshiftapps':
-                  return !isFlux && !item.metadata?.namespace?.startsWith('openshift-')
+                  return (
+                    !isFlux &&
+                    !item.metadata?.namespace?.startsWith('openshift-') &&
+                    item.metadata?.namespace !== 'openshift'
+                  )
                 case 'openshift-default':
-                  return !isFlux && item.metadata?.namespace?.startsWith('openshift-')
+                  return (
+                    !isFlux &&
+                    (item.metadata?.namespace?.startsWith('openshift-') || item.metadata?.namespace === 'openshift')
+                  )
                 case 'fluxapps':
                   return isFlux
               }


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://issues.redhat.com/browse/ACM-2503

- Don't run OCP apps search query if they are filtered out
- Fix filter count for non default OCP apps