### PR TITLE
ACM-4186 Add condition for hosted cluster import failed

### DIFF
--- a/frontend/src/resources/utils/status-conditions.ts
+++ b/frontend/src/resources/utils/status-conditions.ts
@@ -13,6 +13,11 @@ export const getConditionMessage = (condition: string, conditions: V1CustomResou
   return cond?.message
 }
 
+export const getConditionReason = (condition: string, conditions: V1CustomResourceDefinitionCondition[]) => {
+  const cond = conditions?.find((c) => c.type === condition)
+  return cond?.reason
+}
+
 export const checkForRequirementsMetConditionFailureReason = (
   reason: string,
   conditions: V1CustomResourceDefinitionCondition[]


### PR DESCRIPTION
Importing hosted clusters with invalid name will no longer get stuck on importing

Before:

After:
![image](https://user-images.githubusercontent.com/15898988/226024101-df19fe22-ffc4-40d6-9d18-a4f73e17fb70.png)
![image](https://user-images.githubusercontent.com/15898988/226024273-38e2b413-c02a-4567-8ac5-180774a5206d.png)
