### PR TITLE
ACM-3195

### DIFF
--- a/frontend/src/components/Topology/css/topology-details.css
+++ b/frontend/src/components/Topology/css/topology-details.css
@@ -10,6 +10,7 @@
     top: 0px;
     box-shadow: var(--pf-c-page--section--m-sticky-top--BoxShadow);
     z-index: var(--pf-c-page--section--m-sticky-top--ZIndex);
+    background-color: var(--pf-global--BackgroundColor--100);
 }
 
 .topologyDetails .detailsHeader .innerDetailsHeader {


### PR DESCRIPTION
Added background color to prevent text overflow on scroll

Before: 
![image](https://user-images.githubusercontent.com/15898988/217945241-dfc0583d-d116-4a5b-b63b-87edc1532073.png)

After: 
![image](https://user-images.githubusercontent.com/15898988/217945108-11bae182-7c51-4871-96b0-b8987ee43c87.png)


Signed-off-by: Omar Farag <ofarag@redhat.com>