### PR TITLE
UI fix of NavItem highlighting

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -332,7 +332,7 @@ function AppSidebar(props: { routes: (IRoute | IRouteGroup)[] }) {
                   key={route.title}
                   title={route.title}
                   isExpanded
-                  isActive={!!route.routes.find((route) => location.pathname.startsWith(route.route)}
+                  isActive={!!route.routes.find((route) => location.pathname.startsWith(route.route))}
                 >
                   {route.routes.map((route) => (
                     <NavItem key={route.route} isActive={location.pathname.startsWith(route.route)}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -332,7 +332,7 @@ function AppSidebar(props: { routes: (IRoute | IRouteGroup)[] }) {
                   key={route.title}
                   title={route.title}
                   isExpanded
-                  isActive={!!route.routes.find((route) => location.pathname === route.route)}
+                  isActive={!!route.routes.find((route) => location.pathname.startsWith(route.route)}
                 >
                   {route.routes.map((route) => (
                     <NavItem key={route.route} isActive={location.pathname.startsWith(route.route)}>
@@ -341,7 +341,7 @@ function AppSidebar(props: { routes: (IRoute | IRouteGroup)[] }) {
                   ))}
                 </NavExpandable>
               ) : (
-                <NavItem key={route.route} isActive={location.pathname === route.route}>
+                <NavItem key={route.route} isActive={location.pathname.startsWith(route.route)}>
                   <Link to={route.route}>{route.title}</Link>
                 </NavItem>
               )


### PR DESCRIPTION
in ACM 2.5+, when opening the "clusters" menu tab (sub-item of Infrastructure), the opened URL does not end with /clusters, therefore the isActive member of NavItem would always return false.  In ACM 2.5 line 338's isActive check was the same as in 335 and 344, which was fixed in ACM 2.6+. The bug persists for NavItem's that are either a group or not children of a group. The suggested PR is a fix for the above.

steps to reproduce the bug:
1. Expand Infrastructure NavItem
2. Open clusters sub-NavItem
3. Close Infrastructure NavItem

Bugged behavior:
Infrastructure NavItem is not highlighted 

Wanted behavior:
Infrastructure NavItem is highlighted (same as all other cases, e.g., Welcome).

This bug exists also in upstream.