### PR TITLE
MGMT-13551 Move reconcilePause control to automationControlData

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -386,11 +386,6 @@ export const clusterDetailsControlData = (t) => {
       type: 'hidden',
       active: false,
     },
-    {
-      active: '',
-      id: 'reconcilePause',
-      type: 'hidden',
-    },
   ]
 }
 
@@ -693,6 +688,11 @@ export const automationControlData = (t) => {
       id: 'toweraccess-destroy',
       type: 'hidden',
       active: '',
+    },
+    {
+      active: '',
+      id: 'reconcilePause',
+      type: 'hidden',
     },
   ]
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAI.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAI.test.js.snap
@@ -135,6 +135,11 @@ Array [
     "type": "hidden",
   },
   Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
     "comment": "Ensure these settings are correct. The saved cluster draft will be used to determine the available network resources. Therefore after you press Save you will not be able to change these cluster settings.",
     "disableEditorOnSuccess": true,
     "disablePreviousControlsOnSuccess": true,
@@ -295,6 +300,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAWS.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAWS.test.js.snap
@@ -79,11 +79,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -1825,6 +1820,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1914,11 +1914,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -3660,6 +3655,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -5513,11 +5513,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -7409,6 +7404,11 @@ Array [
     "type": "hidden",
   },
   Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
     "active": true,
     "id": "includeKlusterletAddonConfig",
     "type": "hidden",
@@ -7492,11 +7492,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -9241,6 +9236,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAZR.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAZR.test.js.snap
@@ -79,11 +79,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -1461,6 +1456,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1540,11 +1540,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -2923,6 +2918,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]
@@ -4403,11 +4403,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -5783,6 +5778,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataCIM.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataCIM.test.js.snap
@@ -135,6 +135,11 @@ Array [
     "type": "hidden",
   },
   Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
     "comment": "Ensure these settings are correct. The saved cluster draft will be used to determine the available network resources. Therefore after you press Save you will not be able to change these cluster settings.",
     "disableEditorOnSuccess": true,
     "disablePreviousControlsOnSuccess": true,
@@ -300,6 +305,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataGCP.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataGCP.test.js.snap
@@ -79,11 +79,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -1075,6 +1070,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1154,11 +1154,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -2151,6 +2146,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]
@@ -3245,11 +3245,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -4239,6 +4234,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataHypershift.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataHypershift.test.js.snap
@@ -167,6 +167,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -335,6 +340,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataOST.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataOST.test.js.snap
@@ -79,11 +79,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -628,6 +623,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -707,11 +707,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1259,6 +1254,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1338,11 +1338,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1888,6 +1883,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataRHV.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataRHV.test.js.snap
@@ -81,11 +81,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -660,6 +655,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]
@@ -746,11 +746,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -1327,6 +1322,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1408,11 +1408,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1990,6 +1985,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataVMW.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataVMW.test.js.snap
@@ -82,11 +82,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -661,6 +656,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -743,11 +743,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1325,6 +1320,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1407,11 +1407,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1987,6 +1982,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]


### PR DESCRIPTION
`reconcilePause` control flag is currently only used by `onChangeAutomationTemplate` function inside `automationControlData`. The function relies on the control to be defined in the `controlData` otherwise an error occurs when trying to set `reconcilePause.active` value. Since the `reconcilePause` control was defined in `clusterDetailsControlData`, for the wizards (e.g. CIM or AI) which don't use this step the error occurred.

To fix this, we're moving the reconcilePause control to automationControlData which is only controlData which actually uses that flag.