### PR TITLE
Fix Accessibility issue in Management-column

### DIFF
--- a/frontend/src/ui-components/AcmTable/AcmManageColumn.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmManageColumn.tsx
@@ -199,7 +199,7 @@ function ManageColumnModal<T>(props: ManageColumnModalProps<T>) {
                           id={`table-column-management-${policy.id}`}
                           key={`table-column-management-${policy.id}`}
                         >
-                          <label htmlFor={`table-column-management-${policy.id}`}>{policy.header}</label>
+                          <label htmlFor={`checkbox-${policy.id}`}>{policy.header}</label>
                         </DataListCell>,
                       ]}
                     />


### PR DESCRIPTION
The label "for" attribute seems to be tied incorrectly which is causing clicking on an option label to do nothing instead of selecting the column because the `label for` and id do not match.

This PR fixes this issue.