### PR TITLE
MGMT-13262: CIM/Hypershift: Enable hostPrefix and stop using podCIDR (deprecated)

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/NetworkForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/NetworkForm.tsx
@@ -10,7 +10,7 @@ import { HypershiftAgentContext } from './HypershiftAgentContext'
 import { isBMPlatform } from '../../../../../../InfraEnvironments/utils'
 import { useSharedAtoms, useSharedRecoil, useRecoilValue } from '../../../../../../../../shared-recoil'
 import { getTemplateValue } from '../utils'
-import { defaultPodCIDR, defaultServiceCIDR } from './constants'
+import { defaultHostPrefix, defaultPodCIDR, defaultServiceCIDR } from './constants'
 import { getClusterImageVersion, getDefaultNetworkType } from './utils'
 
 type FormControl = {
@@ -38,8 +38,9 @@ export const getDefaultNetworkFormValues = (
   // To preserve form values on Back button
   // Find a better way than parsing the yaml - is there already a parsed up-to-date template?
   const machineCIDR = getTemplateValue(templateYAML, 'machineCIDR', '')
-  const serviceCIDR = getTemplateValue(templateYAML, 'serviceCIDR', defaultServiceCIDR)
-  const podCIDR = getTemplateValue(templateYAML, 'podCIDR', defaultPodCIDR)
+  const serviceNetworkCidr = getTemplateValue(templateYAML, 'serviceNetworkCidr', defaultServiceCIDR)
+  const clusterNetworkCidr = getTemplateValue(templateYAML, 'clusterNetworkCidr', defaultPodCIDR)
+  const clusterNetworkHostPrefix = parseInt(getTemplateValue(templateYAML, 'clusterNetworkHostPrefix', defaultHostPrefix))
   const sshPublicKey = getTemplateValue(templateYAML, 'id_rsa.pub', '')
 
   const httpProxy = getTemplateValue(templateYAML, 'httpProxy', '')
@@ -55,8 +56,8 @@ export const getDefaultNetworkFormValues = (
     machineCIDR,
     isAdvanced: isAdvancedNetworking,
     sshPublicKey,
-    serviceCIDR,
-    podCIDR,
+    serviceNetworkCidr,
+    clusterNetworkCidr,
     enableProxy,
     httpProxy,
     httpsProxy,
@@ -64,6 +65,7 @@ export const getDefaultNetworkFormValues = (
     apiPublishingStrategy: isNodePort || isBM ? 'NodePort' : 'LoadBalancer',
     nodePortPort,
     nodePortAddress,
+    clusterNetworkHostPrefix,
   }
 }
 
@@ -119,12 +121,16 @@ const NetworkForm: React.FC<NetworkFormProps> = ({ control, handleChange, templa
       summary.push(
         ...[
           {
-            term: 'Cluster CIDR',
-            desc: control.active.podCIDR,
+            term: 'Cluster network CIDR',
+            desc: control.active.clusterNetworkCidr,
           },
           {
-            term: 'Service CIDR',
-            desc: control.active.serviceCIDR,
+            term: 'Cluster network host prefix',
+            desc: control.active.clusterNetworkHostPrefix,
+          },
+          {
+            term: 'Service network CIDR',
+            desc: control.active.serviceNetworkCidr,
           },
         ]
       )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/constants.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/constants.ts
@@ -1,3 +1,4 @@
 /* Copyright Contributors to the Open Cluster Management project */
 export const defaultServiceCIDR = '172.31.0.0/16'
 export const defaultPodCIDR = '10.132.0.0/14'
+export const defaultHostPrefix = '23'

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
@@ -17,10 +17,13 @@ spec:
     name: sshkey-cluster-{{{hypershift.name}}}
   networking:
     {{#if hypershift-network.isAdvanced}}
-    podCIDR: {{{hypershift-network.podCIDR}}}
-    serviceCIDR: {{{hypershift-network.serviceCIDR}}}
+    clusterNetwork:
+      - cidr: {{{hypershift-network.clusterNetworkCidr}}}
+        hostPrefix: {{{hypershift-network.clusterNetworkHostPrefix}}}
+    serviceCIDR: {{{hypershift-network.serviceNetworkCidr}}}
     {{else}}
-    podCIDR: 10.132.0.0/14
+    clusterNetwork:
+      - cidr: 10.132.0.0/14
     serviceCIDR: 172.31.0.0/16
     {{/if}}
     machineCIDR: {{{hypershift-network.machineCIDR}}}


### PR DESCRIPTION
Requires https://github.com/openshift-assisted/assisted-ui-lib/pull/1982