### PR TITLE
ACM-3090 Change link to inline copy for Git/Helm resources

### DIFF
--- a/frontend/src/routes/Applications/components/ResourceLabels.tsx
+++ b/frontend/src/routes/Applications/components/ResourceLabels.tsx
@@ -1,7 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { Divider, Split, SplitItem, Stack, StackItem } from '@patternfly/react-core'
-import { ExternalLinkAltIcon } from '@patternfly/react-icons'
 import _ from 'lodash'
 
 import { CHANNEL_TYPES, getResourceLabel, groupByRepoType } from '../helpers/resource-helper'
@@ -9,6 +8,7 @@ import LabelWithPopover from './LabelWithPopover'
 import { TFunction } from 'i18next'
 import '../css/ResourceLabels.css'
 import { Fragment } from 'react'
+import { AcmInlineCopy } from '../../../ui-components'
 
 function repoSort(appRepos: any) {
   return _.sortBy(appRepos, ['pathName', 'gitBranch', 'gitPath'])
@@ -58,7 +58,6 @@ export function ResourceLabels(props: {
             <Stack className="channel-labels channel-labels-popover-content">
               {repoSort(repoMap[type]).map((repo, index) => {
                 const pathName = repo.pathName
-                const link = type === 'namespace' ? '' : pathName
                 let repoTypeAttributes: any = []
                 if (props.showSubscriptionAttributes) {
                   if (type === 'git') {
@@ -87,10 +86,7 @@ export function ResourceLabels(props: {
                     <StackItem className="channel-entry">
                       <Stack>
                         <StackItem className="channel-entry-link">
-                          <a href={link} target="_blank" rel="noreferrer">
-                            {pathName}
-                            <ExternalLinkAltIcon />
-                          </a>
+                          <AcmInlineCopy text={pathName} id="pathName" />
                         </StackItem>
                         {repoTypeAttributes.length > 0 && (
                           <Fragment>


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-3090

### Before
<img width="1823" alt="image" src="https://user-images.githubusercontent.com/42188127/232866830-5bf145c3-6b28-47cd-8032-459c0ca0f202.png">

<img width="1535" alt="image" src="https://user-images.githubusercontent.com/42188127/232866978-6ea74a3f-5a1f-499a-8a0e-805300b2c3bd.png">

<img width="1526" alt="image" src="https://user-images.githubusercontent.com/42188127/232867289-4eef03ab-a17d-4f9e-befe-2d72d3a51cfd.png">


### After
<img width="1526" alt="image" src="https://user-images.githubusercontent.com/42188127/232867084-1bb61be7-8830-4cf0-a2e1-964486d1d1b2.png">

<img width="1528" alt="image" src="https://user-images.githubusercontent.com/42188127/232867222-a0dc2c3b-0644-4141-89b3-4cdab087bb94.png">

![image](https://user-images.githubusercontent.com/42188127/232867679-8970c0c4-0483-439e-be6a-451ef800dc4d.png)

