### PR TITLE
:bug: [ACM-5433] Gov donut chart Error color should be #c9190b

### DIFF
--- a/frontend/src/ui-components/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
+++ b/frontend/src/ui-components/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
@@ -138,7 +138,7 @@ export function AcmDonutChart(props: {
   )
 }
 
-const criticalColorClass = 'var(--pf-chart-color-red-100)'
+const criticalColorClass = 'var(--pf-global--palette--red-100)'
 const importantColorClass = 'var(--pf-chart-color-orange-300)'
 const moderateColorClass = 'var(--pf-chart-color-gold-300)'
 const lowColorClass = 'var(--pf-chart-color-blue-200)'


### PR DESCRIPTION
Expected results:
The error color should be pf-chart-color-red-100 on light and dark modes both

https://docs.google.com/presentation/d/1ZiDAXhEUE-PaX408mEkC70O4sCb78oxQ3kX5SrpibUo/edit#slide=id.g191f7922817_0_1569 

Changed result:
<img width="853" alt="Screenshot 2023-06-30 at 1 28 18 PM" src="https://github.com/stolostron/console/assets/121250524/ce1e9989-ba8d-4a1e-8628-588695e6c795">



Ref: https://issues.redhat.com/browse/ACM-5433