### PR TITLE
ACM-3947 fix placement query apiversion

### DIFF
--- a/frontend/src/routes/Applications/AdvancedConfiguration.tsx
+++ b/frontend/src/routes/Applications/AdvancedConfiguration.tsx
@@ -26,7 +26,7 @@ import {
   ChannelDefinition,
   ChannelKind,
   IResource,
-  PlacementApiVersionAlpha,
+  PlacementApiVersionBeta,
   PlacementDefinition,
   PlacementKind,
   PlacementRuleApiVersion,
@@ -554,7 +554,7 @@ export default function AdvancedConfiguration() {
               return editLink({
                 resource,
                 kind: 'Placement',
-                apiversion: PlacementApiVersionAlpha,
+                apiversion: _.get(resource, 'apiVersion') || PlacementApiVersionBeta,
               })
             },
             sort: 'metadata.name',

--- a/frontend/src/routes/Applications/AdvancedConfiguration.tsx
+++ b/frontend/src/routes/Applications/AdvancedConfiguration.tsx
@@ -339,7 +339,7 @@ export default function AdvancedConfiguration() {
               return editLink({
                 resource,
                 kind: 'Subscription',
-                apiversion: SubscriptionApiVersion,
+                apiversion: _.get(resource, 'apiVersion') || SubscriptionApiVersion,
               })
             },
             sort: 'metadata.name',
@@ -462,7 +462,7 @@ export default function AdvancedConfiguration() {
               return editLink({
                 resource,
                 kind: 'Channel',
-                apiversion: ChannelApiVersion,
+                apiversion: _.get(resource, 'apiVersion') || ChannelApiVersion,
               })
             },
             sort: 'metadata.name',
@@ -600,7 +600,7 @@ export default function AdvancedConfiguration() {
               return editLink({
                 resource,
                 kind: 'PlacementRule',
-                apiversion: PlacementRuleApiVersion,
+                apiversion: _.get(resource, 'apiVersion') || PlacementRuleApiVersion,
               })
             },
             sort: 'metadata.name',


### PR DESCRIPTION
Placement api version was outdated (hardcoded) causing query to fail

Before:
![image](https://user-images.githubusercontent.com/15898988/222004801-8879cd46-33c1-41b5-a726-1d3786c9b876.png)

After:
![image](https://user-images.githubusercontent.com/15898988/222004791-bbd09fa0-b6c2-49e2-88ea-2f7e5f1e4aab.png)
 