### PR TITLE
ACM-2112 Fix filter value clash

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -48,7 +48,7 @@ const config: Config.InitialOptions = {
   ci: true,
   collectCoverage: true,
   coverageDirectory: './coverage',
-  coverageReporters: ['text-summary', 'html', ['lcov', { projectRoot: '../' }]],
+  coverageReporters: ['text', 'text-summary', 'html', ['lcov', { projectRoot: '../' }]],
   collectCoverageFrom: [
     '<rootDir>/src/**/*.{tsx,ts,jsx,js}',
     '<rootDir>/src/*.{tsx,ts,jsx,js}',

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1313,7 +1313,6 @@
     "Failed to get job names from Ansible": "Failed to get job names from Ansible",
     "False": "False",
     "Filter": "Filter",
-    "Filter select error: Incorrect selection type": "Filter select error: Incorrect selection type",
     "Filters": "Filters",
     "Find": "Find",
     "Find by name": "Find by name",

--- a/frontend/src/routes/Applications/Overview.test.tsx
+++ b/frontend/src/routes/Applications/Overview.test.tsx
@@ -106,17 +106,14 @@ describe('Applications Page', () => {
 
     // Open filter
     userEvent.click(screen.getByText('Filter'))
-    expect(screen.getByTestId('app.k8s.io/Application')).toBeTruthy()
-    userEvent.click(screen.getByTestId('app.k8s.io/Application'))
+    expect(screen.getByRole('checkbox', { name: /subscription/i })).toBeTruthy()
+    userEvent.click(screen.getByRole('checkbox', { name: /subscription/i }))
 
     // Close filter
     userEvent.click(screen.getByText('Filter'))
-    const subscriptionCheckBox = screen.queryByTestId('app.k8s.io/Application')
-    expect(subscriptionCheckBox).toBeNull()
-    const applicationSetType = screen.queryByText(ApplicationSetKind)
-    expect(applicationSetType).toBeNull()
-    const discoveredType = screen.queryByText('Discovered')
-    expect(discoveredType).toBeNull()
+    expect(screen.queryByRole('checkbox', { name: /subscription/i })).toBeNull()
+    expect(screen.queryByText(ApplicationSetKind)).toBeNull()
+    expect(screen.queryByText('Discovered')).toBeNull()
     expect(screen.getAllByText(SubscriptionKind)).toBeTruthy()
 
     // clear subscription filter
@@ -125,16 +122,14 @@ describe('Applications Page', () => {
     // argo apps
     // Open filter
     userEvent.click(screen.getByText('Filter'))
-    expect(screen.getByTestId('argoproj.io/Application')).toBeTruthy()
-    userEvent.click(screen.getByTestId('argoproj.io/Application'))
+    expect(screen.getByRole('checkbox', { name: /argo cd/i })).toBeTruthy()
+    userEvent.click(screen.getByRole('checkbox', { name: /argo cd/i }))
 
     // Close filter
     userEvent.click(screen.getByText('Filter'))
-    const argoCheckBox = screen.queryByTestId('argoproj.io/Application')
-    expect(argoCheckBox).toBeNull()
-    const applicationType = screen.queryByText(ApplicationKind)
-    expect(applicationType).toBeNull()
-    expect(applicationSetType).toBeNull()
+    expect(screen.queryByRole('checkbox', { name: /argo cd/i })).toBeNull()
+    expect(screen.queryByText(ApplicationKind)).toBeNull()
+    expect(screen.queryByText(ApplicationSetKind)).toBeNull()
     expect(screen.getAllByText('Discovered')).toBeTruthy()
 
     // clear argo filter
@@ -143,15 +138,14 @@ describe('Applications Page', () => {
     // appset
     // Open filter
     userEvent.click(screen.getByText('Filter'))
-    expect(screen.getByTestId('argoproj.io/ApplicationSet')).toBeTruthy()
-    userEvent.click(screen.getByTestId('argoproj.io/ApplicationSet'))
+    expect(screen.getByRole('checkbox', { name: /application set/i })).toBeTruthy()
+    userEvent.click(screen.getByRole('checkbox', { name: /application set/i }))
 
     // Close filter
     userEvent.click(screen.getByText('Filter'))
-    const argoAppSetCheckBox = screen.queryByTestId('argoproj.io/ApplicationSet')
-    expect(argoAppSetCheckBox).toBeNull()
-    expect(applicationType).toBeNull()
-    expect(discoveredType).toBeNull()
+    expect(screen.queryByRole('checkbox', { name: /application set/i })).toBeNull()
+    expect(screen.queryByText(ApplicationKind)).toBeNull()
+    expect(screen.queryByText('Discovered')).toBeNull()
     expect(screen.getAllByText(ApplicationSetKind)).toBeTruthy()
 
     // clear appset filter
@@ -160,15 +154,14 @@ describe('Applications Page', () => {
     // OCP
     // Open filter
     userEvent.click(screen.getByText('Filter'))
-    expect(screen.getByTestId('openshiftapps')).toBeTruthy()
-    userEvent.click(screen.getByTestId('openshiftapps'))
+    expect(screen.getByRole('checkbox', { name: /openshift/i })).toBeTruthy()
+    userEvent.click(screen.getByRole('checkbox', { name: /openshift/i }))
 
     // Close filter
     userEvent.click(screen.getByText('Filter'))
-    const ocpCheckBox = screen.queryByTestId('openshiftapps')
-    expect(ocpCheckBox).toBeNull()
-    expect(applicationType).toBeNull()
-    expect(discoveredType).toBeNull()
+    expect(screen.queryByRole('checkbox', { name: /openshift/i })).toBeNull()
+    expect(screen.queryByText(ApplicationKind)).toBeNull()
+    expect(screen.queryByText('Discovered')).toBeNull()
 
     // clear openshift filter
     userEvent.click(screen.getByRole('button', { name: /close openshift/i }))

--- a/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
@@ -894,18 +894,18 @@ describe('AcmTable', () => {
     // Table renders
     expect(getByText('Filter')).toBeInTheDocument()
     userEvent.click(getByText('Filter'))
-    expect(getByTestId('male')).toBeInTheDocument()
+    expect(getByTestId('gender-male')).toBeInTheDocument()
 
     // Filtering works
-    userEvent.click(getByTestId('male'))
+    userEvent.click(getByTestId('gender-male'))
     expect(container.querySelectorAll('.pf-c-chip-group__list-item')).toHaveLength(1)
-    userEvent.click(getByTestId('female'))
+    userEvent.click(getByTestId('gender-female'))
     expect(container.querySelectorAll('.pf-c-chip-group__list-item')).toHaveLength(2)
 
     // Unselect current options
-    userEvent.click(getByTestId('female'))
+    userEvent.click(getByTestId('gender-female'))
     expect(container.querySelectorAll('.pf-c-chip-group__list-item')).toHaveLength(1)
-    userEvent.click(getByTestId('male'))
+    userEvent.click(getByTestId('gender-male'))
     expect(container.querySelectorAll('.pf-c-chip-group__list-item')).toHaveLength(0)
   })
 
@@ -932,16 +932,16 @@ describe('AcmTable', () => {
     // Test deleting chip group
     expect(getByText('Filter')).toBeInTheDocument()
     userEvent.click(getByText('Filter'))
-    userEvent.click(getByTestId('male'))
-    userEvent.click(getByTestId('female'))
+    userEvent.click(getByTestId('gender-male'))
+    userEvent.click(getByTestId('gender-female'))
     userEvent.click(getByLabelText('Close chip group'))
     expect(container.querySelectorAll('.pf-c-chip-group__list-item')).toHaveLength(0)
 
     // test deleting single chip
     expect(getByText('Filter')).toBeInTheDocument()
     userEvent.click(getByText('Filter'))
-    userEvent.click(getByTestId('male'))
-    userEvent.click(getByTestId('female'))
+    userEvent.click(getByTestId('gender-male'))
+    userEvent.click(getByTestId('gender-female'))
     userEvent.click(getAllByLabelText('close')[1])
     expect(container.querySelectorAll('.pf-c-chip-group__list-item')).toHaveLength(1)
     userEvent.click(getAllByLabelText('close')[0])
@@ -950,7 +950,7 @@ describe('AcmTable', () => {
     // test deleting all selected filters
     expect(getByText('Filter')).toBeInTheDocument()
     userEvent.click(getByText('Filter'))
-    userEvent.click(getByTestId('male'))
+    userEvent.click(getByTestId('gender-male'))
     userEvent.click(getAllByText('Clear all filters')[1])
     expect(container.querySelectorAll('.pf-c-chip-group__list-item')).toHaveLength(0)
   })

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -1361,7 +1361,7 @@ function TableColumnFilters<T>(props: {
           onSelect={(
             _event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,
             selection: SelectOptionObject
-          ) => onFilterSelect(selection)}
+          ) => onFilterSelect(selection as FilterSelectOptionObject)}
           selections={Object.keys(toolbarFilterIds).reduce(
             (acc: string[], val: string) => acc.concat(toolbarFilterIds[val]),
             []

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -1310,10 +1310,6 @@ function TableColumnFilters<T>(props: {
               key={key}
               inputId={key}
               value={createFilterSelectOptionObject(filter.filter.id, option.option.value)}
-              isChecked={
-                /* istanbul ignore next */
-                toolbarFilterIds[filter.filter.id]?.indexOf(option.option.value) > -1 ?? false
-              }
             >
               <div className={classes.filterOption}>
                 {option.option.label}
@@ -1328,6 +1324,14 @@ function TableColumnFilters<T>(props: {
     ))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filters, items, toolbarFilterIds])
+
+  const selections = useMemo(() => {
+    return Object.keys(toolbarFilterIds).reduce(
+      (acc: FilterSelectOptionObject[], filterId: string) =>
+        acc.concat(toolbarFilterIds[filterId].map((value) => createFilterSelectOptionObject(filterId, value))),
+      []
+    )
+  }, [toolbarFilterIds])
 
   return (
     <ToolbarItem>
@@ -1362,11 +1366,9 @@ function TableColumnFilters<T>(props: {
             _event: React.MouseEvent<Element, MouseEvent> | React.ChangeEvent<Element>,
             selection: SelectOptionObject
           ) => onFilterSelect(selection as FilterSelectOptionObject)}
-          selections={Object.keys(toolbarFilterIds).reduce(
-            (acc: string[], val: string) => acc.concat(toolbarFilterIds[val]),
-            []
-          )}
+          selections={selections}
           isOpen={isOpen}
+          isGrouped
           placeholderText={
             <div>
               <FilterIcon className={classes.filterLabelMargin} />


### PR DESCRIPTION
Allow different filters to have options with the same value, e.g. cluster status/node status/add-on status might all use `Unknown` as a value.

Also fixes keyboard navigability for the filter select menu.