### PR TITLE
ACM-5596-Base-domain-is-not-populated-in-the-form

### DIFF
--- a/frontend/src/lib/nock-util.ts
+++ b/frontend/src/lib/nock-util.ts
@@ -231,9 +231,10 @@ export function nockCreate(
   statusCode = 201,
   params?: any
 ) {
+  const apiPath = getResourceApiPathTestHelper(resource)
   const scope = nocked(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
-    .post(`${getResourceApiPathTestHelper(resource)}${getNockParams(params)}`, (body) => {
-      set(scope, 'diff', diff(body, resource))
+    .post(`${apiPath}${getNockParams(params)}`, (body) => {
+      set(scope, 'bodyDiff', { diff: diff(body, resource), apiPath })
       return isEqual(body, resource)
     })
     .reply(statusCode, response ?? resource, {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/cim-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/cim-template.hbs
@@ -61,6 +61,8 @@ spec:
   {{#each ssh-publickey}}
       {{{.}}}
   {{/each}}
+{{else}}
+  sshPublicKey: ''
 {{/if}}
 
 ---

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/cim-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/cim-template.hbs
@@ -56,7 +56,12 @@ spec:
       hostPrefix: 23
     serviceNetwork:
     - 172.30.0.0/16
-  sshPublicKey: '{{{ai.sshPublicKey}}}'
+{{#if ssh-publickey}}
+  sshPublicKey: |-
+  {{#each ssh-publickey}}
+      {{{.}}}
+  {{/each}}
+{{/if}}
 
 ---
 apiVersion: v1

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -120,7 +120,7 @@ expect.extend({
       window.pendingNocks.forEach((nock) => {
         if (nock.scope.isDone()) {
           completedNocks.push(nock)
-        } else if (get(nock.scope, 'diff')) {
+        } else if (get(nock.scope, 'bodyDiff')) {
           mismatchedNocks.push(nock)
         } else {
           pendingNocks.push(nock)
@@ -132,13 +132,15 @@ expect.extend({
         msgs.push('!!!!!!!!!!!!!!!! MISMATCHED NOCK(S) !!!!!!!!!!!!!!!!!!!!!!!!')
         mismatchedNocks.forEach(({ scope, nock, source }) => {
           msgs.push(`'${nock}' ${source.trim()}`)
-          const diff = get(scope, 'diff')
-          if (diff) {
-            msgs.push('\n this nock almost matched a request but the bodies were different here:')
-            diff.forEach((d: { lhs: any; rhs: any }) => {
-              msgs.push(' the request expected this:')
+          const bodyDiff = get(scope, 'bodyDiff')
+          if (bodyDiff) {
+            const { diff, apiPath } = bodyDiff
+            msgs.push('\n this nock almost matched a request but the bodies were different here:\n' + apiPath)
+            diff.forEach((d: { lhs: any; path: string[]; rhs: any }) => {
+              msgs.push(` for this path into body ${d.path.join('.')} `)
+              msgs.push(' the api expected this:')
               msgs.push(`  ${d?.lhs}`)
-              msgs.push(' the nock provided this:')
+              msgs.push(' but your nock body definition request was this:')
               msgs.push(`  ${d?.rhs}`)
             })
           }


### PR DESCRIPTION
1  the ssh public key add to the yaml from the credential wizard was in wrong format causing syntax errors
2 when yaml has syntax errors, the form won't update from it as a precaution

Signed-off-by: John Swanke <jswanke@redhat.com>