### PR TITLE
Update the pod must exist policy template

### DIFF
--- a/frontend/src/wizards/Governance/Policy/specifications.ts
+++ b/frontend/src/wizards/Governance/Policy/specifications.ts
@@ -27,7 +27,7 @@ function getPolicySpecification(description: string, yaml: string) {
   yaml = yaml.replace('sample-role', '')
   yaml = yaml.replace('-example', '')
   yaml = yaml.replace('name: prod', 'name: ""')
-  yaml = yaml.replace('sample-nginx-pod', '')
+  yaml = yaml.replace('sample-httpd-pod', '')
   const policy = getExamplePolicy(yaml)
   return {
     name: description,

--- a/frontend/src/wizards/Governance/Policy/stable/CM-Configuration-Management/policy-pod.yaml
+++ b/frontend/src/wizards/Governance/Policy/stable/CM-Configuration-Management/policy-pod.yaml
@@ -25,15 +25,20 @@ spec:
             - complianceType: musthave
               objectDefinition:
                 apiVersion: v1
-                kind: Pod # nginx pod must exist
+                kind: Pod # httpd pod must exist
                 metadata:
-                  name: sample-nginx-pod
+                  name: sample-httpd-pod
                 spec:
                   containers:
-                    - image: nginx:1.18.0
-                      name: nginx
-                      ports:
-                        - containerPort: 80
+                    - image: registry.redhat.io/rhel9/httpd-24:latest
+                      name: httpd
+                      securityContext:
+                        allowPrivilegeEscalation: false
+                        capabilities:
+                          drop:
+                            - ALL
+                        privileged: false
+                        runAsNonRoot: true
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
This updates it to use an official Red Hat image as well as set the proper security constraints for restricted configurations.

Relates:
https://issues.redhat.com/browse/ACM-7630