### PR TITLE
ACM-3787 (2.7) fetch placement apiversion for appset delete

### DIFF
--- a/frontend/src/routes/Applications/components/DeleteResourceModal.tsx
+++ b/frontend/src/routes/Applications/components/DeleteResourceModal.tsx
@@ -10,6 +10,7 @@ import { Trans } from '../../../lib/acm-i18next'
 import { deleteApplication } from '../../../lib/delete-application'
 import { ApplicationKind, ApplicationSetKind, IResource } from '../../../resources'
 import '../css/DeleteResourceModal.css'
+import { useRecoilState, useSharedAtoms } from '../../../shared-recoil'
 
 export interface IDeleteResourceModalProps {
     open: boolean
@@ -33,6 +34,9 @@ export function DeleteResourceModal(props: IDeleteResourceModalProps | { open: f
     const [removeAppResources, setRemoveAppResources] = useState<boolean>(false)
     const [removeAppSetResource, setRemoveAppSetResource] = useState<boolean>(false)
     const history = useHistory()
+    const { placementsState } = useSharedAtoms()
+    const [placements] = useRecoilState(placementsState)
+    const placementApiVersion = placements[0].apiVersion || 'cluster.open-cluster-management.io/v1beta1'
 
     if (props.open === false) {
         return <></>
@@ -62,7 +66,7 @@ export function DeleteResourceModal(props: IDeleteResourceModalProps | { open: f
                 props.appSetsSharingPlacement?.length === 0 && removeAppSetResource
                     ? [
                           {
-                              apiVersion: 'cluster.open-cluster-management.io/v1alpha1', // replace when placement type is available
+                              apiVersion: placementApiVersion,
                               kind: 'Placement',
                               name: props.appSetPlacement,
                               namespace: props.resource.metadata?.namespace,


### PR DESCRIPTION
fetch placement apiversion for appset delete

Outdated version of placement apiversion meant placements were not deleted with appset
