### PR TITLE
ACM-5690 add clustername on managedclusterpath

### DIFF
--- a/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
+++ b/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
@@ -175,7 +175,7 @@ export function PolicySetDetailSidebar(props: { policySet: PolicySet }) {
           /* istanbul ignore next */
           compareStrings(a, b),
         cell: (cluster: string) => (
-          <a href={`/multicloud/infrastructure/clusters/details/${cluster}/overview`}>{cluster}</a>
+          <a href={`/multicloud/infrastructure/clusters/details/${cluster}/${cluster}/overview`}>{cluster}</a>
         ),
       },
       clusterPolicyViolationsColumn,


### PR DESCRIPTION
Description of problem:
The url link of managed cluster is wrong on the policyset panel. Users got 404 NotFound to access the cluster's Overview page. However, users can still access the Overview page via CLC panel.

Actual results:
404 Not found.
https://console-openshift-console.apps.o4-ibmvm-04.qe.red-chesterfield.com/multicloud/infrastructure/clusters/details/iks508/overview 

Expected results:
Cluster Overview page loaded.

https://console-openshift-console.apps.o4-ibmvm-04.qe.red-chesterfield.com/multicloud/infrastructure/clusters/details/iks508/iks508/overview 

Ref: https://issues.redhat.com/browse/ACM-5690
Signed-off-by: Yi Rae Kim <yikim@redhat.com>