### PR TITLE
Disable setting remediationAction and severity for Gatekeeper policy templates

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1369,6 +1369,7 @@
   "formerror.valid.name": "Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
   "G3 - NVIDIA Tesla M60 GPUs": "G3 - NVIDIA Tesla M60 GPUs",
   "G4 - NVIDIA T4 Tensor Core GPUs": "G4 - NVIDIA T4 Tensor Core GPUs",
+  "Gatekeeper policy templates must be customized using the YAML editor.": "Gatekeeper policy templates must be customized using the YAML editor.",
   "Gateway timeout": "Gateway timeout",
   "General": "General",
   "General Purpose": "General Purpose",

--- a/frontend/src/resources/policy.ts
+++ b/frontend/src/resources/policy.ts
@@ -55,8 +55,8 @@ export interface PolicyTemplate {
           subjects?: ResourceRef[]
         }
       }[]
-      remediationAction: string
-      severity: string
+      remediationAction?: string
+      severity?: string
       maxClusterRoleBindingUsers?: number
       pruneObjectBehavior?: string
     }

--- a/frontend/src/routes/Governance/common/util.tsx
+++ b/frontend/src/routes/Governance/common/util.tsx
@@ -480,7 +480,7 @@ export function getPolicyRemediation(policy: Policy | undefined) {
     } else if (remediationAggregation !== '-' && remediationAggregation !== templateRemediation) {
       remediationAggregation = 'inform/enforce'
       return
-    } else if (remediationAggregation !== templateRemediation) {
+    } else if (remediationAggregation !== templateRemediation && templateRemediation) {
       remediationAggregation = templateRemediation
       return
     }

--- a/frontend/src/wizards/Governance/Policy/PolicyWizard.tsx
+++ b/frontend/src/wizards/Governance/Policy/PolicyWizard.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { Alert, Button, Stack, Text, Title } from '@patternfly/react-core'
+import { Alert, Button, Stack, Text, TextContent, Title } from '@patternfly/react-core'
 import { ExternalLinkAltIcon } from '@patternfly/react-icons'
 import get from 'get-value'
 import { klona } from 'klona/json'
@@ -469,34 +469,42 @@ export function PolicyWizardTemplates(props: { policies: IResource[] }) {
           </WizArrayInput>
         </WizHidden>
 
-        <WizRadioGroup path="objectDefinition.spec.remediationAction" label="Remediation">
-          <Radio
-            id="inform"
-            label={t('Inform')}
-            value="inform"
-            description={t('Reports the violation, which requires manual remediation.')}
-          />
-          <Radio
-            id="enforce"
-            label={t('Enforce')}
-            value="enforce"
-            description={t(
-              'Automatically runs remediation action that is defined in the source, if this feature is supported.'
-            )}
-          />
-        </WizRadioGroup>
+        <WizHidden hidden={(template: any) => template?.objectDefinition?.apiVersion?.includes('gatekeeper.sh/')}>
+          <WizRadioGroup path="objectDefinition.spec.remediationAction" label="Remediation">
+            <Radio
+              id="inform"
+              label={t('Inform')}
+              value="inform"
+              description={t('Reports the violation, which requires manual remediation.')}
+            />
+            <Radio
+              id="enforce"
+              label={t('Enforce')}
+              value="enforce"
+              description={t(
+                'Automatically runs remediation action that is defined in the source, if this feature is supported.'
+              )}
+            />
+          </WizRadioGroup>
 
-        <Select
-          path="objectDefinition.spec.severity"
-          label={t('Severity')}
-          placeholder={t('Select severity')}
-          options={[
-            { label: t('low'), value: 'low' },
-            { label: t('medium'), value: 'medium' },
-            { label: t('high'), value: 'high' },
-          ]}
-          required
-        />
+          <Select
+            path="objectDefinition.spec.severity"
+            label={t('Severity')}
+            placeholder={t('Select severity')}
+            options={[
+              { label: t('low'), value: 'low' },
+              { label: t('medium'), value: 'medium' },
+              { label: t('high'), value: 'high' },
+            ]}
+            required
+          />
+        </WizHidden>
+
+        <WizHidden hidden={(template: any) => !template?.objectDefinition?.apiVersion?.includes('gatekeeper.sh/')}>
+          <TextContent>
+            <Text>{t('Gatekeeper policy templates must be customized using the YAML editor.')}</Text>
+          </TextContent>
+        </WizHidden>
       </WizArrayInput>
     </Section>
   )


### PR DESCRIPTION
This disables the remediationAction and severity options in the policy templates section of the policy wizard when it is a Gatekeeper constraint or ConstraintTemplate.

Instead, text is displayed that tells the user to use the YAML editor to make modifications.

Relates:
https://issues.redhat.com/browse/ACM-4808

![image](https://user-images.githubusercontent.com/11711106/233191595-c22e7881-038b-414d-b30b-b98590098a98.png)