### PR TITLE
ACM-2666 Add condition for hcp upgrade true

### DIFF
--- a/frontend/src/resources/utils/get-cluster.test.ts
+++ b/frontend/src/resources/utils/get-cluster.test.ts
@@ -1144,7 +1144,7 @@ describe('getHCUpgradeStatus', () => {
           baseDomain: 'dev06.red-chesterfield.com',
         },
         release: {
-          image: 'randomimage',
+          image: 'quay.io/openshift-release-dev/ocp-release:4.11.22-x86_64',
         },
         services: [],
         platform: {},

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -1390,7 +1390,11 @@ export function getHCUpgradeStatus(hostedCluster?: HostedClusterK8sResource) {
     const mostRecentVersion = pastVersions[0].image
     //If desired version is > current version and progressing, HC is currently updating
 
-    return desiredVersion !== mostRecentVersion || pastVersions[0].state === 'Partial'
+    return (
+      desiredVersion !== mostRecentVersion ||
+      pastVersions[0].state === 'Partial' ||
+      hostedCluster.spec.release.image != mostRecentVersion
+    )
   } else {
     return
   }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
@@ -566,7 +566,7 @@ const mockHostedCluster: HostedClusterK8sResource = {
       baseDomain: 'dev06.red-chesterfield.com',
     },
     release: {
-      image: 'randomimage',
+      image: 'quay.io/openshift-release-dev/ocp-release:4.11.22-x86_64',
     },
     services: [],
     platform: {},

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -267,7 +267,7 @@ export function DistributionField(props: {
     )
   } else if (props.cluster.hypershift?.isUpgrading && props.resource !== 'nodepool') {
     // HYPERSHIFT UPGRADE IN PROGRESS
-    const image = props.hostedCluster?.status?.version?.history[0].image
+    const image = props.hostedCluster?.spec.release.image
     const versionNum = getVersionFromReleaseImage(image)
     return (
       <>


### PR DESCRIPTION
The `hostedCluster?.status?.version?.desired.image` condition used before doesn't get updated right away anymore for some reason. Seems like `hostedCluster.spec.release.image` gets updated right away, so use that as another condition to show HCP upgrading
![image](https://user-images.githubusercontent.com/15898988/228051694-b904be95-1fa3-4a0a-8bd9-f13e9d83a631.png)
