### PR TITLE
ACM-3940 Fix Ansible icon

### DIFF
--- a/frontend/src/ui-components/AcmIcons/AnsibleIcon.tsx
+++ b/frontend/src/ui-components/AcmIcons/AnsibleIcon.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { Fragment } from 'react'
+import './ansible-icon.css'
 import { createAcmIcon } from './createAcmIcon'
 
 export const AnsibleIcon = createAcmIcon({
@@ -8,14 +8,18 @@ export const AnsibleIcon = createAcmIcon({
   yOffset: 0,
   width: 37,
   height: 37,
+  className: 'ansible-icon',
   svgPaths: (
-    <Fragment>
+    <>
       <defs>
         <style>
-          {`.uuid-a5d4a7af-350f-43cb-b3e1-2e9a53ceee32{fill:#e00;}.uuid-e8c797bc-3e74-4433-92df-d7da1b4c814d{fill:#fff;}`}
+          {`.uuid-a5d4a7af-350f-43cb-b3e1-2e9a53ceee32{fill:#e00;}.uuid-e8c797bc-3e74-4433-92df-d7da1b4c814d{fill:#fff;}.uuid-02d8fd21-9ba4-4492-bd10-fea7749ddc54{fill:#000;}`}
         </style>
       </defs>
-      <path d="M28,1H10C5.0294,1,1,5.0294,1,10V28c0,4.9706,4.0294,9,9,9H28c4.9706,0,9-4.0294,9-9V10c0-4.9706-4.0294-9-9-9h0Z" />
+      <path
+        className="uuid-02d8fd21-9ba4-4492-bd10-fea7749ddc54"
+        d="M28,1H10C5.0294,1,1,5.0294,1,10V28c0,4.9706,4.0294,9,9,9H28c4.9706,0,9-4.0294,9-9V10c0-4.9706-4.0294-9-9-9h0Z"
+      />
       <path
         className="uuid-e8c797bc-3e74-4433-92df-d7da1b4c814d"
         d="M14.9995,23.625c-.0859,0-.1729-.0176-.2563-.0552-.3149-.1421-.4546-.5122-.313-.8267l4-8.8677c.2026-.4482,.939-.4473,1.1392,0l4,8.8677c.1182,.2598,.0439,.5664-.1787,.7446-.2227,.1787-.5371,.1846-.7656,.0117l-5.3511-4.0205-1.7041,3.7778c-.1045,.2314-.332,.3682-.5703,.3682Zm2.8013-5.314l3.6289,2.7271-2.4297-5.3857-1.1992,2.6587Z"
@@ -24,7 +28,7 @@ export const AnsibleIcon = createAcmIcon({
         className="uuid-a5d4a7af-350f-43cb-b3e1-2e9a53ceee32"
         d="M19,30.125c-6.1343,0-11.125-4.9907-11.125-11.125S12.8657,7.875,19,7.875s11.125,4.9907,11.125,11.125-4.9902,11.125-11.125,11.125Zm0-21c-5.4453,0-9.875,4.4297-9.875,9.875s4.4297,9.875,9.875,9.875,9.875-4.4297,9.875-9.875-4.4297-9.875-9.875-9.875Z"
       />
-    </Fragment>
+    </>
   ),
 })
 

--- a/frontend/src/ui-components/AcmIcons/ansible-icon.css
+++ b/frontend/src/ui-components/AcmIcons/ansible-icon.css
@@ -1,0 +1,3 @@
+.ansible-icon {
+  filter: drop-shadow(0 0 1.5px white);
+}

--- a/frontend/src/ui-components/AcmIcons/ansible-icon.css
+++ b/frontend/src/ui-components/AcmIcons/ansible-icon.css
@@ -1,3 +1,3 @@
-.ansible-icon {
+:root:where(.pf-theme-dark) .ansible-icon {
   filter: drop-shadow(0 0 1.5px white);
 }

--- a/frontend/src/ui-components/AcmIcons/createAcmIcon.tsx
+++ b/frontend/src/ui-components/AcmIcons/createAcmIcon.tsx
@@ -11,6 +11,7 @@ export function createAcmIcon(iconDefinition: {
   xOffset?: number
   yOffset?: number
   svgPaths: ReactNode
+  className?: string
 }) {
   return (props: SVGIconProps) => {
     const { size, color, title, noVerticalAlign, ...otherProps } = props
@@ -27,6 +28,7 @@ export function createAcmIcon(iconDefinition: {
     return (
       <svg
         style={style}
+        className={iconDefinition.className}
         fill={color ?? 'currentColor'}
         height={heightWidth}
         width={heightWidth}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-3940

As per product icons brand standards, the AAP logo should have a drop shadow when shown on a dark background.
https://www.redhat.com/en/about/brand/standards/icons/product-icons

<img width="301" alt="image" src="https://user-images.githubusercontent.com/42188127/221963403-919a9d4b-d9c4-4dd3-94be-80dd4f60b583.png">

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/42188127/221963512-fbc7dfb4-f6d6-47e5-bfd8-b48cab9e56a0.png">
