### PR TITLE
Group search results by apiGroup

### DIFF
--- a/frontend/src/routes/Home/Search/SearchResults/RelatedResults.tsx
+++ b/frontend/src/routes/Home/Search/SearchResults/RelatedResults.tsx
@@ -90,7 +90,8 @@ export default function RelatedResults(props: {
 
   const relatedCounts = useMemo(() => {
     const dataArray = data?.searchResult?.[0]?.related || []
-    return dataArray.sort((a, b) => compareStrings(a!.kind, b!.kind))
+    const tmpArray = [...dataArray] // use new array so we are not manipulating the memo deps
+    return tmpArray.sort((a, b) => compareStrings(a!.kind, b!.kind))
   }, [data])
 
   if (loading) {

--- a/frontend/src/routes/Home/Search/SearchResults/RelatedResults.tsx
+++ b/frontend/src/routes/Home/Search/SearchResults/RelatedResults.tsx
@@ -13,7 +13,7 @@ import _ from 'lodash'
 import { useMemo } from 'react'
 import { useTranslation } from '../../../../lib/acm-i18next'
 import { useSharedAtoms } from '../../../../shared-recoil'
-import { AcmLoadingPage, AcmTable } from '../../../../ui-components'
+import { AcmLoadingPage, AcmTable, compareStrings } from '../../../../ui-components'
 import { IDeleteModalProps } from '../components/Modals/DeleteResourceModal'
 import { convertStringToQuery } from '../search-helper'
 import { searchClient } from '../search-sdk/search-client'
@@ -88,6 +88,11 @@ export default function RelatedResults(props: {
     },
   })
 
+  const relatedCounts = useMemo(() => {
+    const dataArray = data?.searchResult?.[0]?.related || []
+    return dataArray.sort((a, b) => compareStrings(a!.kind, b!.kind))
+  }, [data])
+
   if (loading) {
     return (
       <Accordion isBordered asDefinitionList={true}>
@@ -119,7 +124,6 @@ export default function RelatedResults(props: {
     )
   }
 
-  const relatedCounts = data.searchResult[0]?.related || []
   if (relatedCounts.length === 0) {
     return <Alert variant={'info'} isInline title={t('There are no resources related to your search results.')} />
   }


### PR DESCRIPTION
This PR groups search results by apigroup instead of by kind to differentiate resources with the same kind but different apigroup (ex: clusterclaim, authentication).
Also adds the apigroup to the search result accordion header.

![Screen Shot 2023-05-25 at 11 23 06 AM](https://github.com/stolostron/console/assets/14047925/bf40c52e-d892-46b9-a2f2-7f4b30d44bc9)
