### PR TITLE
Add additional default columns to poliy table

### DIFF
--- a/frontend/src/routes/Governance/policies/Policies.test.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.test.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { render, waitFor, screen, fireEvent, within } from '@testing-library/react'
+import { render, waitFor, screen, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
 import {
@@ -85,10 +85,10 @@ describe('Policies Page', () => {
     await waitForText(mockPendingPolicy[0].metadata.name!)
     await waitForText('Name')
     await waitForText('Namespace')
-    await waitForText('Status')
     await waitForText('Remediation')
     await waitForText('Cluster violations')
-    await waitForText('Created')
+    await waitForText('Source')
+    await waitForText('Policy set')
     // This is dot dot dot action button
     await screen.getAllByRole('button', { name: 'Actions' })
   })
@@ -106,13 +106,6 @@ describe('Policies Page', () => {
         </MemoryRouter>
       </RecoilRoot>
     )
-
-    // Add policyset column
-    screen.getByRole('button', { name: /columns-management/i }).click()
-    await waitForText('Manage columns')
-    const checkbox = screen.getByTestId('checkbox-policyset')
-    fireEvent.click(checkbox)
-    screen.getByRole('button', { name: /save/i }).click()
 
     // Wait for page load
     await waitForText(mockPolicy[0].metadata.name!)

--- a/frontend/src/routes/Governance/policies/Policies.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.tsx
@@ -181,7 +181,7 @@ export default function PoliciesPage() {
         id: 'status',
         order: 3,
         isDefault: false,
-        isFirstVisitChecked: true,
+        isFirstVisitChecked: false,
       },
       {
         header: t('Remediation'),
@@ -225,6 +225,7 @@ export default function PoliciesPage() {
         id: 'policyset',
         order: 5,
         isDefault: false,
+        isFirstVisitChecked: true,
       },
       { ...policyClusterViolationsColumn, id: 'cv', isDefault: true, order: 6 },
       {
@@ -248,6 +249,7 @@ export default function PoliciesPage() {
         id: 'source',
         order: 7,
         isDefault: false,
+        isFirstVisitChecked: true,
       },
       {
         header: t('Automation'),
@@ -335,7 +337,7 @@ export default function PoliciesPage() {
         id: 'created',
         order: 9,
         isDefault: false,
-        isFirstVisitChecked: true,
+        isFirstVisitChecked: false,
       },
       {
         header: '',


### PR DESCRIPTION
1. Required columns (the ones that can't be deselected).  **Name, Namespace and Cluster compliance**
2. Default columns (the columns that are selected by default and that you reset to when selecting reset to defaults).  This must always include the required columns, but can include 1 or more additional columns.   **Remediation action, Policy Set and Source** along with #1 columns.
The rest (not selected) columns

Ref: https://issues.redhat.com/browse/ACM-7156