### PR TITLE
Remove old annotations from hc import

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterDetails.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterDetails.test.tsx
@@ -33,7 +33,6 @@ import {
   nockIgnoreApiPaths,
   nockList,
   nockNamespacedList,
-  nockPatch,
 } from '../../../../../lib/nock-util'
 import { mockManagedClusterSet, mockOpenShiftConsoleConfigMap } from '../../../../../lib/test-metadata'
 import {
@@ -68,7 +67,6 @@ import {
   ClusterProvisionKind,
   HostedClusterApiVersion,
   HostedClusterKind,
-  IResource,
   ManagedCluster,
   ManagedClusterAddOn,
   ManagedClusterAddOnApiVersion,
@@ -1555,16 +1553,6 @@ describe('ClusterDetails with not found', () => {
       nockCreate(createManagedcluster1, createManagedcluster1),
       nockCreate(mockKlusterletAddonConfig, mockKlusterletAddonConfig),
       nockCreate(mockNamespace, mockNamespace),
-      nockPatch(mockHostedCluster1 as IResource, [
-        {
-          op: 'replace',
-          path: '/metadata/annotations',
-          value: {
-            'cluster.open-cluster-management.io/managedcluster-name': 'hostedcluster1',
-            'cluster.open-cluster-management.io/hypershiftdeployment': 'test-cluster/hostedcluster1',
-          },
-        },
-      ]),
     ]
 
     userEvent.click(

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftImportCommand.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftImportCommand.tsx
@@ -16,7 +16,6 @@ import {
   KlusterletAddonConfigApiVersion,
   KlusterletAddonConfigKind,
   KlusterletAddonConfig,
-  patchResource,
   unpackSecret,
   Namespace,
   NamespaceApiVersion,
@@ -62,7 +61,6 @@ export const HypershiftImportCommand = (props: { selectedHostedClusterResource: 
 
   function importHostedControlPlaneCluster() {
     const hdName = selectedHostedClusterResource.metadata?.name
-    const hdNamespace = selectedHostedClusterResource.metadata?.namespace
 
     const match = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(hdName!)
 
@@ -137,11 +135,6 @@ export const HypershiftImportCommand = (props: { selectedHostedClusterResource: 
       },
     }
 
-    const updateAnnotations = {
-      'cluster.open-cluster-management.io/managedcluster-name': hdName,
-      'cluster.open-cluster-management.io/hypershiftdeployment': `${hdNamespace}/${hdName}`,
-    }
-
     createResource(managedClusterResource as IResource)
       .promise.then(() => {
         toastContext.addAlert({
@@ -153,10 +146,6 @@ export const HypershiftImportCommand = (props: { selectedHostedClusterResource: 
       .catch((err) => {
         toastContext.addAlert(getErrorInfo(err, t))
       })
-
-    patchResource(selectedHostedClusterResource as IResource, [
-      { op: 'replace', path: '/metadata/annotations', value: updateAnnotations },
-    ])
 
     //Create namespace for addons if it doesn't already exist
     if (isACMAvailable) {


### PR DESCRIPTION
Remove old annotations from hosted cluster when importing
Old: ![image](https://github.com/stolostron/console/assets/15898988/6e025f45-592f-492a-a4b1-6c4ff1f38620)

Should be: 
![image](https://github.com/stolostron/console/assets/15898988/edbc2201-ca07-4ca7-a890-de1bbb136f97)
