### PR TITLE
ACM-5281 Use serviceNetwork instead of serviceCIDR for HostedCluster

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/NetworkForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/NetworkForm.test.tsx
@@ -22,7 +22,8 @@ spec:
     name: sshkey-cluster-test-cluster-name
   networking:
     podCIDR: 1.2.3.4/18
-    serviceCIDR: 4.5.6.7/16
+    serviceNetwork:
+      - cidr: 4.5.6.7/16
     machineCIDR: 2.4.6.8/12
   configuration:
     items:

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
@@ -20,11 +20,13 @@ spec:
     clusterNetwork:
       - cidr: {{{hypershift-network.clusterNetworkCidr}}}
         hostPrefix: {{{hypershift-network.clusterNetworkHostPrefix}}}
-    serviceCIDR: {{{hypershift-network.serviceNetworkCidr}}}
+    serviceNetwork:
+      - cidr: {{{hypershift-network.serviceNetworkCidr}}}
     {{else}}
     clusterNetwork:
       - cidr: 10.132.0.0/14
-    serviceCIDR: 172.31.0.0/16
+    serviceNetwork:
+      - cidr: 172.31.0.0/16
     {{/if}}
     networkType: {{{hypershift-network.networkType}}}
   {{#if hypershift-network.enableProxy}}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-5281

- Use serviceNetwork instead of serviceCIDR for HostedCluster as serviceCIDR is removed from version v1beta1

![nonadvancednetwork](https://user-images.githubusercontent.com/38960034/236283996-ebc201da-63e8-41c9-a44d-5f36bb13cbcd.jpg)

![image](https://user-images.githubusercontent.com/38960034/236284028-2a9be98a-bfdd-4f1d-a7aa-6bff6428b578.png)
