### PR TITLE
ACM-4857 Check for ClusterClaim reference directly on ClusterDeployment

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -415,7 +415,6 @@ export function getCluster(
     managedCluster,
     clusterCurator,
     agentClusterInstall,
-    clusterClaim,
     hostedCluster
   )
 
@@ -1029,7 +1028,6 @@ export function getClusterStatus(
   managedCluster: ManagedCluster | undefined,
   clusterCurator: ClusterCurator | undefined,
   agentClusterInstall: AgentClusterInstallK8sResource | undefined,
-  clusterClaim: ClusterClaim | undefined,
   hostedCluster: HostedClusterK8sResource | undefined
 ) {
   let statusMessage: string | undefined

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -1149,7 +1149,9 @@ export function getClusterStatus(
         switch (powerState) {
           case 'Running':
             cdStatus =
-              clusterDeployment.spec?.clusterPoolRef && !clusterClaim ? ClusterStatus.running : ClusterStatus.detached
+              clusterDeployment.spec?.clusterPoolRef && !clusterDeployment.spec.clusterPoolRef.claimName
+                ? ClusterStatus.running
+                : ClusterStatus.detached
             break
           case 'Hibernating':
             cdStatus = ClusterStatus.hibernating


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-4857

Claimed clusters may show `Running` status due to RBAC limitations if the user has permission to view the `ClusterDeployment` but not the `ClusterClaim`.

The second issue is that without permission to view the`ManagedCluster`, such clusters will appear as `Detached` which is not fully accurate either.