### PR TITLE
ACM-6099 YAML-Finder-search-bar-takes-no-input for 2.7

### DIFF
--- a/frontend/src/components/TemplateEditor/components/EditorBar.js
+++ b/frontend/src/components/TemplateEditor/components/EditorBar.js
@@ -98,7 +98,17 @@ class EditorBar extends React.Component {
         this.props.handleEditorCommand(command)
     }
 
-    handleSearch = (searchName) => {
+    // at some point patternfly switches these two
+    //const onChangeHandler = (value: string, event: React.FormEvent<HTMLInputElement>) => {
+    //onChange?: (event: React.FormEvent<HTMLInputElement>, value: string) => void;
+    handleSearch = (value1, value2) => {
+        let searchName = ''
+        if (typeof value1 === 'string') {
+            searchName = value1
+        }
+        if (typeof value2 === 'string') {
+            searchName = value2
+        }
         this.props.handleSearchChange(searchName)
         this.setState({ searchName })
     }


### PR DESCRIPTION
[ACM-6099](https://issues.redhat.com/browse/ACM-6099)