### PR TITLE
Add outcome of bindingoverrides

### DIFF
--- a/frontend/src/resources/placement-binding.ts
+++ b/frontend/src/resources/placement-binding.ts
@@ -13,6 +13,10 @@ export interface PlacementBinding extends IResource {
   apiVersion: PlacementBindingApiVersionType
   kind: PlacementBindingKindType
   metadata: Metadata
+  bindingOverrides?: {
+    remediationAction?: 'Enforce' | 'enforce' | null
+  }
+  subfilter?: boolean | string
   placementRef: ResourceRef
   subjects?: ResourceRef[] | null
 }

--- a/frontend/src/resources/policy.ts
+++ b/frontend/src/resources/policy.ts
@@ -15,6 +15,16 @@ export const PolicyDefinition: IResourceDefinition = {
   kind: PolicyKind,
 }
 
+export enum REMEDIATION_ACTION {
+  ENFORCE_OVERRIDDEN = 'enforce (overridden)',
+  INFORM_ENFORCE_OVERRIDDEN = 'inform/enforce (overridden)',
+  INFORM = 'inform',
+  ENFORCE = 'enforce',
+  INFORM_ENFORCE = 'inform/enforce',
+  INFORM_ONLY = 'informOnly',
+  INFORMONLY_ENFORCE_OVERRIDDEN = 'informOnly/enforce (overridden)',
+  INFORM_INFORMONLY_ENFORCE_OVERRIDDEN = 'inform/informOnly/enforce (overridden)',
+}
 export interface Policy {
   apiVersion: PolicyApiVersionType
   kind: PolicyKindType
@@ -30,6 +40,8 @@ export interface Policy {
     placement?: { placementBinding: string; placementRule?: string; placement?: string; policySet?: string }[]
     status?: { clustername: string; clusternamespace: string; compliant?: string }[]
   }
+  // This not from API, this will be added at console
+  remediationResult?: REMEDIATION_ACTION | string
 }
 
 export interface PolicyTemplate {

--- a/frontend/src/routes/Governance/common/useCustom.tsx
+++ b/frontend/src/routes/Governance/common/useCustom.tsx
@@ -1,0 +1,40 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { useMemo } from 'react'
+import { useRecoilState, useSharedAtoms } from '../../../shared-recoil'
+import { Policy } from '../../../resources/policy'
+import { getPolicyRemediation } from './util'
+import { cloneDeep } from 'lodash'
+
+export function useAddRemediationPolicies() {
+  const { policiesState, usePolicies } = useSharedAtoms()
+  const policies = usePolicies()
+  const [propaPolicies] = useRecoilState(policiesState)
+  const filteredPolicies: Policy[] = useMemo(() => {
+    const resultPolicies = policies.map((p) => {
+      const policyName = p.metadata.name ?? ''
+      const policyNamespace = p.metadata.namespace ?? ''
+      const matchedPropagated: Policy[] = propaPolicies.filter(
+        (p: Policy) => p.metadata.name === `${policyNamespace}.${policyName}`
+      )
+      const result = cloneDeep(p)
+      result.remediationResult = getPolicyRemediation(p, matchedPropagated)
+      return result
+    })
+    return resultPolicies
+  }, [propaPolicies, policies])
+  return filteredPolicies
+}
+
+export function usePropagatedPolicies(policy: Policy) {
+  const { policiesState } = useSharedAtoms()
+  const [propaPolicies] = useRecoilState(policiesState)
+  const filteredPolicies: Policy[] = useMemo(() => {
+    const policyName = policy.metadata.name ?? ''
+    const policyNamespace = policy.metadata.namespace ?? ''
+    const matchedPropagated: Policy[] = propaPolicies.filter(
+      (p: Policy) => p.metadata.name === `${policyNamespace}.${policyName}`
+    )
+    return matchedPropagated
+  }, [propaPolicies, policy])
+  return filteredPolicies
+}

--- a/frontend/src/routes/Governance/common/util.test.tsx
+++ b/frontend/src/routes/Governance/common/util.test.tsx
@@ -1,9 +1,10 @@
 /* Copyright Contributors to the Open Cluster Management project */
 'use strict'
 
-import { getInformOnlyPolicies, getPolicyRemediation, resolveExternalStatus } from './util'
-import { Policy } from '../../../resources'
+import { hasInformOnlyPolicies, getPolicyRemediation, resolveExternalStatus } from './util'
 import { PolicyTableItem } from '../policies/Policies'
+import { Policy, PolicyTemplate, REMEDIATION_ACTION } from '../../../resources'
+import { cloneDeep } from 'lodash'
 
 describe('Test resolveExternalStatus', () => {
   const mockPolicyWithManagers = (managers: string[]): Policy => {
@@ -73,7 +74,7 @@ describe('Test getPolicyRemediation', () => {
         ],
       },
     }
-    expect(getPolicyRemediation(rootPolicy)).toEqual('enforce/informOnly')
+    expect(getPolicyRemediation(rootPolicy, [rootPolicy])).toEqual('enforce/informOnly')
   })
 
   test('getPolicyRemediation should be inform/enforce/informOnly', () => {
@@ -123,7 +124,7 @@ describe('Test getPolicyRemediation', () => {
         ],
       },
     }
-    expect(getPolicyRemediation(rootPolicy)).toEqual('inform/enforce/informOnly')
+    expect(getPolicyRemediation(rootPolicy, [rootPolicy])).toEqual('inform/enforce/informOnly')
   })
 
   test('getPolicyRemediation should be inform/informOnly', () => {
@@ -162,17 +163,648 @@ describe('Test getPolicyRemediation', () => {
         ],
       },
     }
-    expect(getPolicyRemediation(rootPolicy)).toEqual('inform/informOnly')
+    expect(getPolicyRemediation(rootPolicy, [rootPolicy])).toEqual('inform/informOnly')
+  })
+
+  const policy: Policy = {
+    apiVersion: 'policy.open-cluster-management.io/v1',
+    kind: 'Policy',
+    metadata: {},
+    spec: {
+      disabled: false,
+      remediationAction: 'enforce',
+    },
+  }
+  function getPolicyRemediationTestSetting(remediationActions: (string | undefined)[]) {
+    const rootPolicy = cloneDeep(policy)
+    const clusterA = cloneDeep(policy)
+    const clusterB = cloneDeep(policy)
+    const clusterC = cloneDeep(policy)
+    rootPolicy.spec.remediationAction = remediationActions[0]
+    clusterA.spec.remediationAction = remediationActions[1]
+    clusterB.spec.remediationAction = remediationActions[2]
+    clusterC.spec.remediationAction = remediationActions[3]
+    return getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])
+  }
+  describe('Should be enforce when Root policy remediation is enforce', () => {
+    // first element is expected and then rootpolicy, clusterA, clusterB, clusterC respectively
+    test.each([
+      [
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.ENFORCE,
+      ],
+      [
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.ENFORCE,
+      ],
+    ])('getPolicyRemediation with policies should be $expected', (expected, ...rest) => {
+      expect(getPolicyRemediationTestSetting(rest)).toEqual(expected)
+    })
+  })
+  describe('Should be inform/enforce (overridden) when Root policy remediation is inform and mixed cluster remediations', () => {
+    test.each([
+      [
+        REMEDIATION_ACTION.INFORM_ENFORCE_OVERRIDDEN,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.INFORM,
+      ],
+      [
+        REMEDIATION_ACTION.INFORM_ENFORCE_OVERRIDDEN,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.ENFORCE,
+      ],
+      [
+        REMEDIATION_ACTION.INFORM_ENFORCE_OVERRIDDEN,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.INFORM,
+      ],
+    ])('getPolicyRemediation with policies should be $expected', (expected, ...rest) => {
+      expect(getPolicyRemediationTestSetting(rest)).toEqual(expected)
+    })
+  })
+  describe('Should be enforce (overridden) when Root policy = inform or undefined and all clusters = enforce', () => {
+    test.each([
+      [
+        REMEDIATION_ACTION.ENFORCE_OVERRIDDEN,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.ENFORCE,
+        REMEDIATION_ACTION.ENFORCE,
+      ],
+    ])('getPolicyRemediation with policies should be $expected', (expected, ...rest) => {
+      expect(getPolicyRemediationTestSetting(rest)).toEqual(expected)
+    })
+  })
+  describe('Should be inform when Root policy remediation = inform and All cluster remediations = inform', () => {
+    test.each([
+      [
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.INFORM,
+        REMEDIATION_ACTION.INFORM,
+      ],
+    ])('getPolicyRemediation with policies should be $expected', (expected, ...rest) => {
+      expect(getPolicyRemediationTestSetting(rest)).toEqual(expected)
+    })
+  })
+  describe('Should follow template-remediation, all cluster remediations = undefined', () => {
+    const rootPolicy = cloneDeep(policy)
+    const clusterA = cloneDeep(policy)
+    const clusterB = cloneDeep(policy)
+    const clusterC = cloneDeep(policy)
+    rootPolicy.spec.remediationAction = undefined
+    clusterA.spec.remediationAction = undefined
+    clusterB.spec.remediationAction = undefined
+    clusterC.spec.remediationAction = undefined
+    test('getPolicyRemediation should be inform when all template-remediations = inform', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(REMEDIATION_ACTION.INFORM)
+    })
+    test('getPolicyRemediation should be inform/enforce when template-remediations mixed', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(
+        REMEDIATION_ACTION.INFORM_ENFORCE
+      )
+    })
+    test('getPolicyRemediation should be enforce when all template-remediations = enforce', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(REMEDIATION_ACTION.ENFORCE)
+    })
+  })
+  describe('Should be enforce override or enforce, all cluster remediations = ENFORCE (overridden)', () => {
+    const rootPolicy = cloneDeep(policy)
+    const clusterA = cloneDeep(policy)
+    const clusterB = cloneDeep(policy)
+    const clusterC = cloneDeep(policy)
+    rootPolicy.spec.remediationAction = undefined
+    clusterA.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+    clusterB.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+    clusterC.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+    test('getPolicyRemediation should be inform when all template-remediations = inform', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(
+        REMEDIATION_ACTION.ENFORCE_OVERRIDDEN
+      )
+    })
+    test('getPolicyRemediation should be inform/enforce when template-remediations mixed', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(
+        REMEDIATION_ACTION.ENFORCE_OVERRIDDEN
+      )
+    })
+    test('getPolicyRemediation should be enforce when all template-remediations = enforce', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(REMEDIATION_ACTION.ENFORCE)
+    })
+    // This test should be the last in this describe
+    test.each([
+      [
+        // rootpolicy remediation
+        REMEDIATION_ACTION.INFORM,
+        // 1 propagated remediation
+        REMEDIATION_ACTION.INFORM,
+        // 2 propagated remediation
+        REMEDIATION_ACTION.INFORM,
+        // 2 propagated remediation
+        REMEDIATION_ACTION.INFORM,
+      ],
+      [
+        // rootpolicy remediation
+        REMEDIATION_ACTION.INFORM,
+        // 1 propagated remediation
+        REMEDIATION_ACTION.ENFORCE,
+        // 2 propagated remediation
+        REMEDIATION_ACTION.INFORM,
+        // 2 propagated remediation
+        REMEDIATION_ACTION.INFORM,
+      ],
+      [
+        // rootpolicy remediation
+        undefined,
+        // 1 propagated remediation
+        REMEDIATION_ACTION.ENFORCE,
+        // 2 propagated remediation
+        REMEDIATION_ACTION.ENFORCE,
+        // 2 propagated remediation
+        REMEDIATION_ACTION.ENFORCE,
+      ],
+      [
+        // rootpolicy remediation
+        undefined,
+        // 1 propagated remediation
+        undefined,
+        // 2 propagated remediation
+        REMEDIATION_ACTION.ENFORCE,
+        // 2 propagated remediation
+        REMEDIATION_ACTION.ENFORCE,
+      ],
+    ])('getPolicyRemediation should be informOnly when All template-remediations = informOnly', (...rest) => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM_ONLY,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM_ONLY,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec.remediationAction = rest[0]
+      clusterA.spec.remediationAction = rest[1]
+      clusterB.spec.remediationAction = rest[2]
+      clusterC.spec.remediationAction = rest[3]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(REMEDIATION_ACTION.INFORM_ONLY)
+    })
+  })
+  describe('Should be inform/enforce overriden or enforce, some cluster remediations = ENFORCE (overridden)', () => {
+    const rootPolicy = cloneDeep(policy)
+    const clusterA = cloneDeep(policy)
+    const clusterB = cloneDeep(policy)
+    const clusterC = cloneDeep(policy)
+    rootPolicy.spec.remediationAction = undefined
+    clusterA.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+    clusterB.spec.remediationAction = undefined
+    clusterC.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+    test('getPolicyRemediation should be inform when all template-remediations = inform', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(
+        REMEDIATION_ACTION.INFORM_ENFORCE_OVERRIDDEN
+      )
+    })
+    test('getPolicyRemediation should be inform/enforce when template-remediations mixed', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(
+        REMEDIATION_ACTION.INFORM_ENFORCE_OVERRIDDEN
+      )
+    })
+    test('getPolicyRemediation should be enforce when all template-remediations = enforce', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(REMEDIATION_ACTION.ENFORCE)
+    })
+  })
+  describe('Should be inform/enforce overriden or enforce, some cluster remediations = ENFORCE (overridden)', () => {
+    const rootPolicy = cloneDeep(policy)
+    const clusterA = cloneDeep(policy)
+    const clusterB = cloneDeep(policy)
+    const clusterC = cloneDeep(policy)
+    rootPolicy.spec.remediationAction = undefined
+    clusterA.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+    clusterB.spec.remediationAction = undefined
+    clusterC.spec.remediationAction = undefined
+    test('getPolicyRemediation should be inform when all template-remediations = inform', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(
+        REMEDIATION_ACTION.INFORM_ENFORCE_OVERRIDDEN
+      )
+    })
+    test('getPolicyRemediation should be inform/enforce when template-remediations mixed', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(
+        REMEDIATION_ACTION.INFORM_ENFORCE_OVERRIDDEN
+      )
+    })
+    test('getPolicyRemediation should be enforce when all template-remediations = enforce', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual(REMEDIATION_ACTION.ENFORCE)
+    })
+  })
+  describe('Should informOnly showed, all cluster remediations = ENFORCE (overridden)', () => {
+    const rootPolicy = cloneDeep(policy)
+    const clusterA = cloneDeep(policy)
+    const clusterB = cloneDeep(policy)
+    const clusterC = cloneDeep(policy)
+    test('getPolicyRemediation should be enforce/informOnly override', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM_ONLY,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      clusterA.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+      clusterB.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB, clusterC])).toEqual('enforce/informOnly')
+    })
+    test('getPolicyRemediation should be inform/enforce when template-remediations mixed', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.ENFORCE,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM_ONLY,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec.remediationAction = REMEDIATION_ACTION.INFORM
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      clusterA.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+      clusterB.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB])).toEqual(
+        REMEDIATION_ACTION.INFORMONLY_ENFORCE_OVERRIDDEN
+      )
+    })
+    test('getPolicyRemediation should be inform/enfoce/informOnly (overriden)', () => {
+      const rootPolicyTemplates: PolicyTemplate[] = [
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c1' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM,
+            },
+          },
+        },
+        {
+          objectDefinition: {
+            apiVersion: 'v1',
+            kind: 'configurationpolicy',
+            metadata: { name: 'c2' },
+            spec: {
+              remediationAction: REMEDIATION_ACTION.INFORM_ONLY,
+            },
+          },
+        },
+      ]
+      rootPolicy.spec.remediationAction = REMEDIATION_ACTION.INFORM
+      rootPolicy.spec['policy-templates'] = rootPolicyTemplates
+      clusterA.spec.remediationAction = REMEDIATION_ACTION.ENFORCE
+      clusterB.spec.remediationAction = REMEDIATION_ACTION.INFORM
+      expect(getPolicyRemediation(rootPolicy, [clusterA, clusterB])).toEqual(
+        REMEDIATION_ACTION.INFORM_INFORMONLY_ENFORCE_OVERRIDDEN
+      )
+    })
   })
 })
 
