### PR TITLE
Mark more policies as externally managed

### DIFF
--- a/frontend/src/routes/Governance/common/util.test.tsx
+++ b/frontend/src/routes/Governance/common/util.test.tsx
@@ -1,0 +1,36 @@
+/* Copyright Contributors to the Open Cluster Management project */
+'use strict'
+
+import { resolveExternalStatus } from './util'
+import { Policy } from '../../../resources'
+
+describe('Test resolveExternalStatus', () => {
+  const mockPolicyWithManagers = (managers: string[]): Policy => {
+    return {
+      apiVersion: 'policy.open-cluster-management.io/v1',
+      kind: 'Policy',
+      metadata: {
+        name: 'mock-policy',
+        namespace: 'test',
+        managedFields: managers.map((m) => ({ manager: m })),
+      },
+      spec: {
+        disabled: false,
+      },
+    }
+  }
+
+  test.each([
+    { managers: [], expected: false },
+    { managers: ['kubectl'], expected: false },
+    { managers: ['argocd-controller'], expected: true },
+    { managers: ['argocd-application-controller'], expected: true },
+    { managers: ['multicluster-operators-subscription'], expected: true },
+    { managers: ['multicluster-operators-subscription-controller'], expected: false },
+    { managers: ['kubectl', 'argocd-controller'], expected: true },
+    { managers: ['multicluster-operators-subscription', 'kubectl'], expected: true },
+  ])('resolveExternalStatus with managers $managers should be $expected', ({ managers, expected }) => {
+    const policy = mockPolicyWithManagers(managers)
+    expect(resolveExternalStatus(policy)).toEqual(expected)
+  })
+})

--- a/frontend/src/routes/Governance/common/util.tsx
+++ b/frontend/src/routes/Governance/common/util.tsx
@@ -286,9 +286,9 @@ export function getClustersSummaryForPolicySet(
 }
 
 export function resolveExternalStatus(policy: Policy) {
-  const knownExternalManagers = ['multicluster-operators-subscription', 'argocd-application-controller']
+  const knownExternalManagerPatterns = [/^multicluster-operators-subscription$/, /argocd/]
   const managedFields = policy.metadata.managedFields ?? []
-  return managedFields.some((mf) => knownExternalManagers.includes(mf.manager ?? 'none'))
+  return managedFields.some((mf) => knownExternalManagerPatterns.some((p) => p.test(mf.manager ?? 'none')))
 }
 
 function getHelmReleaseMap(helmReleases: HelmRelease[]) {


### PR DESCRIPTION
Policies are determined to be local or externally managed based on their managed fields. Previously, only exact values were checked, but the ArgoCD manager's name sometimes varies slightly, so some policies from Argo were being marked as "local". Now pattern matching is used to mark more policies correctly.

Refs:
 - https://issues.redhat.com/browse/ACM-2846

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>