### PR TITLE
Restore the table columns to the default view

### DIFF
--- a/frontend/src/routes/Governance/policies/Policies.test.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.test.tsx
@@ -89,8 +89,26 @@ describe('Policies Page', () => {
     await waitForText('Cluster violations')
     await waitForText('Source')
     await waitForText('Policy set')
+    expect(screen.queryByRole('columnheader', { name: /Status/ })).not.toBeInTheDocument()
     // This is dot dot dot action button
     await screen.getAllByRole('button', { name: 'Actions' })
+
+    // Add a non-default column
+    screen.getByRole('button', { name: /columns-management/i }).click()
+    await waitForText('Manage columns')
+    screen.getByTestId('checkbox-status').click()
+    screen.getByRole('button', { name: /save/i }).click()
+    screen.getByRole('columnheader', { name: /Status/ })
+
+    screen.getByRole('button', { name: /columns-management/i }).click()
+    await waitForText('Manage columns')
+    screen.getByRole('button', { name: /restore defaults/i }).click()
+    // Verify that the Status column was unchecked.
+    expect(screen.getByTestId('checkbox-status')).not.toBeChecked()
+    screen.getByRole('button', { name: /save/i }).click()
+
+    // Verify that the Status column is no longer present
+    expect(screen.queryByRole('columnheader', { name: /Status/ })).not.toBeInTheDocument()
   })
 
   test('Should have correct links to PolicySet & Policy detail results pages', async () => {

--- a/frontend/src/ui-components/AcmTable/AcmManageColumn.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmManageColumn.tsx
@@ -26,7 +26,8 @@ interface AcmManageColumnProps<T> {
   allCols: IAcmTableColumn<T>[]
   selectedColIds: string[]
   setSelectedColIds: (selectedIds: string[]) => void
-  defaultColIds: string[]
+  requiredColIds: string[]
+  defaultColIds?: string[]
   setColOrderIds: (colOrderIds: string[]) => void
   colOrderIds: string[]
 }
@@ -37,6 +38,7 @@ export function AcmManageColumn<T>({
   colOrderIds,
   setColOrderIds,
   setSelectedColIds,
+  requiredColIds,
   defaultColIds,
 }: AcmManageColumnProps<T>) {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
@@ -49,7 +51,16 @@ export function AcmManageColumn<T>({
   return (
     <>
       <ManageColumnModal<T>
-        {...{ isModalOpen, selectedColIds, allCols, setSelectedColIds, defaultColIds, setColOrderIds, colOrderIds }}
+        {...{
+          isModalOpen,
+          selectedColIds,
+          allCols,
+          setSelectedColIds,
+          requiredColIds,
+          defaultColIds,
+          setColOrderIds,
+          colOrderIds,
+        }}
         toggleModal={toggleModal}
       />
       <Tooltip content={t('Manage columns')} enableFlip trigger="mouseenter" position="top" exitDelay={50}>
@@ -82,7 +93,8 @@ interface ManageColumnModalProps<T> {
   selectedColIds: string[]
   setSelectedColIds: (selectedIds: string[]) => void
   allCols: IAcmTableColumn<T>[]
-  defaultColIds: string[]
+  requiredColIds: string[]
+  defaultColIds?: string[]
   colOrderIds: string[]
   setColOrderIds: (colOrderIds: string[]) => void
 }
@@ -97,6 +109,7 @@ function ManageColumnModal<T>(props: ManageColumnModalProps<T>) {
     setSelectedColIds,
     colOrderIds,
     setColOrderIds,
+    requiredColIds,
     defaultColIds,
   } = props
   const [items, setItems] = useState<IAcmTableColumn<T>[]>(sortByList(colOrderIds, allCols))
@@ -128,7 +141,7 @@ function ManageColumnModal<T>(props: ManageColumnModalProps<T>) {
   }
 
   const restoreDefault = () => {
-    setlocalSelectedIds(defaultColIds)
+    setlocalSelectedIds(defaultColIds || requiredColIds)
     const sortedItems = [...items].sort((a, b) => {
       return a.order != null && b.order != null ? a.order - b.order : -1
     })
@@ -184,9 +197,9 @@ function ManageColumnModal<T>(props: ManageColumnModalProps<T>) {
                       <DataListCheck
                         aria-labelledby={`table-column-management-${policy.id}`}
                         checked={
-                          defaultColIds.includes(policy.id as string) || localSelectedIds.includes(policy.id as string)
+                          requiredColIds.includes(policy.id as string) || localSelectedIds.includes(policy.id as string)
                         }
-                        isDisabled={defaultColIds.includes(policy.id!)}
+                        isDisabled={requiredColIds.includes(policy.id!)}
                         name={policy.id}
                         id={`checkbox-${policy.id}`}
                         onChange={handleChange}

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -409,12 +409,15 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
   const tableDivRef = useCallback((elem: HTMLDivElement | null) => setTableDiv(elem), [])
 
   //Column management
-  const defaultColIds = useMemo(
+  const requiredColIds = useMemo(
     () => columns.filter((col) => col.isDefault && col.id && !col.isActionCol).map((col) => col.id as string),
     [columns]
   )
-  const firstVisitColIds = useMemo(
-    () => columns.filter((col) => col.isFirstVisitChecked && col.id && !col.isActionCol).map((col) => col.id as string),
+  const defaultColIds = useMemo(
+    () =>
+      columns
+        .filter((col) => (col.isFirstVisitChecked || col.isDefault) && col.id && !col.isActionCol)
+        .map((col) => col.id as string),
     [columns]
   )
   const defaultOrderIds = useMemo(
@@ -431,7 +434,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
   const localSavedColOrder = JSON.parse(localStorage.getItem(id + 'SavedColOrder')!)
   const [colOrderIds, setColOrderIds] = useState<string[]>(localSavedColOrder || defaultOrderIds)
   const [selectedColIds, setSelectedColIds] = useState<string[]>(
-    localSavedCols || [...defaultColIds, ...firstVisitColIds]
+    localSavedCols || [...requiredColIds, ...defaultColIds]
   )
   const selectedSortedCols = useMemo(() => {
     const sortedColumns: IAcmTableColumn<T>[] = []
@@ -1016,7 +1019,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
             )}
             {showColumManagement && (
               <AcmManageColumn<T>
-                {...{ selectedColIds, setSelectedColIds, defaultColIds, setColOrderIds, colOrderIds }}
+                {...{ selectedColIds, setSelectedColIds, requiredColIds, defaultColIds, setColOrderIds, colOrderIds }}
                 allCols={columns.filter((col) => !col.isActionCol)}
               />
             )}


### PR DESCRIPTION
There was a bug where the "Restore defaults" button would only restore the required columns and not the default columns. As part of this change, the existing defaultColIds was renamed to requiredColIds. There is a new optional prop of defaultColIds that allows you to specify the columns that should be shown on the first visit and when the "Restore defaults" button is clicked.

In the "Policies" table, the default columns are a union of required columns and "isFirstVisitChecked" columns.

Relates:
https://issues.redhat.com/browse/ACM-7584