-describe('Test getInformOnlyPolicies', () => {
-  test('getInformOnlyPolicies should be true', () => {
+describe('Test hasInformOnlyPolicies', () => {
+  test('hasInformOnlyPolicies should be true', () => {
     const policyItem: PolicyTableItem = {
       policy: {
         apiVersion: 'policy.open-cluster-management.io/v1',
         kind: 'Policy',
         metadata: {},
+        remediationResult: 'enforce/informOnly',
         spec: {
           disabled: false,
           remediationAction: 'enforce',
@@ -206,15 +838,16 @@ describe('Test getInformOnlyPolicies', () => {
       },
       source: 'Local',
     }
-    expect(getInformOnlyPolicies([policyItem])).toBe(true)
+    expect(hasInformOnlyPolicies([policyItem])).toBe(true)
   })
 
-  test('getInformOnlyPolicies should be false', () => {
+  test('hasInformOnlyPolicies should be false', () => {
     const policyItem: PolicyTableItem = {
       policy: {
         apiVersion: 'policy.open-cluster-management.io/v1',
         kind: 'Policy',
         metadata: {},
+        remediationResult: 'enforce',
         spec: {
           disabled: false,
           remediationAction: 'enforce',
@@ -248,6 +881,6 @@ describe('Test getInformOnlyPolicies', () => {
       },
       source: 'Local',
     }
-    expect(getInformOnlyPolicies([policyItem])).toBe(false)
+    expect(hasInformOnlyPolicies([policyItem])).toBe(false)
   })
 })

--- a/frontend/src/routes/Governance/components/PolicyActionDropdown.tsx
+++ b/frontend/src/routes/Governance/components/PolicyActionDropdown.tsx
@@ -8,7 +8,6 @@ import { useTranslation } from '../../../lib/acm-i18next'
 import { rbacDelete, rbacPatch } from '../../../lib/rbac-util'
 import { NavigationPath } from '../../../NavigationPath'
 import { patchResource, Policy, PolicyApiVersion, PolicyDefinition, PolicyKind } from '../../../resources'
-import { getPolicyRemediation } from '../common/util'
 import { AddToPolicySetModal, DeletePolicyModal, PolicyTableItem } from '../policies/Policies'
 
 export function PolicyActionDropdown(props: {
@@ -24,7 +23,7 @@ export function PolicyActionDropdown(props: {
     open: false,
   })
   const { item, setModal } = props
-  const policyRemediationAction = useMemo(() => getPolicyRemediation(item.policy), [item.policy])
+  const policyRemediationAction = item.policy.remediationResult
 
   const bulkModalStatusColumns = useMemo(
     () => [
@@ -56,7 +55,7 @@ export function PolicyActionDropdown(props: {
       },
       {
         header: t('policy.table.actionGroup.status'),
-        cell: (item: PolicyTableItem) => getPolicyRemediation(item.policy),
+        cell: (item: PolicyTableItem) => item.policy.remediationResult,
       },
     ],
     [t]
@@ -68,7 +67,7 @@ export function PolicyActionDropdown(props: {
         id: 'add-to-set',
         text: t('Add to policy set'),
         tooltip: t('Add to policy set'),
-        click: (policy: PolicyTableItem) => {
+        click: (policy: PolicyTableItem): void => {
           setModal(<AddToPolicySetModal policyTableItems={[policy]} onClose={() => setModal(undefined)} />)
         },
         rbac: [rbacPatch(PolicyDefinition, item.policy.metadata.namespace)],
@@ -153,7 +152,7 @@ export function PolicyActionDropdown(props: {
         tooltip: policyRemediationAction === 'inform' ? t('Already informing') : t('Inform policy'),
         addSeparator: true,
         isAriaDisabled: policyRemediationAction === 'inform',
-        click: (item: PolicyTableItem) => {
+        click: (item: PolicyTableItem): void => {
           setModalProps({
             open: true,
             title: t('policy.modal.title.inform'),
@@ -201,7 +200,7 @@ export function PolicyActionDropdown(props: {
             processing: t('policy.table.actions.enforcing'),
             items: [item],
             emptyState: undefined, // there is always 1 item supplied
-            description: policyRemediationAction.includes('informOnly')
+            description: policyRemediationAction?.includes('informOnly')
               ? t('policy.modal.message.enforce') +
                 ' When you enforce a policy where the remediation action for some of the policy templates are set to `informOnly`, there is no effect to those policy templates.'
               : t('policy.modal.message.enforce'),

--- a/frontend/src/routes/Governance/governance.sharedMocks.tsx
+++ b/frontend/src/routes/Governance/governance.sharedMocks.tsx
@@ -224,6 +224,104 @@ const policy1: Policy = {
   },
 }
 
+export const policy2: Policy = {
+  apiVersion: 'policy.open-cluster-management.io/v1',
+  kind: 'Policy',
+  metadata: {
+    name: 'test.policy-set-with-1-placement-policy',
+    namespace: 'local-cluster',
+    labels: {
+      'policy.open-cluster-management.io/cluster-name': 'local-cluster',
+      'policy.open-cluster-management.io/cluster-namespace': 'local-cluster',
+      'policy.open-cluster-management.io/root-policy': 'test.policy-set-with-1-placement-policy',
+    },
+  },
+  spec: {
+    disabled: false,
+    remediationAction: 'enforce',
+    'policy-templates': [
+      {
+        objectDefinition: {
+          apiVersion: 'policy.open-cluster-management.io/v1',
+          kind: 'ConfigurationPolicy',
+          metadata: { name: 'policy-set-with-1-placement-policy-1' },
+          spec: {
+            namespaceSelector: { exclude: ['kube-*'], include: ['default'] },
+            remediationAction: 'inform',
+            severity: 'low',
+          },
+        },
+      },
+    ],
+  },
+  status: {
+    compliant: 'Compliant',
+    details: [
+      {
+        compliant: 'Compliant',
+        history: [
+          {
+            eventName: 'test.policy-set-with-1-placement-policy.16d459c516462fbf',
+            lastTimestamp: '2022-02-16T19:07:46Z',
+            message:
+              'Compliant; notification - namespaces [test] found as specified, therefore this Object template is compliant',
+          },
+        ],
+        templateMeta: { creationTimestamp: null, name: 'policy-set-with-1-placement-policy-1' },
+      },
+    ],
+  },
+}
+
+export const policy3: Policy = {
+  apiVersion: 'policy.open-cluster-management.io/v1',
+  kind: 'Policy',
+  metadata: {
+    name: 'test.policy-set-with-1-placement-policy',
+    namespace: 'test',
+    labels: {
+      'policy.open-cluster-management.io/cluster-name': 'local-cluster1',
+      'policy.open-cluster-management.io/cluster-namespace': 'local-cluster1',
+      'policy.open-cluster-management.io/root-policy': 'test.policy-set-with-1-placement-policy',
+    },
+  },
+  spec: {
+    disabled: false,
+    remediationAction: 'inform',
+    'policy-templates': [
+      {
+        objectDefinition: {
+          apiVersion: 'policy.open-cluster-management.io/v1',
+          kind: 'ConfigurationPolicy',
+          metadata: {
+            name: 'test-policy-namespace-2',
+          },
+          spec: {
+            remediationAction: 'inform',
+            severity: 'low',
+            namespaceSelector: {
+              exclude: ['kube-*'],
+              include: ['default'],
+            },
+            'object-templates': [
+              {
+                complianceType: 'musthave',
+                objectDefinition: {
+                  kind: 'Namespace',
+                  apiVersion: 'v1',
+                  metadata: {
+                    name: 'test',
+                  },
+                },
+              },
+            ],
+            pruneObjectBehavior: 'DeleteIfCreated',
+          },
+        },
+      },
+    ],
+  },
+}
 const pendingPolicy: Policy = {
   apiVersion: 'policy.open-cluster-management.io/v1',
   kind: 'Policy',
@@ -668,6 +766,7 @@ export const mockEditedPolicyAutomation: PolicyAutomation = {
 
 export const mockEmptyPolicy: Policy[] = []
 export const mockPolicy: Policy[] = [rootPolicy, policy0, policy1]
+export const mockPolicyBinding: Policy[] = [rootPolicy, policy2]
 export const mockPendingPolicy: Policy[] = [pendingPolicy, pendingPolicy0]
 
 export const mockPolicyNoStatus: Policy = policyWithoutStatus

--- a/frontend/src/routes/Governance/policies/Policies.test.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.test.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { render, waitFor, screen, fireEvent } from '@testing-library/react'
+import { render, waitFor, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
 import {
@@ -13,7 +13,13 @@ import { nockIgnoreApiPaths, nockIgnoreRBAC } from '../../../lib/nock-util'
 import { waitForText } from '../../../lib/test-util'
 import { Placement, PlacementBinding, PlacementRule } from '../../../resources'
 import PoliciesPage, { AddToPolicySetModal, DeletePolicyModal, PolicyTableItem } from './Policies'
-import { mockPolicy, mockEmptyPolicy, mockPolicySets, mockPendingPolicy } from '../governance.sharedMocks'
+import {
+  mockPolicy,
+  mockEmptyPolicy,
+  mockPolicySets,
+  mockPendingPolicy,
+  mockPolicyBinding,
+} from '../governance.sharedMocks'
 
 describe('Policies Page', () => {
   beforeEach(async () => {
@@ -127,6 +133,26 @@ describe('Policies Page', () => {
         '/multicloud/governance/policies/details/test/policy-set-with-1-placement-policy/results?sort=-1'
       )
     )
+  })
+
+  test('should show enforce fitler without (overridden)', async () => {
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policiesState, mockPolicyBinding)
+        }}
+      >
+        <MemoryRouter>
+          <PoliciesPage />
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+    await waitForText('enforce (overridden)')
+    await waitForText('Filter')
+    screen.getByRole('button', { name: 'Options menu' }).click()
+    await waitForText('Enforce')
+    const enforceDiv = screen.getByText('Enforce').closest('div')
+    within(enforceDiv!).getByText('1')
   })
 })
 

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsOverview.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsOverview.tsx
@@ -30,6 +30,7 @@ import {
 import { AutomationDetailsSidebar } from '../../components/AutomationDetailsSidebar'
 import { ClusterPolicyViolationIcons } from '../../components/ClusterPolicyViolations'
 import { useGovernanceData } from '../../useGovernanceData'
+import { usePropagatedPolicies } from '../../common/useCustom'
 
 interface TableData {
   apiVersion: string
@@ -59,6 +60,7 @@ export default function PolicyDetailsOverview(props: { policy: Policy }) {
   const [placementDecisions] = useRecoilState(placementDecisionsState)
   const [policyAutomations] = useRecoilState(policyAutomationState)
   const [namespaces] = useRecoilState(namespacesState)
+  const policies = usePropagatedPolicies(policy)
   const govData = useGovernanceData([policy])
   const clusterRiskScore =
     govData.clusterRisks.high +
@@ -99,7 +101,7 @@ export default function PolicyDetailsOverview(props: { policy: Policy }) {
       },
       {
         key: t('Remediation'),
-        value: getPolicyRemediation(policy),
+        value: getPolicyRemediation(policy, policies),
       },
       {
         key: t('Cluster violations'),
@@ -193,6 +195,7 @@ export default function PolicyDetailsOverview(props: { policy: Policy }) {
     setDrawerContext,
     canCreatePolicyAutomation,
     canUpdatePolicyAutomation,
+    policies,
     t,
   ])
 

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
@@ -6,7 +6,7 @@ import { policiesState } from '../../../../atoms'
 import { nockIgnoreApiPaths, nockIgnoreRBAC } from '../../../../lib/nock-util'
 import { waitForText } from '../../../../lib/test-util'
 import PolicyDetailsResults from './PolicyDetailsResults'
-import { mockPolicy, mockPendingPolicy } from '../../governance.sharedMocks'
+import { mockPolicy, mockPendingPolicy, mockPolicyBinding } from '../../governance.sharedMocks'
 
 describe('Policy Details Results', () => {
   beforeEach(async () => {
@@ -36,6 +36,23 @@ describe('Policy Details Results', () => {
     await waitForText(
       'notification - namespaces [test] found as specified, therefore this Object template is compliant'
     )
+    await waitForText('Remediation')
+    await waitForText('inform')
+  })
+  test('Should render Policy Details Results Page with Remediation enforce', async () => {
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policiesState, mockPolicyBinding)
+        }}
+      >
+        <MemoryRouter>
+          <PolicyDetailsResults policy={mockPolicyBinding[0]} />
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+    await waitForText('Remediation')
+    await waitForText('enforce')
   })
 })
 

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -11,6 +11,7 @@ import { checkPermission, rbacCreate } from '../../../../lib/rbac-util'
 import { transformBrowserUrlToFilterPresets } from '../../../../lib/urlQuery'
 import { NavigationPath, UNKNOWN_NAMESPACE } from '../../../../NavigationPath'
 import { getGroupFromApiVersion, Policy, PolicyDefinition, PolicyStatusDetails } from '../../../../resources'
+import { getPolicyTempRemediation } from '../../common/util'
 
 interface resultsTableData {
   templateName: string
@@ -23,6 +24,7 @@ interface resultsTableData {
   timestamp: moment.MomentInput
   policyName: string
   policyNamespace: string
+  remediationAction: string
 }
 
 export default function PolicyDetailsResults(props: { policy: Policy }) {
@@ -72,6 +74,7 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
             timestamp: detail?.history && detail?.history[0]?.lastTimestamp,
             policyName,
             policyNamespace,
+            remediationAction: getPolicyTempRemediation(policyResponse, template),
           })
         })
       })
@@ -191,6 +194,12 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
           return '-'
         },
         search: (item: resultsTableData) => item.message,
+      },
+      {
+        header: t('Remediation'),
+        sort: 'remediationAction',
+        cell: (item: resultsTableData) => item.remediationAction,
+        search: (item: resultsTableData) => item.remediationAction,
       },
       {
         header: t('Last report'),

--- a/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.test.tsx
+++ b/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.test.tsx
@@ -11,7 +11,14 @@ import {
   policiesState,
 } from '../../../../atoms'
 import { clickByText, waitForText } from '../../../../lib/test-util'
-import { PlacementBinding, PlacementDecision, PlacementRule, Policy, PolicySet } from '../../../../resources'
+import {
+  PlacementBinding,
+  PlacementDecision,
+  PlacementRule,
+  Policy,
+  PolicySet,
+  REMEDIATION_ACTION,
+} from '../../../../resources'
 import { ManagedCluster } from '../../../../resources/managed-cluster'
 import { PolicySetDetailSidebar } from './PolicySetDetailSidebar'
 
@@ -124,7 +131,7 @@ const mockPolicy0: Policy = {
         },
       },
     ],
-    remediationAction: 'inform',
+    remediationAction: 'enforce',
   },
   status: {
     compliant: 'Compliant',
@@ -243,6 +250,9 @@ const mockPlacementRules: PlacementRule[] = [mockPlacementRule]
 const mockPlacementBinding: PlacementBinding = {
   apiVersion: 'policy.open-cluster-management.io/v1',
   kind: 'PlacementBinding',
+  bindingOverrides: {
+    remediationAction: 'enforce',
+  },
   metadata: {
     name: 'policy-set-with-1-placement-rule',
     namespace: 'test',
@@ -333,6 +343,10 @@ describe('PolicySets Page', () => {
 
     // switch to the policies table
     await clickByText('Policies')
+
+    // Find remediation
+    await waitForText('Cluster violation')
+    await waitForText(REMEDIATION_ACTION.ENFORCE_OVERRIDDEN)
 
     // find the policy names in table
     await waitForText(mockPolicy.metadata.name!)

--- a/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
+++ b/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
@@ -30,7 +30,6 @@ import { Policy, PolicySet } from '../../../../resources'
 import {
   getClustersSummaryForPolicySet,
   getPlacementDecisionsForResource,
-  getPolicyRemediation,
   getPolicySetPolicies,
 } from '../../common/util'
 import { ClusterPolicyViolationIcons2 } from '../../components/ClusterPolicyViolations'
@@ -38,6 +37,7 @@ import {
   useClusterViolationSummaryMap,
   usePolicySetClusterPolicyViolationsColumn,
 } from '../../overview/ClusterViolationSummary'
+import { useAddRemediationPolicies } from '../../common/useCustom'
 
 function renderDonutChart(
   clusterComplianceSummary: { compliant: string[]; nonCompliant: string[]; pending: string[] },
@@ -108,10 +108,9 @@ export function PolicySetDetailSidebar(props: { policySet: PolicySet }) {
     placementDecisionsState,
     placementRulesState,
     placementsState,
-    usePolicies,
   } = useSharedAtoms()
   const [managedClusters] = useRecoilState(managedClustersState)
-  const policies = usePolicies()
+  const policies = useAddRemediationPolicies()
   const [placements] = useRecoilState(placementsState)
   const [placementRules] = useRecoilState(placementRulesState)
   const [placementBindings] = useRecoilState(placementBindingsState)
@@ -319,13 +318,12 @@ export function PolicySetDetailSidebar(props: { policySet: PolicySet }) {
       {
         header: t('Remediation'),
         sort: (policyA: Policy, policyB: Policy) => {
-          const policyARemediation = getPolicyRemediation(policyA)
-          const policyBRemediation = getPolicyRemediation(policyB)
-          /* istanbul ignore next */
+          const policyARemediation = policyA.remediationResult
+          const policyBRemediation = policyB.remediationResult
           return compareStrings(policyARemediation, policyBRemediation)
         },
         cell: (policy: Policy) => {
-          return getPolicyRemediation(policy)
+          return policy.remediationResult
         },
       },
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1413,9 +1413,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -2488,9 +2488,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.1.3.tgz",
-      "integrity": "sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
+      "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
       "dev": true
     },
     "yargs": {


### PR DESCRIPTION
As a policy user that uses `bindingOverrides.remediationAction` on a `PlacementBinding`, I'd like to see in the console the correct remediationAction reflected.

- The policy Results tab's table should have a `Remediation` column. Add an indicator that it is overridden.

- The "Policies" tab's table's `Remediation` column should indicate that there are some overrides. For example, if the parent policy has `remediationAction` set to `inform` but there are some overrides, the text should go from `inform` to `inform/enforce (overridden)`.

Ref: https://issues.redhat.com/browse/ACM-6634