### PR TITLE
Remove unnecessary tooltips in grc table

### DIFF
--- a/frontend/src/routes/Governance/components/PolicyActionDropdown.tsx
+++ b/frontend/src/routes/Governance/components/PolicyActionDropdown.tsx
@@ -66,7 +66,6 @@ export function PolicyActionDropdown(props: {
       {
         id: 'add-to-set',
         text: t('Add to policy set'),
-        tooltip: t('Add to policy set'),
         click: (policy: PolicyTableItem): void => {
           setModal(<AddToPolicySetModal policyTableItems={[policy]} onClose={() => setModal(undefined)} />)
         },


### PR DESCRIPTION
The kebab menu displays exactly the same text on the tooltips, which is unnecessary.