### PR TITLE
MGMT-14742: Use SSH public key from credentials

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/DetailsForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/DetailsForm.test.tsx
@@ -1,0 +1,66 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { render } from '@testing-library/react'
+import { MemoryRouter, Route } from 'react-router-dom'
+import { RecoilRoot } from 'recoil'
+import { NavigationPath } from '../../../../../../../../NavigationPath'
+import { nockIgnoreApiPaths, nockIgnoreRBAC, nockList } from '../../../../../../../../lib/nock-util'
+import { waitForNocks, waitForText } from '../../../../../../../../lib/test-util'
+import { clusterImageSet, mockClusterImageSet } from '../../../CreateCluster.sharedmocks'
+import { IResource } from '../../../../../../../../resources'
+
+import DetailsForm from './DetailsForm'
+
+describe('DetailsForm', () => {
+  const handleChange = jest.fn()
+  const Component = () => {
+    return (
+      <RecoilRoot>
+        <MemoryRouter initialEntries={[NavigationPath.createCluster]}>
+          <Route path={NavigationPath.createCluster}>
+            <DetailsForm
+              key={'key'}
+              control={{
+                active: {
+                  name: '',
+                  highAvailabilityMode: 'Full',
+                  openshiftVersion: '',
+                  pullSecret: '',
+                  baseDnsDomain: '',
+                  SNODisclaimer: false,
+                  useRedHatDnsService: true,
+                  enableDiskEncryptionOnMasters: false,
+                  enableDiskEncryptionOnWorkers: false,
+                  diskEncryptionMode: 'tpmv2',
+                  diskEncryptionTangServers: [],
+                  diskEncryption: {},
+                  cpuArchitecture: '',
+                },
+                step: {
+                  title: {
+                    isComplete: false,
+                  },
+                },
+              }}
+              controlProps={{
+                apiVersion: 'v1',
+                kind: 'Secret',
+                metadata: {},
+              }}
+              handleChange={handleChange}
+            />
+          </Route>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+  }
+
+  test('it renders', async () => {
+    nockIgnoreRBAC()
+    nockIgnoreApiPaths()
+    const initialNocks = [nockList(clusterImageSet as IResource, mockClusterImageSet as IResource[])]
+    const { container } = render(<Component />)
+    await waitForNocks(initialNocks)
+    await waitForText('ai:Cluster name')
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/DetailsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/DetailsForm.tsx
@@ -32,6 +32,7 @@ type FormControl = {
       [x: string]: string
     }[]
     releaseImage?: string
+    sshPublicKey?: string
   }
   disabled?: VoidFunction
   reverse?: (control: { active: ClusterDetailsValues }, templateObject: any) => void
@@ -54,7 +55,7 @@ const fields: any = {
 }
 
 const DetailsForm: React.FC<DetailsFormProps> = ({ control, handleChange, controlProps }) => {
-  const { setClusterName, setReleaseImage } = useContext(HypershiftAgentContext)
+  const { setClusterName, setReleaseImage, setSshPublicKey } = useContext(HypershiftAgentContext)
   const { waitForAll } = useSharedRecoil()
   const { clusterDeploymentsState, clusterImageSetsState, configMapsState } = useSharedAtoms()
   const [clusterDeployments, clusterImageSets, configMaps] = useRecoilValue(
@@ -146,6 +147,8 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ control, handleChange, contro
   const onValuesChanged = useCallback((formikValues: any, initRender: any) => {
     setClusterName(formikValues.name)
     setReleaseImage(formikValues.openshiftVersion)
+    setSshPublicKey(control.active.sshPublicKey ?? '')
+
     const values = {
       ...formikValues,
       managedClusterSet: control.active.managedClusterSet,
@@ -178,6 +181,7 @@ const DetailsForm: React.FC<DetailsFormProps> = ({ control, handleChange, contro
       ...control.active,
       pullSecret: getDefault([controlProps?.stringData?.pullSecret, control.active.pullSecret, '']),
       baseDnsDomain: getDefault([controlProps?.stringData?.baseDomain, control.active.baseDnsDomain, '']),
+      sshPublicKey: getDefault([controlProps?.stringData?.['ssh-publickey'], control.active.sshPublicKey, '']),
     }
     handleChange(control)
   }, [controlProps?.metadata.uid, controlProps?.stringData?.pullSecret, controlProps?.stringData?.baseDomain])

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAgentContext.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/HypershiftAgentContext.tsx
@@ -21,6 +21,8 @@ export type HypershiftAgentContextType = {
   setReleaseImage: (img: string) => void
   infraEnvNamespace: string
   setInfraEnvNamespace: (ns: string) => void
+  sshPublicKey: string
+  setSshPublicKey: (key: string) => void
 }
 
 export const HypershiftAgentContext = React.createContext<HypershiftAgentContextType>({
@@ -34,6 +36,8 @@ export const HypershiftAgentContext = React.createContext<HypershiftAgentContext
   setReleaseImage: noop,
   infraEnvNamespace: '',
   setInfraEnvNamespace: noop,
+  sshPublicKey: '',
+  setSshPublicKey: noop,
 })
 
 export const useHypershiftContextValues = (): HypershiftAgentContextType => {
@@ -42,6 +46,7 @@ export const useHypershiftContextValues = (): HypershiftAgentContextType => {
   const [clusterName, setClusterName] = React.useState('')
   const [releaseImage, setReleaseImage] = React.useState('')
   const [infraEnvNamespace, setInfraEnvNamespace] = React.useState('')
+  const [sshPublicKey, setSshPublicKey] = React.useState('')
 
   return {
     nodePools,
@@ -54,5 +59,7 @@ export const useHypershiftContextValues = (): HypershiftAgentContextType => {
     setReleaseImage,
     infraEnvNamespace,
     setInfraEnvNamespace,
+    sshPublicKey,
+    setSshPublicKey,
   }
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/NetworkForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/NetworkForm.test.tsx
@@ -83,7 +83,7 @@ describe('NetworkForm', () => {
   }
 
   test('it sets default form values', () => {
-    const initialValues = getDefaultNetworkFormValues(templateYAML, true, false)
+    const initialValues = getDefaultNetworkFormValues(templateYAML, true, false, 'ssh-rsa AAAAB3NzaC1ycFOOBAR')
     expect(initialValues).toMatchSnapshot()
   })
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/NetworkForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/NetworkForm.tsx
@@ -31,7 +31,8 @@ type NetworkFormProps = {
 export const getDefaultNetworkFormValues = (
   templateYAML: string,
   isBM: boolean,
-  isAdvancedNetworking: boolean
+  isAdvancedNetworking: boolean,
+  initialSshPublicKey: string
 ): NetworkFormValues => {
   // To preserve form values on Back button
   // Find a better way than parsing the yaml - is there already a parsed up-to-date template?
@@ -40,7 +41,7 @@ export const getDefaultNetworkFormValues = (
   const clusterNetworkHostPrefix = parseInt(
     getTemplateValue(templateYAML, 'clusterNetworkHostPrefix', defaultHostPrefix)
   )
-  const sshPublicKey = getTemplateValue(templateYAML, 'id_rsa.pub', '')
+  const sshPublicKey = getTemplateValue(templateYAML, 'id_rsa.pub', '') || initialSshPublicKey
 
   const httpProxy = getTemplateValue(templateYAML, 'httpProxy', '')
   const httpsProxy = getTemplateValue(templateYAML, 'httpsProxy', '')
@@ -68,7 +69,8 @@ export const getDefaultNetworkFormValues = (
 }
 
 const NetworkForm: React.FC<NetworkFormProps> = ({ control, handleChange, templateYAML }) => {
-  const { isAdvancedNetworking, setIsAdvancedNetworking, releaseImage } = React.useContext(HypershiftAgentContext)
+  const { isAdvancedNetworking, setIsAdvancedNetworking, releaseImage, sshPublicKey } =
+    React.useContext(HypershiftAgentContext)
   const { waitForAll } = useSharedRecoil()
   const { agentsState, infrastructuresState, clusterImageSetsState } = useSharedAtoms()
   const [agents, infrastructures, clusterImageSets] = useRecoilValue(
@@ -137,8 +139,9 @@ const NetworkForm: React.FC<NetworkFormProps> = ({ control, handleChange, templa
   }
 
   const initialValues: NetworkFormValues = React.useMemo(
-    () => getDefaultNetworkFormValues(templateYAML, isBMPlatform(infrastructures[0]), isAdvancedNetworking),
-    [templateYAML, infrastructures, isAdvancedNetworking]
+    () =>
+      getDefaultNetworkFormValues(templateYAML, isBMPlatform(infrastructures[0]), isAdvancedNetworking, sshPublicKey),
+    [templateYAML, infrastructures, isAdvancedNetworking, sshPublicKey]
   )
 
   return agents ? (

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/__snapshots__/DetailsForm.test.tsx.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/__snapshots__/DetailsForm.test.tsx.snap
@@ -1,0 +1,436 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DetailsForm it renders 1`] = `
+<div>
+  <form
+    class="pf-c-form"
+    novalidate=""
+  >
+    <div
+      class="pf-l-stack"
+    >
+      <div
+        class="pf-l-stack__item"
+      >
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="form-input-name-field"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                ai:Cluster name
+              </span>
+              <span
+                aria-hidden="true"
+                class="pf-c-form__label-required"
+              >
+                 
+                *
+              </span>
+            </label>
+             
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <div
+              class="pf-l-split"
+            >
+              <div
+                class="pf-l-split__item pf-m-fill"
+              >
+                <input
+                  aria-describedby="form-input-name-field-helper"
+                  aria-invalid="false"
+                  class="pf-c-form-control"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-1"
+                  data-ouia-component-type="PF4/TextInput"
+                  data-ouia-safe="true"
+                  id="form-input-name-field"
+                  name="name"
+                  placeholder="ai:Enter cluster name"
+                  required=""
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                class="pf-l-split__item"
+              />
+            </div>
+            <div
+              aria-live="polite"
+              class="pf-c-form__helper-text"
+              id="form-input-name-field-helper"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-l-stack__item"
+      />
+    </div>
+    <div
+      class="pf-c-form__group"
+      id="managedClusterSet-label"
+    >
+      <div
+        class="pf-c-form__group-label"
+      >
+        <label
+          class="pf-c-form__label"
+          for="managedClusterSet"
+        >
+          <span
+            class="pf-c-form__label-text"
+          >
+            Cluster set
+          </span>
+        </label>
+         
+        <button
+          aria-disabled="false"
+          aria-label="More info"
+          class="pf-c-button pf-m-plain pf-c-form__group-label-help"
+          data-ouia-component-id="OUIA-Generated-Button-plain-1"
+          data-ouia-component-type="PF4/Button"
+          data-ouia-safe="true"
+          id="managedClusterSet-label-help-button"
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="1em"
+            role="img"
+            viewBox="0 0 1024 1024"
+            width="1em"
+          >
+            <path
+              d="M521.3,576 C627.5,576 713.7,502 713.7,413.7 C713.7,325.4 627.6,253.6 521.3,253.6 C366,253.6 334.5,337.7 329.2,407.2 C329.2,414.3 335.2,416 343.5,416 L445,416 C450.5,416 458,415.5 460.8,406.5 C460.8,362.6 582.9,357.1 582.9,413.6 C582.9,441.9 556.2,470.9 521.3,473 C486.4,475.1 447.3,479.8 447.3,521.7 L447.3,553.8 C447.3,570.8 456.1,576 472,576 C487.9,576 521.3,576 521.3,576 M575.3,751.3 L575.3,655.3 C575.313862,651.055109 573.620137,646.982962 570.6,644 C567.638831,640.947672 563.552355,639.247987 559.3,639.29884 L463.3,639.29884 C459.055109,639.286138 454.982962,640.979863 452,644 C448.947672,646.961169 447.247987,651.047645 447.29884,655.3 L447.29884,751.3 C447.286138,755.544891 448.979863,759.617038 452,762.6 C454.961169,765.652328 459.047645,767.352013 463.3,767.30116 L559.3,767.30116 C563.544891,767.313862 567.617038,765.620137 570.6,762.6 C573.659349,759.643612 575.360354,755.553963 575.3,751.3 M512,896 C300.2,896 128,723.9 128,512 C128,300.3 300.2,128 512,128 C723.8,128 896,300.2 896,512 C896,723.8 723.7,896 512,896 M512.1,0 C229.7,0 0,229.8 0,512 C0,794.2 229.8,1024 512.1,1024 C794.4,1024 1024,794.3 1024,512 C1024,229.7 794.4,0 512.1,0"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="pf-c-form__group-control"
+      >
+        <div
+          class="pf-c-select"
+          data-ouia-component-id="OUIA-Generated-Select-single-1"
+          data-ouia-component-type="PF4/Select"
+          data-ouia-safe="true"
+        >
+          <div
+            class="pf-c-select__toggle pf-m-disabled pf-m-typeahead"
+          >
+            <div
+              class="pf-c-select__toggle-wrapper"
+            >
+              <span
+                class="pf-c-select__toggle-text"
+              >
+                <span
+                  style="color: rgb(102, 102, 102);"
+                >
+                  No cluster sets available
+                </span>
+              </span>
+            </div>
+            <button
+              aria-expanded="false"
+              aria-haspopup="listbox"
+              aria-label="Options menu"
+              aria-labelledby="managedClusterSet-label pf-select-toggle-id-1"
+              class="pf-c-button pf-c-select__toggle-button pf-m-plain"
+              disabled=""
+              id="pf-select-toggle-id-1"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="pf-c-select__toggle-arrow"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                style="vertical-align: -0.125em;"
+                viewBox="0 0 320 512"
+                width="1em"
+              >
+                <path
+                  d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+        <small
+          class=""
+          data-ouia-component-id="OUIA-Generated-Text-1"
+          data-ouia-component-type="PF4/Text"
+          data-ouia-safe="true"
+          data-pf-content="true"
+        >
+          <a
+            href="/multicloud/infrastructure/clusters/sets"
+          >
+            Manage cluster sets
+          </a>
+        </small>
+      </div>
+    </div>
+    <div
+      class="pf-l-stack"
+    >
+      <div
+        class="pf-l-stack__item"
+      >
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="form-input-baseDnsDomain-field"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                ai:Base domain
+              </span>
+              <span
+                aria-hidden="true"
+                class="pf-c-form__label-required"
+              >
+                 
+                *
+              </span>
+            </label>
+             
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <div
+              class="pf-l-split"
+            >
+              <div
+                class="pf-l-split__item pf-m-fill"
+              >
+                <input
+                  aria-describedby="form-input-baseDnsDomain-field-helper"
+                  aria-invalid="false"
+                  class="pf-c-form-control"
+                  data-ouia-component-id="OUIA-Generated-TextInputBase-2"
+                  data-ouia-component-type="PF4/TextInput"
+                  data-ouia-safe="true"
+                  id="form-input-baseDnsDomain-field"
+                  name="baseDnsDomain"
+                  placeholder="example.com"
+                  required=""
+                  type="text"
+                  value=""
+                />
+              </div>
+              <div
+                class="pf-l-split__item"
+              />
+            </div>
+            <div
+              aria-live="polite"
+              class="pf-c-form__helper-text"
+              id="form-input-baseDnsDomain-field-helper"
+            >
+              ai:All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation. The full cluster address will be:
+               
+              <br />
+              <strong>
+                [Cluster Name]
+                .
+                [example.com]
+              </strong>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-l-stack__item"
+      />
+    </div>
+    <div
+      class="pf-l-stack"
+    >
+      <div
+        class="pf-l-stack__item"
+      >
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="form-input-openshiftVersion-field"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                ai:OpenShift version
+              </span>
+              <span
+                aria-hidden="true"
+                class="pf-c-form__label-required"
+              >
+                 
+                *
+              </span>
+            </label>
+             
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <select
+              aria-describedby="form-input-openshiftVersion-field-helper"
+              aria-invalid="false"
+              class="pf-c-form-control"
+              data-ouia-component-id="OUIA-Generated-FormSelect-default-1"
+              data-ouia-component-type="PF4/FormSelect"
+              data-ouia-safe="true"
+              id="form-input-openshiftVersion-field"
+              name="openshiftVersion"
+              required=""
+            >
+              <option
+                class=""
+                value="ocp-release48"
+              >
+                OpenShift 4.8.15
+              </option>
+            </select>
+            <div
+              aria-live="polite"
+              class="pf-c-form__helper-text"
+              id="form-input-openshiftVersion-field-helper"
+            />
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-l-stack__item"
+      />
+    </div>
+    <div
+      class="pf-l-stack"
+    >
+      <div
+        class="pf-l-stack__item"
+      >
+        <div
+          class="pf-c-form__group"
+        >
+          <div
+            class="pf-c-form__group-label"
+          >
+            <label
+              class="pf-c-form__label"
+              for="form-input-pullSecret-field"
+            >
+              <span
+                class="pf-c-form__label-text"
+              >
+                ai:Pull secret
+              </span>
+              <span
+                aria-hidden="true"
+                class="pf-c-form__label-required"
+              >
+                 
+                *
+              </span>
+            </label>
+             
+            <button
+              aria-disabled="false"
+              class="pf-c-button pf-m-plain pf-c-form__group-label-help pf-u-p-0"
+              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe="true"
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                fill="currentColor"
+                height="1em"
+                role="img"
+                viewBox="0 0 512 512"
+                width="1em"
+              >
+                <path
+                  d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="pf-c-form__group-control"
+          >
+            <textarea
+              aria-describedby="form-input-pullSecret-field-helper"
+              aria-invalid="false"
+              class="pf-c-form-control"
+              id="form-input-pullSecret-field"
+              name="pullSecret"
+              required=""
+              rows="10"
+              style="resize: vertical;"
+            />
+            <div
+              aria-live="polite"
+              class="pf-c-form__helper-text"
+              id="form-input-pullSecret-field-helper"
+            >
+              ai:A Red Hat account's pull secret can be found in 
+               
+              <a
+                href="https://console.redhat.com/openshift/install/pull-secret"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                ai:OpenShift Cluster Manager
+                 
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="vertical-align: -0.125em;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z"
+                  />
+                </svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="pf-l-stack__item"
+      />
+    </div>
+  </form>
+</div>
+`;

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/__snapshots__/NetworkForm.test.tsx.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/hypershift/__snapshots__/NetworkForm.test.tsx.snap
@@ -938,6 +938,6 @@ Object {
   "nodePortAddress": "4.5.6.7",
   "nodePortPort": 12,
   "serviceNetworkCidr": "172.31.0.0/16",
-  "sshPublicKey": "",
+  "sshPublicKey": "ssh-rsa AAAAB3NzaC1ycFOOBAR",
 }
 `;


### PR DESCRIPTION
In the Hypershift Create cluster flow, the SSH
public key on the Network screen is reused from
Credentials, if selected.

[Screencast from 2023-08-02 14-20-48.webm](https://github.com/stolostron/console/assets/17194943/4ad19336-7ce0-4e0e-8248-3de730c82c80)
