### PR TITLE
Fix propagated policy nav from search

### DIFF
--- a/frontend/src/routes/Home/Search/searchDefinitions.tsx
+++ b/frontend/src/routes/Home/Search/searchDefinitions.tsx
@@ -3,11 +3,11 @@
 // Copyright Contributors to the Open Cluster Management project
 
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons'
-import { TFunction } from 'react-i18next'
 import _ from 'lodash'
 import moment from 'moment'
 import queryString from 'query-string'
 import { useMemo } from 'react'
+import { TFunction } from 'react-i18next'
 import { generatePath, Link } from 'react-router-dom'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { NavigationPath } from '../../../NavigationPath'
@@ -1452,7 +1452,11 @@ export function CreateDetailsLink(item: any) {
     case 'policy':
       // Redirects to the policy page if the policy is a hub cluster resource.
       // If the policy is not, it will redirect and just show the yaml.
-      if (item._hubClusterResource && item.apigroup === 'policy.open-cluster-management.io') {
+      if (
+        item._hubClusterResource &&
+        item.apigroup === 'policy.open-cluster-management.io' &&
+        !item.label?.includes('policy.open-cluster-management.io/root-policy') // only go to Policies page for non-propagated Policies
+      ) {
         return (
           <Link to={generatePath(NavigationPath.policyDetails, { name: item.name, namespace: item.namespace })}>
             {item.name}


### PR DESCRIPTION
Navigate to Policies page for hub Policies. 
For propagated Policies use the search details view. 
Related issue: https://issues.redhat.com/browse/ACM-5800