### PR TITLE
Fix case where users use same name different namespace for resources 2.8

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/components/DetailsTable.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/components/DetailsTable.js
@@ -59,7 +59,10 @@ class DetailsTable extends Component {
     resources.forEach((resource) => {
       clustersNames.forEach((cluster) => {
         Array.from(Array(replicaCount)).forEach((_, i) => {
-          const status = statusMap[`${resource.name}-${cluster}`]
+          const modelKey = resource.namespace
+            ? `${resource.name}-${cluster}-${resource.namespace}`
+            : `${resource.name}-${cluster}`
+          const status = statusMap[modelKey]
           available.push({
             pulse: status && status.length > i ? status[i].pulse || 'green' : 'orange',
             name: status && status.length > i ? status[i].name : resource.name,

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/helpers/diagram-helpers.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/helpers/diagram-helpers.js
@@ -423,9 +423,12 @@ export const addResourceToModel = (resourceMapObject, kind, relatedKind, nameWit
     resourceType === 'project'
       ? _.get(resourceMapObject, `specs.projectModel`, {})
       : _.get(resourceMapObject, `specs.${kind.toLowerCase()}Model`, {})
-  const kindList = kindModel[`${nameWithoutChartRelease}-${relatedKind.cluster}`] || []
+  const modelKey = relatedKind.namespace
+    ? `${nameWithoutChartRelease}-${relatedKind.cluster}-${relatedKind.namespace}`
+    : `${nameWithoutChartRelease}-${relatedKind.cluster}`
+  const kindList = kindModel[modelKey] || []
   kindList.push(relatedKind)
-  kindModel[`${nameWithoutChartRelease}-${relatedKind.cluster}`] = kindList
+  kindModel[modelKey] = kindList
   _.set(resourceMapObject, `specs.${resourceType === 'project' ? 'project' : kind.toLowerCase()}Model`, kindModel)
 }
 
@@ -600,10 +603,14 @@ export const addNodeServiceLocation = (node, clusterName, targetNS, details, t) 
 //generic function to write location info
 export const addNodeInfoPerCluster = (node, clusterName, targetNS, details, getDetailsFunction, t) => {
   const resourceName = _.get(node, 'name', '')
+  const resourceNamespace = _.get(node, 'namespace')
   const resourceMap = _.get(node, `specs.${node.type}Model`, {})
 
   const locationDetails = []
-  const resourcesForCluster = resourceMap[`${resourceName}-${clusterName}`] || []
+  const modelKey = resourceNamespace
+    ? `${resourceName}-${clusterName}-${resourceNamespace}`
+    : `${resourceName}-${clusterName}`
+  const resourcesForCluster = resourceMap[modelKey] || []
   const typeObject = _.find(resourcesForCluster, (obj) => _.get(obj, 'namespace', '') === targetNS)
   if (typeObject) {
     getDetailsFunction(node, typeObject, locationDetails, t, clusterName)

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/helpers/diagram-helpers.test.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/helpers/diagram-helpers.test.js
@@ -1233,7 +1233,7 @@ describe('addNodeServiceLocation 1', () => {
     id: 'member--member--deployable--member--clusters--possiblereptile--default--mortgage-app-subscription-mortgage-mortgage-app-deploy-service--service--mortgage-app-deploy',
     specs: {
       serviceModel: {
-        'mortgage-app-deploy-possiblereptile': [
+        'mortgage-app-deploy-possiblereptile-default': [
           {
             namespace: 'default',
             clusterIP: '1.1',

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeRelated.test.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeRelated.test.js
@@ -3789,7 +3789,7 @@ describe('addDiagramDetails', () => {
             },
           },
           subscriptionModel: {
-            'feng-bz-subscription-1-local-cluster': [
+            'feng-bz-subscription-1-local-cluster-feng-bz': [
               {
                 _gitbranch: 'master',
                 _gitpath: 'resources17',
@@ -3812,7 +3812,7 @@ describe('addDiagramDetails', () => {
                 timeWindow: 'none',
               },
             ],
-            'feng-bz-subscription-1-local-local-cluster': [
+            'feng-bz-subscription-1-local-local-cluster-feng-bz': [
               {
                 _gitbranch: 'master',
                 _gitpath: 'resources17',

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.test.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.test.js
@@ -1132,7 +1132,7 @@ describe('setResourceDeployStatus 2', () => {
         },
       },
       serviceModel: {
-        'mortgage-app-svc-possiblereptile': [
+        'mortgage-app-svc-possiblereptile-default': [
           {
             cluster: 'possiblereptile',
             clusterIP: '172.30.140.196',
@@ -1209,7 +1209,7 @@ describe('setResourceDeployStatus 2 with filter green', () => {
         },
       },
       serviceModel: {
-        'mortgage-app-svc-possiblereptile': [
+        'mortgage-app-svc-possiblereptile-default': [
           {
             cluster: 'possiblereptile',
             clusterIP: '172.30.140.196',


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

https://issues.redhat.com/browse/ACM-3337

- Add namespace to the model key to make it more unique for when users use the same resource name but different namespaces in their apps