### PR TITLE
[2.7] MGMT-13551 Move reconcilePause control to automationControlData

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -378,11 +378,6 @@ export const clusterDetailsControlData = (t) => {
             type: 'hidden',
             active: false,
         },
-        {
-            active: '',
-            id: 'reconcilePause',
-            type: 'hidden',
-        },
     ]
 }
 
@@ -685,6 +680,11 @@ export const automationControlData = (t) => {
             id: 'toweraccess-destroy',
             type: 'hidden',
             active: '',
+        },
+        {
+            active: '',
+            id: 'reconcilePause',
+            type: 'hidden',
         },
     ]
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAI.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAI.test.js.snap
@@ -135,6 +135,11 @@ Array [
     "type": "hidden",
   },
   Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
     "comment": "Ensure these settings are correct. The saved cluster draft will be used to determine the available network resources. Therefore after you press Save you will not be able to change these cluster settings.",
     "disableEditorOnSuccess": true,
     "disablePreviousControlsOnSuccess": true,
@@ -295,6 +300,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAWS.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAWS.test.js.snap
@@ -79,11 +79,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -1824,6 +1819,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1913,11 +1913,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -3658,6 +3653,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -5510,11 +5510,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -7405,6 +7400,11 @@ Array [
     "type": "hidden",
   },
   Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
     "active": true,
     "id": "includeKlusterletAddonConfig",
     "type": "hidden",
@@ -7488,11 +7488,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -9236,6 +9231,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAZR.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataAZR.test.js.snap
@@ -79,11 +79,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -1460,6 +1455,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1539,11 +1539,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -2921,6 +2916,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]
@@ -4400,11 +4400,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -5779,6 +5774,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataCIM.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataCIM.test.js.snap
@@ -135,6 +135,11 @@ Array [
     "type": "hidden",
   },
   Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
+  Object {
     "comment": "Ensure these settings are correct. The saved cluster draft will be used to determine the available network resources. Therefore after you press Save you will not be able to change these cluster settings.",
     "disableEditorOnSuccess": true,
     "disablePreviousControlsOnSuccess": true,
@@ -300,6 +305,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataGCP.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataGCP.test.js.snap
@@ -79,11 +79,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -1074,6 +1069,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1153,11 +1153,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -2149,6 +2144,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]
@@ -3242,11 +3242,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -4235,6 +4230,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataHypershift.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataHypershift.test.js.snap
@@ -167,6 +167,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -335,6 +340,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataOST.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataOST.test.js.snap
@@ -79,11 +79,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -627,6 +622,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -706,11 +706,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1257,6 +1252,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1336,11 +1336,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1885,6 +1880,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataRHV.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataRHV.test.js.snap
@@ -81,11 +81,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -659,6 +654,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]
@@ -745,11 +745,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -1325,6 +1320,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1406,11 +1406,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1987,6 +1982,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataVMW.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataVMW.test.js.snap
@@ -82,11 +82,6 @@ Array [
     "type": "hidden",
   },
   Object {
-    "active": "",
-    "id": "reconcilePause",
-    "type": "hidden",
-  },
-  Object {
     "fetchAvailable": Object {
       "emptyDesc": "No default images. Enter a release image path.",
       "loadingDesc": "Loading release image sets...",
@@ -660,6 +655,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -742,11 +742,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1323,6 +1318,11 @@ Array [
     "id": "toweraccess-destroy",
     "type": "hidden",
   },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
+    "type": "hidden",
+  },
 ]
 `;
 
@@ -1405,11 +1405,6 @@ Array [
   Object {
     "active": false,
     "id": "showSecrets",
-    "type": "hidden",
-  },
-  Object {
-    "active": "",
-    "id": "reconcilePause",
     "type": "hidden",
   },
   Object {
@@ -1984,6 +1979,11 @@ Array [
   Object {
     "active": "",
     "id": "toweraccess-destroy",
+    "type": "hidden",
+  },
+  Object {
+    "active": "",
+    "id": "reconcilePause",
     "type": "hidden",
   },
 ]


### PR DESCRIPTION
`reconcilePause` control flag is currently only used by `onChangeAutomationTemplate` function inside automationControlData. The function relies on the control to be defined in the controlData otherwise an error occurs when trying to set reconcilePause.active value. Since the reconcilePause control was defined in clusterDetailsControlData, for the wizards (e.g. CIM or AI) which don't use this step the error occurred.

To fix this, we're moving the reconcilePause control to automationControlData which is only controlData which actually uses that flag.

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>

Cherry-picked from 405b2654