### PR TITLE
ACM-2863 Fix create application button in dark mode

### DIFF
--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -1010,7 +1010,7 @@ export default function ApplicationsOverview() {
           },
         ]}
         isKebab={false}
-        isPlain={true}
+        isPlain={false}
         isPrimary={true}
         // tooltipPosition={tableDropdown.tooltipPosition}
         // dropdownPosition={DropdownPosition.left}

--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
@@ -170,7 +170,6 @@ export function AcmDropdown(props: AcmDropdownProps) {
           )
         }
         isOpen={isOpen}
-        isPlain={props.isPlain}
       />
     </TooltipWrapper>
   )

--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
@@ -170,6 +170,7 @@ export function AcmDropdown(props: AcmDropdownProps) {
           )
         }
         isOpen={isOpen}
+        isPlain={props.isPlain}
       />
     </TooltipWrapper>
   )


### PR DESCRIPTION
Aligns the 'Create application' button so it works properly in dark mode.
Before:
![Screenshot from 2023-02-08 16-00-13](https://user-images.githubusercontent.com/17188326/217650183-401517e6-7641-4078-a118-0fd718bf6e85.png)


After: 
![Screenshot from 2023-02-08 15-59-06](https://user-images.githubusercontent.com/17188326/217650193-118e6aea-d978-468c-a4a1-bd4f0937bd0d.png)




The prop, isPlain was already being set by the useStyles() func above.

Addresses:
 - https://issues.redhat.com/browse/ACM-2863


Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>