### PR TITLE
set create-via annotation to hypershift for HC import

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterDetails.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterDetails.test.tsx
@@ -1217,7 +1217,7 @@ const createManagedcluster1: ManagedCluster = {
     annotations: {
       'import.open-cluster-management.io/hosting-cluster-name': 'local-cluster',
       'import.open-cluster-management.io/klusterlet-deploy-mode': 'Hosted',
-      'open-cluster-management/created-via': 'other',
+      'open-cluster-management/created-via': 'hypershift',
     },
     labels: {
       cloud: 'auto-detect',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
@@ -132,7 +132,7 @@ metadata:
   annotations:
     import.open-cluster-management.io/hosting-cluster-name: local-cluster 
     import.open-cluster-management.io/klusterlet-deploy-mode: Hosted
-    open-cluster-management/created-via: other
+    open-cluster-management/created-via: hypershift
   labels:
     cloud: BareMetal
     vendor: OpenShift

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftImportCommand.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HypershiftImportCommand.tsx
@@ -80,7 +80,7 @@ export const HypershiftImportCommand = (props: { selectedHostedClusterResource: 
         annotations: {
           'import.open-cluster-management.io/hosting-cluster-name': 'local-cluster',
           'import.open-cluster-management.io/klusterlet-deploy-mode': 'Hosted',
-          'open-cluster-management/created-via': 'other',
+          'open-cluster-management/created-via': 'hypershift',
         },
         labels: {
           cloud: 'auto-detect',


### PR DESCRIPTION
This is for story https://issues.redhat.com/browse/ACM-6547 to set `open-cluster-management/created-via: hypershift` annotation in ManagedCluster CRs the console creates to auto-import hosted clusters.