### PR TITLE
[2.6] ACM-3668 Move installAttemptsLimit control to automationControlData

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -361,11 +361,6 @@ export const clusterDetailsControlData = [
         type: 'hidden',
         active: false,
     },
-    {
-        active: 1,
-        id: 'installAttemptsLimit',
-        type: 'hidden',
-    },
 ]
 
 export const clusterPoolDetailsControlData = [
@@ -659,6 +654,11 @@ export const automationControlData = [
         id: 'toweraccess-destroy',
         type: 'hidden',
         active: '',
+    },
+    {
+        active: 1,
+        id: 'installAttemptsLimit',
+        type: 'hidden',
     },
 ]
 


### PR DESCRIPTION
`installAttemtpsLimit` control flag is currently only used by `onChangeAutomationTemplate` function inside automationControlData. The function relies on the control to be defined in the controlData otherwise an error occurs when trying to set installAttemtsLimit.active value. Since the installAttemptsLimit control was defined in clusterDetailsControlData, for the wizards (e.g. CIM or AI) which don't use this step the error occured.

To fix this, we're moving the installAttemptsLimit control to automationControlData which is only controlData which actually uses that flag.

Cherry-picked from 405b2654ef1b1f0ad19dafda8a177d72690961c5

Signed-off-by: Jiri Tomasek <jtomasek@redhat.com>