### PR TITLE
ACM-4738 Show detailed error message immediately when Ansible connection fails

### DIFF
--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -60,8 +60,10 @@ export async function ansibleTower(req: Http2ServerRequest, res: Http2ServerResp
           pipeline(response, res as unknown as NodeJS.WritableStream, () => logger.error)
         }),
         (err) => {
-          if (err) logger.error(err)
-          respond(res, JSON.stringify(err.message), constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
+          if (err) {
+            logger.error(err)
+            respond(res, JSON.stringify(err.message), constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
+          }
         }
       )
     })

--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -1,11 +1,11 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { Http2ServerRequest, Http2ServerResponse } from 'http2'
-import { request, RequestOptions } from 'https'
+import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
+import { Agent, request, RequestOptions } from 'https'
 import ProxyAgent from 'proxy-agent'
 import { pipeline } from 'stream'
 import { URL } from 'url'
 import { logger } from '../lib/logger'
-import { notFound, respondBadRequest } from '../lib/respond'
+import { notFound, respond, respondBadRequest } from '../lib/respond'
 import { getAuthenticatedToken } from '../lib/token'
 
 interface AnsibleCredential {
@@ -61,6 +61,7 @@ export async function ansibleTower(req: Http2ServerRequest, res: Http2ServerResp
         }),
         (err) => {
           if (err) logger.error(err)
+          respond(res, JSON.stringify(err.message), constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
         }
       )
     })

--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
-import { Agent, request, RequestOptions } from 'https'
+import { request, RequestOptions } from 'https'
 import ProxyAgent from 'proxy-agent'
 import { pipeline } from 'stream'
 import { URL } from 'url'
@@ -47,6 +47,7 @@ export async function ansibleTower(req: Http2ServerRequest, res: Http2ServerResp
         headers: {
           Authorization: `Bearer ${ansibleCredential.token}`,
         },
+        rejectUnauthorized: false, // NOSONAR - AAP connects insecurely by default
       }
       if (process.env.HTTPS_PROXY) {
         options.agent = new ProxyAgent()

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2855,6 +2855,7 @@
   "Use the oc login command.": "Use the oc login command.",
   "Use the rules filter to search for PolicyReports that contain a specific rule.": "Use the rules filter to search for PolicyReports that contain a specific rule.",
   "validate.ansible.host": "The credential returned an error response from Ansible Tower. Please review the host and token.",
+  "validate.ansible.reason": "The credential returned an error response from Ansible Tower: {{reason}}",
   "validate.ansible.url.not.valid": "The provided URL is not a valid Ansible Tower host URL.",
   "validate.baseDnsName.char": "Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
   "validate.baseDnsName.start": "The base DNS domain must not begin with a period.",

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -877,7 +877,7 @@ export function AcmDataFormInputs(props: {
     <Fragment>
       {inputs?.map((input) => {
         const error: string | undefined = inputError(t, input)
-        const validated = showFormErrors && error !== undefined ? 'error' : undefined
+        const validated = (showFormErrors || input.validate) && error !== undefined ? 'error' : undefined
         return (
           <Fragment key={input.id}>
             {!input.isHidden && (

--- a/frontend/src/components/AcmFormData.ts
+++ b/frontend/src/components/AcmFormData.ts
@@ -57,6 +57,7 @@ export interface InputBase<T> {
   value: T
   onChange: (value: T) => void
   validation?: (value: T) => string | undefined
+  validate?: boolean
 
   isRequired?: boolean
   isDisabled?: boolean

--- a/frontend/src/lib/nock-util.ts
+++ b/frontend/src/lib/nock-util.ts
@@ -74,13 +74,6 @@ export function nockGet<Resource extends IResource>(
   return finalNockScope
 }
 
-// export function nockGetError<Resource extends IResource>(resource: Resource, error: string | object) {
-//   const resourcePath = getResourceNameApiPathTestHelper(resource)
-//   return nocked(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
-//     .get(resourcePath)
-//     .replyWithError(error)
-// }
-
 export function nockGetTextPlain(response: string, statusCode = 200, polling = true, customUri = '') {
   const nockScope = nocked(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true }).get(customUri)
   const finalNockScope = nockScope.reply(statusCode, response, {
@@ -370,6 +363,14 @@ export function nockAnsibleTowerInventory(
       'Access-Control-Allow-Methods': 'POST, OPTIONS',
       'Access-Control-Allow-Credentials': 'true',
     })
+}
+
+export function nockAnsibleTowerError(data: AnsibleCredentialPostBody | unknown, error: string | object) {
+  return nocked(process.env.JEST_DEFAULT_HOST as string, {
+    encodedQueryParams: true,
+  })
+    .post('/ansibletower', (body) => isEqual(body, data))
+    .replyWithError(error)
 }
 
 export function nockIgnoreApiPaths() {

--- a/frontend/src/resources/utils/resource-request.ts
+++ b/frontend/src/resources/utils/resource-request.ts
@@ -813,7 +813,11 @@ export async function fetchRetry<T>(options: {
 
       if (retries === 0) {
         if (ResourceErrorCodes.includes(response.status)) {
-          throw new ResourceError(response.status, response.statusText)
+          throw new ResourceError(
+            response.status,
+            response.statusText,
+            typeof responseData === 'string' ? responseData : undefined
+          )
         } else {
           throw new ResourceError(ResourceErrorCode.Unknown, `Unknown error code: ${response.status}`)
         }

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -213,6 +213,8 @@ export function AnsibleAutomationsForm(props: {
           setAnsibleTowerAuthError('')
         })
         .catch((err) => {
+          console.log('CAUGHT THE ERROR')
+          console.log(err)
           setAnsibleTowerAuthError(
             err.code === ResourceErrorCode.InternalServerError && err.reason
               ? t('validate.ansible.reason', { reason: err.reason })


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-4738

- Reverts enablement of SSL verification to unblock QE (will open new issue to track)
- Introduces changes to show error message immediately when Ansible Tower calls do not work (currently you have to click Next in the wizard before the validation message shows)