### PR TITLE
Expose console page visit metric

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
                 "node-fetch": "2.6.7",
                 "pino": "7.11.0",
                 "pluralize": "8.0.0",
+                "prom-client": "^14.2.0",
                 "raw-body": "2.5.1"
             },
             "devDependencies": {
@@ -1975,6 +1976,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/bintrees": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+            "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -5332,6 +5338,17 @@
             "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
             "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
         },
+        "node_modules/prom-client": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+            "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+            "dependencies": {
+                "tdigest": "^0.1.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -6049,6 +6066,14 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
+        },
+        "node_modules/tdigest": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+            "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+            "dependencies": {
+                "bintrees": "1.0.2"
+            }
         },
         "node_modules/terminal-link": {
             "version": "2.1.1",
@@ -8191,6 +8216,11 @@
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
+        },
+        "bintrees": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+            "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -10740,6 +10770,14 @@
             "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
             "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
         },
+        "prom-client": {
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
+            "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+            "requires": {
+                "tdigest": "^0.1.1"
+            }
+        },
         "prompts": {
             "version": "2.4.2",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11256,6 +11294,14 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
+        },
+        "tdigest": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+            "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+            "requires": {
+                "bintrees": "1.0.2"
+            }
         },
         "terminal-link": {
             "version": "2.1.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,7 @@
         "node-fetch": "2.6.7",
         "pino": "7.11.0",
         "pluralize": "8.0.0",
+        "prom-client": "^14.2.0",
         "raw-body": "2.5.1"
     },
     "devDependencies": {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -15,6 +15,7 @@ import { apiPaths } from './routes/apiPaths'
 import { configure } from './routes/configure'
 import { events, startWatching, stopWatching } from './routes/events'
 import { liveness } from './routes/liveness'
+import { metrics } from './routes/metrics'
 import { login, loginCallback, logout } from './routes/oauth'
 import { observabilityProxy } from './routes/observabilityProxy'
 import { operatorCheck } from './routes/operatorCheck'
@@ -59,6 +60,7 @@ router.get('/authenticated', authenticated)
 router.post('/ansibletower', ansibleTower)
 router.get('/username', username)
 router.all('/userpreference', userpreference)
+router.all('/metrics', metrics)
 router.get('/*', serveHandler)
 
 export async function requestHandler(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -19,6 +19,7 @@ export async function metrics(req: Http2ServerRequest, res: Http2ServerResponse)
     // POSTs originate from an ACM page - get the page from req url params and increase that pages count
     const page = req.url.split('?')[1]
     acm_console_page_count.labels({ page }).inc()
+    res.end(`Increased ${page} label count for metric acm_console_page_count`)
   } else {
     res.setHeader('Content-Type', register.contentType)
     await register.metrics().then((data) => res.end(data))

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -2,10 +2,8 @@
 
 import { Http2ServerRequest, Http2ServerResponse } from 'http2'
 import Prometheus, { register } from 'prom-client'
-
-interface PageData {
-  page: string
-}
+import { catchInternalServerError } from '../lib/respond'
+import { getAuthenticatedToken } from '../lib/token'
 
 const acm_console_page_count = new Prometheus.Counter({
   name: 'acm_console_page_count',
@@ -15,13 +13,18 @@ const acm_console_page_count = new Prometheus.Counter({
 register.registerMetric(acm_console_page_count)
 
 export async function metrics(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
-  if (req.method === 'POST' && req.url.includes('?')) {
-    // POSTs originate from an ACM page - get the page from req url params and increase that pages count
-    const page = req.url.split('?')[1]
-    acm_console_page_count.labels({ page }).inc()
-    res.end(`Increased ${page} label count for metric acm_console_page_count`)
-  } else {
-    res.setHeader('Content-Type', register.contentType)
-    await register.metrics().then((data) => res.end(data))
-  }
+  const errorCatcher = catchInternalServerError(res)
+  getAuthenticatedToken(req, res)
+    .then(async () => {
+      if (req.method === 'POST' && req.url.includes('?')) {
+        // POSTs originate from an ACM page - get the page from req url params and increase that pages count
+        const page = req.url.split('?')[1]
+        acm_console_page_count.labels({ page }).inc()
+        res.end(`Increased ${page} label count for metric acm_console_page_count`)
+      } else {
+        res.setHeader('Content-Type', register.contentType)
+        await register.metrics().then((data) => res.end(data))
+      }
+    })
+    .catch(errorCatcher)
 }

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -22,21 +22,27 @@ register.registerMetric(acm_console_page_visit_counter)
 
 export async function metrics(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
   if (req.method === 'POST') {
+    logger.info({ msg: 'PRE - Increasing acm_console_page_visit_counter metric' })
     // POSTs originate from the ACM page - get the page from req data and increase that pages count
     let data: string = undefined
     const chucks: string[] = []
     req.on('data', (chuck: string) => {
       chucks.push(chuck)
     })
-    req.on('end', () => {
+    req.on('end', async () => {
       data = chucks.join()
       const parsedData = JSON.parse(data) as PageData
       const page = parsedData.page
-      logger.info({ msg: 'Updating acm_console_page_visit_counter metric', page })
+      logger.info({ msg: 'Increasing acm_console_page_visit_counter metric', page })
       acm_console_page_visit_counter.labels({ page }).inc()
-    })
-  }
 
-  res.setHeader('Content-Type', register.contentType)
-  await register.metrics().then((data) => res.end(data))
+      logger.info({ msg: 'Returning acm_console_page_visit_counter metric' })
+      res.setHeader('Content-Type', register.contentType)
+      await register.metrics().then((data) => res.end(data))
+    })
+  } else {
+    logger.info({ msg: 'Returning acm_console_page_visit_counter metric' })
+    res.setHeader('Content-Type', register.contentType)
+    await register.metrics().then((data) => res.end(data))
+  }
 }

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -12,7 +12,7 @@ const acm_console_page_count = new Prometheus.Counter({
 })
 register.registerMetric(acm_console_page_count)
 
-export async function metrics(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
+export function metrics(req: Http2ServerRequest, res: Http2ServerResponse): void {
   const errorCatcher = catchInternalServerError(res)
   getAuthenticatedToken(req, res)
     .then(async () => {

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -1,0 +1,32 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { Http2ServerRequest, Http2ServerResponse } from 'http2'
+import Prometheus, { register } from 'prom-client'
+import { logger } from '../lib/logger'
+
+const acm_console_page_visit_counter = new Prometheus.Counter({
+  name: 'acm_console_page_visit_counter',
+  help: 'Capture ACM page visit counts',
+  labelNames: ['page'],
+  registers: [register],
+})
+register.registerMetric(acm_console_page_visit_counter)
+
+export function metrics(req: Http2ServerRequest, res: Http2ServerResponse): void {
+  if (req.method === 'POST') {
+    // POSTs originate from the ACM page - get the page from req data and increase that pages count
+    let data: string = undefined
+    const chucks: string[] = []
+    req.on('data', (chuck: string) => {
+      chucks.push(chuck)
+    })
+    req.on('end', async () => {
+      data = chucks.join()
+      logger.info({ msg: 'Updating acm_console_page_visit_counter metric', page: JSON.parse(data).page })
+      acm_console_page_visit_counter.labels({ page: JSON.parse(data).page }).inc()
+    })
+  }
+
+  res.setHeader('Content-Type', register.contentType)
+  register.metrics().then((data) => res.end(data))
+}

--- a/backend/test/routes/metrics.test.ts
+++ b/backend/test/routes/metrics.test.ts
@@ -1,0 +1,22 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import nock from 'nock'
+import { request } from '../mock-request'
+
+describe('metrics route', function () {
+  it('Should response with successful metrics GET', async function () {
+    nock(process.env.CLUSTER_API_URL)
+      .get('/metrics')
+      .reply(200, `# HELP acm_console_page_count Capture ACM page visit counts\n# TYPE acm_console_page_count counter`)
+
+    const res = await request('GET', '/metrics')
+    expect(res.statusCode).toEqual(200)
+  })
+
+  it('Should response with successful metrics GET request with page param', async function () {
+    nock(process.env.CLUSTER_API_URL).post('/metrics?overview-classic').reply(200)
+
+    const res = await request('POST', '/metrics?overview-classic')
+    // POST increases the metric count - no response to validate
+    expect(res.statusCode).toEqual(200)
+  })
+})

--- a/backend/test/routes/metrics.test.ts
+++ b/backend/test/routes/metrics.test.ts
@@ -4,6 +4,18 @@ import { request } from '../mock-request'
 
 describe('metrics route', function () {
   it('Should response with successful metrics GET', async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+      status: 200,
+    })
+    nock(process.env.CLUSTER_API_URL)
+      .post('/apis/authentication.k8s.io/v1/tokenreviews')
+      .reply(200, {
+        status: {
+          user: {
+            username: 'kube:admin',
+          },
+        },
+      })
     nock(process.env.CLUSTER_API_URL)
       .get('/metrics')
       .reply(200, `# HELP acm_console_page_count Capture ACM page visit counts\n# TYPE acm_console_page_count counter`)
@@ -13,6 +25,18 @@ describe('metrics route', function () {
   })
 
   it('Should response with successful metrics GET request with page param', async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, {
+      status: 200,
+    })
+    nock(process.env.CLUSTER_API_URL)
+      .post('/apis/authentication.k8s.io/v1/tokenreviews')
+      .reply(200, {
+        status: {
+          user: {
+            username: 'kube:admin',
+          },
+        },
+      })
     nock(process.env.CLUSTER_API_URL).post('/metrics?overview-classic').reply(200)
 
     const res = await request('POST', '/metrics?overview-classic')

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,27 +17,27 @@ import {
   Title,
 } from '@patternfly/react-core'
 import { CaretDownIcon } from '@patternfly/react-icons'
-import { AcmTablePaginationContextProvider, AcmToastGroup, AcmToastProvider } from './ui-components'
 import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { BrowserRouter, Link, Redirect, Route, RouteComponentProps, Switch, useLocation } from 'react-router-dom'
 import './App.css'
-import { logout } from './logout'
 import { LoadingPage } from './components/LoadingPage'
-import { configure } from './lib/configure'
-import './lib/test-shots'
-import './lib/i18n'
-import { getUsername } from './lib/username'
-import { NavigationPath } from './NavigationPath'
-import { setLightTheme, ThemeSwitcher } from './theme'
-import { usePluginDataContextValue } from './lib/PluginDataContext'
-import { PluginDataContextProvider } from './components/PluginDataContextProvider'
 import { LoadPluginData } from './components/LoadPluginData'
+import { PluginDataContextProvider } from './components/PluginDataContextProvider'
 import { Truncate } from './components/Truncate'
+import { configure } from './lib/configure'
+import './lib/i18n'
+import { usePluginDataContextValue } from './lib/PluginDataContext'
+import './lib/test-shots'
+import { getUsername } from './lib/username'
+import { logout } from './logout'
+import { NavigationPath } from './NavigationPath'
 import { ResourceError, ResourceErrorCode } from './resources'
+import { setLightTheme, ThemeSwitcher } from './theme'
+import { AcmTablePaginationContextProvider, AcmToastGroup, AcmToastProvider } from './ui-components'
 
 // HOME
 const WelcomePage = lazy(() => import('./routes/Home/Welcome/Welcome'))
-const OverviewPage = lazy(() => import('./routes/Home/Overview/OverviewPage'))
+const OverviewPage = lazy(() => import('./routes/Home/Overview/Overview'))
 const Search = lazy(() => import('./routes/Home/Search/Search'))
 
 // INFRASTRUCTURE

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,27 +17,27 @@ import {
   Title,
 } from '@patternfly/react-core'
 import { CaretDownIcon } from '@patternfly/react-icons'
+import { AcmTablePaginationContextProvider, AcmToastGroup, AcmToastProvider } from './ui-components'
 import { lazy, Suspense, useEffect, useLayoutEffect, useMemo, useState } from 'react'
 import { BrowserRouter, Link, Redirect, Route, RouteComponentProps, Switch, useLocation } from 'react-router-dom'
 import './App.css'
-import { LoadingPage } from './components/LoadingPage'
-import { LoadPluginData } from './components/LoadPluginData'
-import { PluginDataContextProvider } from './components/PluginDataContextProvider'
-import { Truncate } from './components/Truncate'
-import { configure } from './lib/configure'
-import './lib/i18n'
-import { usePluginDataContextValue } from './lib/PluginDataContext'
-import './lib/test-shots'
-import { getUsername } from './lib/username'
 import { logout } from './logout'
+import { LoadingPage } from './components/LoadingPage'
+import { configure } from './lib/configure'
+import './lib/test-shots'
+import './lib/i18n'
+import { getUsername } from './lib/username'
 import { NavigationPath } from './NavigationPath'
-import { ResourceError, ResourceErrorCode } from './resources'
 import { setLightTheme, ThemeSwitcher } from './theme'
-import { AcmTablePaginationContextProvider, AcmToastGroup, AcmToastProvider } from './ui-components'
+import { usePluginDataContextValue } from './lib/PluginDataContext'
+import { PluginDataContextProvider } from './components/PluginDataContextProvider'
+import { LoadPluginData } from './components/LoadPluginData'
+import { Truncate } from './components/Truncate'
+import { ResourceError, ResourceErrorCode } from './resources'
 
 // HOME
 const WelcomePage = lazy(() => import('./routes/Home/Welcome/Welcome'))
-const OverviewPage = lazy(() => import('./routes/Home/Overview/Overview'))
+const OverviewPage = lazy(() => import('./routes/Home/Overview/OverviewPage'))
 const Search = lazy(() => import('./routes/Home/Search/Search'))
 
 // INFRASTRUCTURE

--- a/frontend/src/hooks/console-metrics.ts
+++ b/frontend/src/hooks/console-metrics.ts
@@ -1,21 +1,11 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { useEffect } from 'react'
-import { fetchRetry, getBackendUrl } from '../resources'
+import { getBackendUrl, postRequest } from '../resources'
 
 export function usePageVisitMetricHandler(page: string) {
-  console.log('handling page visit metric: ', page)
   useEffect(() => {
-    console.log('Pre overview-fleet metrics POST')
-    const abortController = new AbortController()
-    fetchRetry({
-      method: 'POST',
-      url: getBackendUrl() + '/metrics',
-      data: {
-        page,
-      },
-      signal: abortController.signal,
-      retries: /* istanbul ignore next */ process.env.NODE_ENV === 'production' ? 2 : 0,
-    })
-  }, [page])
+    postRequest(getBackendUrl() + `/metrics?${page}`, {})
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 }

--- a/frontend/src/hooks/console-metrics.ts
+++ b/frontend/src/hooks/console-metrics.ts
@@ -1,14 +1,21 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { useEffect } from 'react'
-import { getBackendUrl, postRequest } from '../resources'
+import { fetchRetry, getBackendUrl } from '../resources'
 
 export const handlePageVisitMetric = (page: string) => {
   console.log('handling page visit metric: ', page)
   useEffect(() => {
     console.log('Pre overview-fleet metrics POST')
-    postRequest(getBackendUrl() + '/metrics', {
-      page,
+    const abortController = new AbortController()
+    fetchRetry({
+      method: 'POST',
+      url: getBackendUrl() + '/metrics',
+      data: {
+        page,
+      },
+      signal: abortController.signal,
+      retries: /* istanbul ignore next */ process.env.NODE_ENV === 'production' ? 2 : 0,
     })
   }, [page])
 }

--- a/frontend/src/hooks/console-metrics.ts
+++ b/frontend/src/hooks/console-metrics.ts
@@ -6,6 +6,8 @@ import { getBackendUrl, postRequest } from '../resources'
 export enum Pages {
   overview = 'overview-classic',
   overviewFleet = 'overview-fleet',
+  search = 'search',
+  searchDetails = 'search-details',
 }
 
 export function usePageVisitMetricHandler(page: Pages) {

--- a/frontend/src/hooks/console-metrics.ts
+++ b/frontend/src/hooks/console-metrics.ts
@@ -3,7 +3,12 @@
 import { useEffect } from 'react'
 import { getBackendUrl, postRequest } from '../resources'
 
-export function usePageVisitMetricHandler(page: string) {
+export enum Pages {
+  overview = 'overview-classic',
+  overviewFleet = 'overview-fleet',
+}
+
+export function usePageVisitMetricHandler(page: Pages) {
   useEffect(() => {
     postRequest(getBackendUrl() + `/metrics?${page}`, {})
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/hooks/console-metrics.ts
+++ b/frontend/src/hooks/console-metrics.ts
@@ -3,7 +3,7 @@
 import { useEffect } from 'react'
 import { fetchRetry, getBackendUrl } from '../resources'
 
-export const handlePageVisitMetric = (page: string) => {
+export function usePageVisitMetricHandler(page: string) {
   console.log('handling page visit metric: ', page)
   useEffect(() => {
     console.log('Pre overview-fleet metrics POST')

--- a/frontend/src/hooks/console-metrics.ts
+++ b/frontend/src/hooks/console-metrics.ts
@@ -1,0 +1,14 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { useEffect } from 'react'
+import { getBackendUrl, postRequest } from '../resources'
+
+export const handlePageVisitMetric = (page: string) => {
+  console.log('handling page visit metric: ', page)
+  useEffect(() => {
+    console.log('Pre overview-fleet metrics POST')
+    postRequest(getBackendUrl() + '/metrics', {
+      page,
+    })
+  }, [page])
+}

--- a/frontend/src/hooks/console-metrics.ts
+++ b/frontend/src/hooks/console-metrics.ts
@@ -13,6 +13,5 @@ export enum Pages {
 export function usePageVisitMetricHandler(page: Pages) {
   useEffect(() => {
     postRequest(getBackendUrl() + `/metrics?${page}`, {})
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [page])
 }

--- a/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
@@ -1062,9 +1062,7 @@ it('should render overview page in empty state', async () => {
   const apiPathNock = nockIgnoreApiPaths()
   const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
   const getManageedClusterAccessRequeset = nockCreate(mockGetSelfSubjectAccessRequest, mockGetSelfSubjectAccessResponse)
-  const metricNock = nockPostRequest('/metrics', {
-    page: 'overview-classic',
-  })
+  const metricNock = nockPostRequest('/metrics?overview-classic', {})
   nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
   nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
 
@@ -1086,9 +1084,7 @@ it('should render overview page in empty state', async () => {
 })
 
 it('should render overview page in error state', async () => {
-  const metricNock = nockPostRequest('/metrics', {
-    page: 'overview-classic',
-  })
+  const metricNock = nockPostRequest('/metrics?overview-classic', {})
   nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
   nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
   const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
@@ -1125,9 +1121,7 @@ it('should render overview page in error state', async () => {
 })
 
 it('should render overview page with expected data', async () => {
-  const metricNock = nockPostRequest('/metrics', {
-    page: 'overview-classic',
-  })
+  const metricNock = nockPostRequest('/metrics?overview-classic', {})
   nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
   nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
   nockIgnoreApiPaths()

--- a/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
@@ -19,7 +19,7 @@ import {
   policiesState,
   policyreportState,
 } from '../../../atoms'
-import { nockCreate, nockGet, nockIgnoreApiPaths, nockSearch } from '../../../lib/nock-util'
+import { nockCreate, nockGet, nockIgnoreApiPaths, nockPostRequest, nockSearch } from '../../../lib/nock-util'
 import { clickByText, wait, waitForNocks } from '../../../lib/test-util'
 import {
   ClusterManagementAddOn,
@@ -1062,6 +1062,9 @@ it('should render overview page in empty state', async () => {
   const apiPathNock = nockIgnoreApiPaths()
   const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
   const getManageedClusterAccessRequeset = nockCreate(mockGetSelfSubjectAccessRequest, mockGetSelfSubjectAccessResponse)
+  const metricNock = nockPostRequest('/metrics', {
+    page: 'overview-classic',
+  })
   nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
   nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
 
@@ -1079,10 +1082,13 @@ it('should render overview page in empty state', async () => {
   await waitFor(() => expect(screen.getByText(`You don't have any clusters`)).toBeInTheDocument())
 
   // Wait for delete resource requests to finish
-  await waitForNocks([getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
+  await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
 })
 
 it('should render overview page in error state', async () => {
+  const metricNock = nockPostRequest('/metrics', {
+    page: 'overview-classic',
+  })
   nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
   nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
   const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
@@ -1112,13 +1118,16 @@ it('should render overview page in error state', async () => {
   await wait()
 
   // Wait for delete resource requests to finish
-  await waitForNocks([getAddonNock, getManageedClusterAccessRequeset])
+  await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset])
 
   // Test that the component has rendered correctly with an error
   await waitFor(() => expect(screen.queryByText('An unexpected error occurred.')).toBeTruthy())
 })
 
 it('should render overview page with expected data', async () => {
+  const metricNock = nockPostRequest('/metrics', {
+    page: 'overview-classic',
+  })
   nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
   nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
   nockIgnoreApiPaths()
@@ -1228,7 +1237,7 @@ it('should render overview page with expected data', async () => {
   )
 
   // Wait for delete resource requests to finish
-  await waitForNocks([getAddonNock])
+  await waitForNocks([metricNock, getAddonNock])
 
   // This wait pauses till apollo query is returning data
   await wait()

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -10,7 +10,7 @@ import {
   GetDiscoveredOCPApps,
   GetOpenShiftAppResourceMaps,
 } from '../../../components/GetDiscoveredOCPApps'
-import { usePageVisitMetricHandler } from '../../../hooks/console-metrics'
+import { Pages, usePageVisitMetricHandler } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { NavigationPath } from '../../../NavigationPath'
 import {
@@ -188,7 +188,7 @@ const searchQueries = (selectedClusters: Array<string>): Array<any> => {
 }
 
 export default function OverviewPage() {
-  usePageVisitMetricHandler('overview-classic')
+  usePageVisitMetricHandler(Pages.overview)
   const applicationsMatch = useRouteMatch()
   const { t } = useTranslation()
   const {

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -235,6 +235,7 @@ export default function OverviewPage() {
   GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
 
   useEffect(() => {
+    console.log('Pre overview-classic metrics POST')
     postRequest(getBackendUrl() + '/metrics', {
       page: 'overview-classic',
     })

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -10,6 +10,7 @@ import {
   GetDiscoveredOCPApps,
   GetOpenShiftAppResourceMaps,
 } from '../../../components/GetDiscoveredOCPApps'
+import { handlePageVisitMetric } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { NavigationPath } from '../../../NavigationPath'
 import {
@@ -20,12 +21,10 @@ import {
   ApplicationSetKind,
   Cluster,
   ClusterStatus,
-  getBackendUrl,
   ManagedClusterInfo,
   Policy,
   PolicyReport,
   PolicyReportResults,
-  postRequest,
 } from '../../../resources'
 import { useRecoilState, useSharedAtoms } from '../../../shared-recoil'
 import {
@@ -205,6 +204,7 @@ export default function OverviewPage() {
     usePolicies,
   } = useSharedAtoms()
 
+  handlePageVisitMetric('overview-classic')
   const policies = usePolicies()
   const [apps] = useRecoilState(applicationsState)
   const [applicationSets] = useRecoilState(applicationSetsState)
@@ -233,13 +233,6 @@ export default function OverviewPage() {
     providers: [],
   })
   GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
-
-  useEffect(() => {
-    console.log('Pre overview-classic metrics POST')
-    postRequest(getBackendUrl() + '/metrics', {
-      page: 'overview-classic',
-    })
-  }, [])
 
   const clusters = useAllClusters(true)
   const argoApplicationsHashSet = GetArgoApplicationsHashSet(discoveredApplications, argoApps, clusters)

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -20,6 +20,8 @@ import {
   ApplicationSetKind,
   Cluster,
   ClusterStatus,
+  fetchPost,
+  getBackendUrl,
   ManagedClusterInfo,
   Policy,
   PolicyReport,
@@ -231,6 +233,17 @@ export default function OverviewPage() {
     providers: [],
   })
   GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
+
+  useEffect(() => {
+    const abortController = new AbortController()
+    fetchPost(
+      getBackendUrl() + '/metrics',
+      {
+        page: 'overview-classic',
+      },
+      abortController.signal
+    )
+  }, [])
 
   const clusters = useAllClusters(true)
   const argoApplicationsHashSet = GetArgoApplicationsHashSet(discoveredApplications, argoApps, clusters)

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -10,7 +10,7 @@ import {
   GetDiscoveredOCPApps,
   GetOpenShiftAppResourceMaps,
 } from '../../../components/GetDiscoveredOCPApps'
-import { handlePageVisitMetric } from '../../../hooks/console-metrics'
+import { usePageVisitMetricHandler } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { NavigationPath } from '../../../NavigationPath'
 import {
@@ -204,7 +204,7 @@ export default function OverviewPage() {
     usePolicies,
   } = useSharedAtoms()
 
-  handlePageVisitMetric('overview-classic')
+  usePageVisitMetricHandler('overview-classic')
   const policies = usePolicies()
   const [apps] = useRecoilState(applicationsState)
   const [applicationSets] = useRecoilState(applicationSetsState)

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -20,12 +20,12 @@ import {
   ApplicationSetKind,
   Cluster,
   ClusterStatus,
-  fetchPost,
   getBackendUrl,
   ManagedClusterInfo,
   Policy,
   PolicyReport,
   PolicyReportResults,
+  postRequest,
 } from '../../../resources'
 import { useRecoilState, useSharedAtoms } from '../../../shared-recoil'
 import {
@@ -235,14 +235,9 @@ export default function OverviewPage() {
   GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
 
   useEffect(() => {
-    const abortController = new AbortController()
-    fetchPost(
-      getBackendUrl() + '/metrics',
-      {
-        page: 'overview-classic',
-      },
-      abortController.signal
-    )
+    postRequest(getBackendUrl() + '/metrics', {
+      page: 'overview-classic',
+    })
   }, [])
 
   const clusters = useAllClusters(true)

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -188,6 +188,7 @@ const searchQueries = (selectedClusters: Array<string>): Array<any> => {
 }
 
 export default function OverviewPage() {
+  usePageVisitMetricHandler('overview-classic')
   const applicationsMatch = useRouteMatch()
   const { t } = useTranslation()
   const {
@@ -204,7 +205,6 @@ export default function OverviewPage() {
     usePolicies,
   } = useSharedAtoms()
 
-  usePageVisitMetricHandler('overview-classic')
   const policies = usePolicies()
   const [apps] = useRecoilState(applicationsState)
   const [applicationSets] = useRecoilState(applicationSetsState)

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.test.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.test.tsx
@@ -20,7 +20,7 @@ import {
   policyreportState,
   subscriptionsState,
 } from '../../../atoms'
-import { nockIgnoreApiPaths, nockRequest, nockSearch } from '../../../lib/nock-util'
+import { nockIgnoreApiPaths, nockPostRequest, nockRequest, nockSearch } from '../../../lib/nock-util'
 import { waitForNocks } from '../../../lib/test-util'
 import {
   mockApplications,
@@ -49,6 +49,9 @@ it('should render overview page with expected data', async () => {
   nockIgnoreApiPaths()
   nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
   nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
+  const metricNock = nockPostRequest('/metrics', {
+    page: 'overview-fleet',
+  })
   const mockAlertMetricsNock = nockRequest('/observability/query?query=ALERTS', mockAlertMetrics)
   const mockOperatorMetricsNock = nockRequest(
     '/observability/query?query=cluster_operator_conditions',
@@ -82,7 +85,7 @@ it('should render overview page with expected data', async () => {
   )
 
   // Wait for prometheus nocks to finish
-  await waitForNocks([mockAlertMetricsNock, mockOperatorMetricsNock])
+  await waitForNocks([metricNock, mockAlertMetricsNock, mockOperatorMetricsNock])
 
   // Test that the component has rendered correctly
   await waitFor(() => expect(getAllByText(/powered by insights/i)).toHaveLength(2))

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.test.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.test.tsx
@@ -49,9 +49,7 @@ it('should render overview page with expected data', async () => {
   nockIgnoreApiPaths()
   nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
   nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-  const metricNock = nockPostRequest('/metrics', {
-    page: 'overview-fleet',
-  })
+  const metricNock = nockPostRequest('/metrics?overview-fleet', {})
   const mockAlertMetricsNock = nockRequest('/observability/query?query=ALERTS', mockAlertMetrics)
   const mockOperatorMetricsNock = nockRequest(
     '/observability/query?query=cluster_operator_conditions',

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -91,6 +91,7 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
     usePolicies,
     managedClusterInfosState,
   } = useSharedAtoms()
+
   const policies = usePolicies()
   const allAddons = useClusterAddons()
   const [apps] = useRecoilState(applicationsState)
@@ -108,13 +109,6 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   const [isInsightsSectionOpen, setIsInsightsSectionOpen] = useState<boolean>(true)
   const [isObservabilityInstalled, setIsObservabilityInstalled] = useState<boolean>(false)
   GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
-
-  // useEffect(() => {
-  //   console.log('Pre overview-fleet metrics POST')
-  //   postRequest(getBackendUrl() + '/metrics', {
-  //     page: 'overview-fleet',
-  //   })
-  // }, [])
 
   const grafanaRoute = useMemo(() => {
     const obsAddOn = clusterManagementAddons.filter(

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -14,7 +14,7 @@ import {
   TextVariants,
 } from '@patternfly/react-core'
 import { AngleDownIcon, AngleUpIcon, ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link, useRouteMatch } from 'react-router-dom'
 import {
   GetArgoApplicationsHashSet,
@@ -25,7 +25,7 @@ import { useTranslation } from '../../../lib/acm-i18next'
 import { DOC_LINKS } from '../../../lib/doc-util'
 import { ObservabilityEndpoint, useObservabilityPoll } from '../../../lib/useObservabilityPoll'
 import { NavigationPath } from '../../../NavigationPath'
-import { Application, ApplicationSet, Cluster } from '../../../resources'
+import { Application, ApplicationSet, Cluster, fetchPost, getBackendUrl } from '../../../resources'
 import { useRecoilState, useSharedAtoms } from '../../../shared-recoil'
 import { AcmButton, AcmDonutChart, AcmScrollable, colorThemes } from '../../../ui-components'
 import { useClusterAddons } from '../../Infrastructure/Clusters/ClusterSets/components/useClusterAddons'
@@ -107,6 +107,17 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   const [isInsightsSectionOpen, setIsInsightsSectionOpen] = useState<boolean>(true)
   const [isObservabilityInstalled, setIsObservabilityInstalled] = useState<boolean>(false)
   GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
+
+  useEffect(() => {
+    const abortController = new AbortController()
+    fetchPost(
+      getBackendUrl() + '/metrics',
+      {
+        page: 'overview-fleet',
+      },
+      abortController.signal
+    )
+  }, [])
 
   const grafanaRoute = useMemo(() => {
     const obsAddOn = clusterManagementAddons.filter(

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -21,7 +21,7 @@ import {
   GetDiscoveredOCPApps,
   GetOpenShiftAppResourceMaps,
 } from '../../../components/GetDiscoveredOCPApps'
-import { usePageVisitMetricHandler } from '../../../hooks/console-metrics'
+import { Pages, usePageVisitMetricHandler } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { DOC_LINKS } from '../../../lib/doc-util'
 import { ObservabilityEndpoint, useObservabilityPoll } from '../../../lib/useObservabilityPoll'
@@ -74,7 +74,7 @@ function renderSummaryLoading() {
 
 export default function OverviewPageBeta(props: { selectedClusterLabels: Record<string, string[]> }) {
   const { selectedClusterLabels } = props
-  usePageVisitMetricHandler('overview-fleet')
+  usePageVisitMetricHandler(Pages.overviewFleet)
   const applicationsMatch = useRouteMatch()
   const { t } = useTranslation()
   const {

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -109,6 +109,7 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
 
   useEffect(() => {
+    console.log('Pre overview-fleet metrics POST')
     postRequest(getBackendUrl() + '/metrics', {
       page: 'overview-fleet',
     })

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -25,7 +25,7 @@ import { useTranslation } from '../../../lib/acm-i18next'
 import { DOC_LINKS } from '../../../lib/doc-util'
 import { ObservabilityEndpoint, useObservabilityPoll } from '../../../lib/useObservabilityPoll'
 import { NavigationPath } from '../../../NavigationPath'
-import { Application, ApplicationSet, Cluster, fetchPost, getBackendUrl } from '../../../resources'
+import { Application, ApplicationSet, Cluster, getBackendUrl, postRequest } from '../../../resources'
 import { useRecoilState, useSharedAtoms } from '../../../shared-recoil'
 import { AcmButton, AcmDonutChart, AcmScrollable, colorThemes } from '../../../ui-components'
 import { useClusterAddons } from '../../Infrastructure/Clusters/ClusterSets/components/useClusterAddons'
@@ -109,14 +109,9 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
 
   useEffect(() => {
-    const abortController = new AbortController()
-    fetchPost(
-      getBackendUrl() + '/metrics',
-      {
-        page: 'overview-fleet',
-      },
-      abortController.signal
-    )
+    postRequest(getBackendUrl() + '/metrics', {
+      page: 'overview-fleet',
+    })
   }, [])
 
   const grafanaRoute = useMemo(() => {

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -14,18 +14,19 @@ import {
   TextVariants,
 } from '@patternfly/react-core'
 import { AngleDownIcon, AngleUpIcon, ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Link, useRouteMatch } from 'react-router-dom'
 import {
   GetArgoApplicationsHashSet,
   GetDiscoveredOCPApps,
   GetOpenShiftAppResourceMaps,
 } from '../../../components/GetDiscoveredOCPApps'
+import { handlePageVisitMetric } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { DOC_LINKS } from '../../../lib/doc-util'
 import { ObservabilityEndpoint, useObservabilityPoll } from '../../../lib/useObservabilityPoll'
 import { NavigationPath } from '../../../NavigationPath'
-import { Application, ApplicationSet, Cluster, getBackendUrl, postRequest } from '../../../resources'
+import { Application, ApplicationSet, Cluster } from '../../../resources'
 import { useRecoilState, useSharedAtoms } from '../../../shared-recoil'
 import { AcmButton, AcmDonutChart, AcmScrollable, colorThemes } from '../../../ui-components'
 import { useClusterAddons } from '../../Infrastructure/Clusters/ClusterSets/components/useClusterAddons'
@@ -89,7 +90,7 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
     usePolicies,
     managedClusterInfosState,
   } = useSharedAtoms()
-
+  handlePageVisitMetric('overview-fleet')
   const policies = usePolicies()
   const allAddons = useClusterAddons()
   const [apps] = useRecoilState(applicationsState)
@@ -108,12 +109,12 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   const [isObservabilityInstalled, setIsObservabilityInstalled] = useState<boolean>(false)
   GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
 
-  useEffect(() => {
-    console.log('Pre overview-fleet metrics POST')
-    postRequest(getBackendUrl() + '/metrics', {
-      page: 'overview-fleet',
-    })
-  }, [])
+  // useEffect(() => {
+  //   console.log('Pre overview-fleet metrics POST')
+  //   postRequest(getBackendUrl() + '/metrics', {
+  //     page: 'overview-fleet',
+  //   })
+  // }, [])
 
   const grafanaRoute = useMemo(() => {
     const obsAddOn = clusterManagementAddons.filter(

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -21,7 +21,7 @@ import {
   GetDiscoveredOCPApps,
   GetOpenShiftAppResourceMaps,
 } from '../../../components/GetDiscoveredOCPApps'
-import { handlePageVisitMetric } from '../../../hooks/console-metrics'
+import { usePageVisitMetricHandler } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { DOC_LINKS } from '../../../lib/doc-util'
 import { ObservabilityEndpoint, useObservabilityPoll } from '../../../lib/useObservabilityPoll'
@@ -90,7 +90,7 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
     usePolicies,
     managedClusterInfosState,
   } = useSharedAtoms()
-  handlePageVisitMetric('overview-fleet')
+  usePageVisitMetricHandler('overview-fleet')
   const policies = usePolicies()
   const allAddons = useClusterAddons()
   const [apps] = useRecoilState(applicationsState)

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -74,6 +74,7 @@ function renderSummaryLoading() {
 
 export default function OverviewPageBeta(props: { selectedClusterLabels: Record<string, string[]> }) {
   const { selectedClusterLabels } = props
+  usePageVisitMetricHandler('overview-fleet')
   const applicationsMatch = useRouteMatch()
   const { t } = useTranslation()
   const {
@@ -90,7 +91,6 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
     usePolicies,
     managedClusterInfosState,
   } = useSharedAtoms()
-  usePageVisitMetricHandler('overview-fleet')
   const policies = usePolicies()
   const allAddons = useClusterAddons()
   const [apps] = useRecoilState(applicationsState)

--- a/frontend/src/routes/Home/Search/Details/DetailsPage.tsx
+++ b/frontend/src/routes/Home/Search/Details/DetailsPage.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { Link, Route, Switch, useLocation } from 'react-router-dom'
+import { Pages, usePageVisitMetricHandler } from '../../../../hooks/console-metrics'
 import { useTranslation } from '../../../../lib/acm-i18next'
 import { NavigationPath } from '../../../../NavigationPath'
 import { IResource } from '../../../../resources'
@@ -46,6 +47,7 @@ export function getResourceParams() {
 }
 
 export default function DetailsPage() {
+  usePageVisitMetricHandler(Pages.searchDetails)
   const { t } = useTranslation()
   const [resource, setResource] = useState<any>(undefined)
   const [containers, setContainers] = useState<string[]>()

--- a/frontend/src/routes/Home/Search/SearchPage.test.tsx
+++ b/frontend/src/routes/Home/Search/SearchPage.test.tsx
@@ -9,7 +9,7 @@ import { GraphQLError } from 'graphql'
 import { createBrowserHistory } from 'history'
 import { Router } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
-import { nockRequest } from '../../../lib/nock-util'
+import { nockPostRequest, nockRequest } from '../../../lib/nock-util'
 import { wait, waitForNocks } from '../../../lib/test-util'
 import { UserPreference } from '../../../resources/userpreference'
 import {
@@ -40,6 +40,7 @@ const mockUserPreference: UserPreference = {
 
 describe('SearchPage', () => {
   it('should render default search page correctly', async () => {
+    const metricNock = nockPostRequest('/metrics?search', {})
     const getUserPreferenceNock = nockRequest('/userpreference', mockUserPreference)
     const mocks = [
       {
@@ -76,7 +77,7 @@ describe('SearchPage', () => {
     )
 
     // Wait for username resource requests to finish
-    await waitForNocks([getUserPreferenceNock])
+    await waitForNocks([metricNock, getUserPreferenceNock])
 
     // This wait pauses till apollo query is returning data
     await wait()
@@ -89,6 +90,7 @@ describe('SearchPage', () => {
   })
 
   it('should render page with errors', async () => {
+    const metricNock = nockPostRequest('/metrics?search', {})
     const getUserPreferenceNock = nockRequest('/userpreference', mockUserPreference)
     const mocks = [
       {
@@ -129,7 +131,7 @@ describe('SearchPage', () => {
     )
 
     // Wait for username resource requests to finish
-    await waitForNocks([getUserPreferenceNock])
+    await waitForNocks([metricNock, getUserPreferenceNock])
 
     // Test the loading state while apollo query finishes - testing that saved searches card label is not present
     expect(screen.getAllByText('Saved searches')[1]).toBeFalsy()
@@ -145,6 +147,7 @@ describe('SearchPage', () => {
   })
 
   it('should render search page correctly and add a search', async () => {
+    const metricNock = nockPostRequest('/metrics?search', {})
     const getUserPreferenceNock = nockRequest('/userpreference', mockUserPreference)
     const mocks = [
       {
@@ -206,7 +209,7 @@ describe('SearchPage', () => {
     )
 
     // Wait for username resource requests to finish
-    await waitForNocks([getUserPreferenceNock])
+    await waitForNocks([metricNock, getUserPreferenceNock])
 
     // This wait pauses till apollo query is returning data
     await wait()
@@ -238,6 +241,7 @@ describe('SearchPage', () => {
       search: '?filters={"textsearch":"kind%3APod%20name%3AtestPod"}',
     } as Location
 
+    const metricNock = nockPostRequest('/metrics?search', {})
     const getUserPreferenceNock = nockRequest('/userpreference', mockUserPreference)
     const mocks = [
       {
@@ -323,7 +327,7 @@ describe('SearchPage', () => {
     )
 
     // Wait for username resource requests to finish
-    await waitForNocks([getUserPreferenceNock])
+    await waitForNocks([metricNock, getUserPreferenceNock])
 
     // Test the loading state while apollo query finishes - testing that saved searches card label is not present
     expect(screen.getAllByText('Saved searches')[1]).toBeFalsy()

--- a/frontend/src/routes/Home/Search/SearchPage.tsx
+++ b/frontend/src/routes/Home/Search/SearchPage.tsx
@@ -17,6 +17,7 @@ import { ExclamationCircleIcon, ExternalLinkAltIcon, InfoCircleIcon } from '@pat
 import _ from 'lodash'
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import { useHistory } from 'react-router-dom'
+import { Pages, usePageVisitMetricHandler } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { NavigationPath } from '../../../NavigationPath'
 import { getUserPreference, SavedSearch, UserPreference } from '../../../resources/userpreference'
@@ -328,6 +329,7 @@ export default function SearchPage() {
     presetSearchQuery = '',
     preSelectedRelatedResources = [], // used to show any related resource on search page navigation
   } = transformBrowserUrlToSearchString(window.location.search || '')
+  usePageVisitMetricHandler(Pages.search)
   const { t } = useTranslation()
   const savedSearches = t('Saved searches')
   const { useSearchResultLimit } = useSharedAtoms()


### PR DESCRIPTION
PR will expose a metric: `acm_console_page_count`.
Metric will be used to track page visits across the RHACM UI. 
This PR will introduce the metric for pages: Overview, Overview beta, Search & Search details. 
To use the metric in other pages - the page will need to include the `usePageVisitMetricHandler` hook with a string param of the page name (which should be defined in the Page enum).