### PR TITLE
MGMT-15484: Fix AI Hypershift delete action

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -343,7 +343,7 @@ export type UpgradeInfo = {
 }
 
 export function mapClusters(
-  clusterDeployments: ClusterDeployment[] = [],
+  allClusterDeployments: ClusterDeployment[] = [],
   managedClusterInfos: ManagedClusterInfo[] = [],
   certificateSigningRequests: CertificateSigningRequest[] = [],
   managedClusters: ManagedCluster[] = [],
@@ -356,6 +356,10 @@ export function mapClusters(
   nodePools: NodePoolK8sResource[] = []
 ) {
   const mcs = managedClusters.filter((mc) => mc.metadata?.name) ?? []
+  const clusterDeployments = allClusterDeployments.filter(
+    // CDs with AgentCluster as owner are just meta objects for AI. We can ignore them.
+    (cd) => (cd.metadata.ownerReferences ? !cd.metadata.ownerReferences.some((o) => o.kind === 'AgentCluster') : true)
+  )
   const uniqueClusterNames = Array.from(
     new Set([
       ...clusterDeployments.map((cd) => cd.metadata.name),


### PR DESCRIPTION
The reason why the delete didnt work properly is that the `getCluster` logic incorrectly mapped CD resource to Hypershift cluster. The CD resource is just a meta object for AI clusters.

When trying to delete NodePools and HostedCluster resource, namespace was taken from that meta CD resource, thus the NodePools and HostedCluster were not found.