### PR TITLE
ACM-5427 Support both new and old versions of TimePicker

### DIFF
--- a/frontend/src/routes/Applications/CreateApplication/Subscription/common/TimeWindow/index.js
+++ b/frontend/src/routes/Applications/CreateApplication/Subscription/common/TimeWindow/index.js
@@ -328,7 +328,8 @@ export class TimeWindow extends Component {
                     id={startTimeID}
                     time={existingStart ? existingStart : ''}
                     isDisabled={!modeSelected}
-                    onChange={(time) => {
+                    onChange={(eventOrTime, timeOrHour) => {
+                      const time = typeof eventOrTime === 'string' ? eventOrTime : timeOrHour
                       this.handleTimeRange.bind(this)(time, startTimeID)
                     }}
                     width={'140px'}
@@ -339,7 +340,8 @@ export class TimeWindow extends Component {
                     id={endTimeID}
                     time={existingEnd ? existingEnd : ''}
                     isDisabled={!modeSelected}
-                    onChange={(time) => {
+                    onChange={(eventOrTime, timeOrHour) => {
+                      const time = typeof eventOrTime === 'string' ? eventOrTime : timeOrHour
                       this.handleTimeRange.bind(this)(time, endTimeID)
                     }}
                     width={'140px'}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-5427

PF TimePicker is still in beta but looks like we've been using it for some time. The newer version of PF TimePicker that's in OCP 4.13 added an event param to the onChange function which is causing issues for the UI. As a plugin we have no control over which PF version we use.

- Check the param type to see which param to use