### PR TITLE
ACM-4222 Fix create application button in dark mode

### DIFF
--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -1033,7 +1033,7 @@ export default function ApplicationsOverview() {
                     },
                 ]}
                 isKebab={false}
-                isPlain={true}
+                isPlain={false}
                 isPrimary={true}
                 // tooltipPosition={tableDropdown.tooltipPosition}
                 // dropdownPosition={DropdownPosition.left}


### PR DESCRIPTION
Aligns the 'Create application' button so it works properly in dark mode.
Before:
![Screenshot from 2023-02-08 16-00-13](https://user-images.githubusercontent.com/17188326/217650183-401517e6-7641-4078-a118-0fd718bf6e85.png)


After: 
![Screenshot from 2023-02-08 15-59-06](https://user-images.githubusercontent.com/17188326/217650193-118e6aea-d978-468c-a4a1-bd4f0937bd0d.png)




Addresses:
 - https://issues.redhat.com/browse/ACM-4222
 - https://issues.redhat.com/browse/ACM-2863


Signed-off-by: Jonathan Marcantonio <jmarcant@redhat.com>