### PR TITLE
Add controllable default columns on column management

### DIFF
--- a/frontend/src/routes/Governance/policies/Policies.test.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.test.tsx
@@ -63,7 +63,7 @@ describe('Policies Page', () => {
     await waitForText('Test policy description')
   })
 
-  test('Should render Policies page correctly', async () => {
+  test('Should render Policies page correctly with Default selected Columns', async () => {
     render(
       <RecoilRoot
         initializeState={(snapshot) => {
@@ -77,6 +77,14 @@ describe('Policies Page', () => {
     )
 
     await waitForText(mockPendingPolicy[0].metadata.name!)
+    await waitForText('Name')
+    await waitForText('Namespace')
+    await waitForText('Status')
+    await waitForText('Remediation')
+    await waitForText('Cluster violations')
+    await waitForText('Created')
+    // This is dot dot dot action button
+    await screen.getAllByRole('button', { name: 'Actions' })
   })
 
   test('Should have correct links to PolicySet & Policy detail results pages', async () => {

--- a/frontend/src/routes/Governance/policies/Policies.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.tsx
@@ -176,6 +176,7 @@ export default function PoliciesPage() {
         id: 'status',
         order: 3,
         isDefault: false,
+        isFirstVisitChecked: true,
       },
       {
         header: t('Remediation'),
@@ -190,6 +191,7 @@ export default function PoliciesPage() {
         id: 'remediation',
         order: 4,
         isDefault: false,
+        isFirstVisitChecked: true,
       },
       {
         header: t('Policy set'),
@@ -330,6 +332,7 @@ export default function PoliciesPage() {
         id: 'created',
         order: 9,
         isDefault: false,
+        isFirstVisitChecked: true,
       },
       {
         header: '',

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -108,6 +108,9 @@ export interface IAcmTableColumn<T> {
   isDefault?: boolean
   // If it is true, This column always the last one and isn't managed by column management filter
   isActionCol?: boolean
+  // isFirstVisitChecked=true, When users visit at the first time, users can see these columns.
+  // unlike isDefualt columns, these columns can be controllable.
+  isFirstVisitChecked?: boolean
 }
 
 /* istanbul ignore next */
@@ -410,6 +413,10 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     () => columns.filter((col) => col.isDefault && col.id && !col.isActionCol).map((col) => col.id as string),
     [columns]
   )
+  const firstVisitColIds = useMemo(
+    () => columns.filter((col) => col.isFirstVisitChecked && col.id && !col.isActionCol).map((col) => col.id as string),
+    [columns]
+  )
   const defaultOrderIds = useMemo(
     () =>
       columns
@@ -423,7 +430,9 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
   const localSavedCols = JSON.parse(localStorage.getItem(id + 'SavedCols')!)
   const localSavedColOrder = JSON.parse(localStorage.getItem(id + 'SavedColOrder')!)
   const [colOrderIds, setColOrderIds] = useState<string[]>(localSavedColOrder || defaultOrderIds)
-  const [selectedColIds, setSelectedColIds] = useState<string[]>(localSavedCols || defaultColIds)
+  const [selectedColIds, setSelectedColIds] = useState<string[]>(
+    localSavedCols || [...defaultColIds, ...firstVisitColIds]
+  )
   const selectedSortedCols = useMemo(() => {
     const sortedColumns: IAcmTableColumn<T>[] = []
 


### PR DESCRIPTION
Add `status`, `remediation`, `created` columns as default columns for fist visit users but should be controllable, unlike default columns. 
Ref: https://issues.redhat.com/browse/ACM-7152