### PR TITLE
ACM-3851 ACM-3850 : Addon detection fix

### DIFF
--- a/frontend/src/resources/utils/get-addons.ts
+++ b/frontend/src/resources/utils/get-addons.ts
@@ -63,7 +63,7 @@ export function mapAddons(
   return addons
 }
 
-export function getDisplayStatus(cma: ClusterManagementAddOn | undefined, mcas: ManagedClusterAddOn[]): string {
+function getDisplayStatus(cma: ClusterManagementAddOn | undefined, mcas: ManagedClusterAddOn[]): string {
   const mcaStatus = mcas?.find((mca) => mca.metadata.name === cma?.metadata.name)
   if (mcaStatus?.status?.conditions === undefined) {
     return AddonStatus.Disabled

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -20,7 +20,7 @@ import { ManagedCluster } from '../managed-cluster'
 import { ManagedClusterInfo, NodeInfo, OpenShiftDistributionInfo } from '../managed-cluster-info'
 import { managedClusterSetLabel } from '../managed-cluster-set'
 import { getLatest } from './utils'
-import { AddonStatus, getDisplayStatus } from './get-addons'
+import { AddonStatus, mapAddons } from './get-addons'
 import { AgentClusterInstallKind } from '../agent-cluster-install'
 import semver from 'semver'
 import { TFunction } from 'i18next'
@@ -954,9 +954,10 @@ export function getAddons(addons: ManagedClusterAddOn[], clusterManagementAddons
   let degraded = 0
   let unknown = 0
 
-  clusterManagementAddons?.forEach((cma) => {
-    const addonStatus = getDisplayStatus(cma, addons)
-    switch (addonStatus) {
+  const addonsStatus = mapAddons(clusterManagementAddons, addons)
+
+  addonsStatus?.forEach((addon) => {
+    switch (addon.status) {
       case AddonStatus.Available:
         available++
         break


### PR DESCRIPTION
Regarding: 
[ACM-3851](https://issues.redhat.com/browse/ACM-3851)
[ACM-3850](https://issues.redhat.com/browse/ACM-3850)

This change reuses an already implemented check for ManagedClusterAddons that lack a respective ManagmentClusterAddon.
