### PR TITLE
ACM-7797 Increase app page search query limit

### DIFF
--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -66,10 +66,11 @@ export function queryRemoteArgoApps(): IRequestResult<ISearchResult> {
             input: [
                 {
                     filters: [
-                        { property: 'kind', values: ['application'] },
+                        { property: 'kind', values: ['Application'] },
                         { property: 'apigroup', values: ['argoproj.io'] },
                         { property: 'cluster', values: ['!local-cluster'] },
                     ],
+                    limit: 20000,
                 },
             ],
         },
@@ -86,10 +87,10 @@ export function queryOCPAppResources(): IRequestResult<ISearchResult> {
                     filters: [
                         {
                             property: 'kind',
-                            values: ['cronjob', 'daemonset', 'deployment', 'deploymentconfig', 'job', 'statefulset'],
+                            values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
                         },
                     ],
-                    limit: 6500,
+                    limit: 20000,
                 },
             ],
         },

--- a/frontend/src/routes/Applications/Application.sharedmocks.tsx
+++ b/frontend/src/routes/Applications/Application.sharedmocks.tsx
@@ -317,10 +317,11 @@ export const mockSearchQuery = {
         input: [
             {
                 filters: [
-                    { property: 'kind', values: ['application'] },
+                    { property: 'kind', values: ['Application'] },
                     { property: 'apigroup', values: ['argoproj.io'] },
                     { property: 'cluster', values: ['!local-cluster'] },
                 ],
+                limit: 20000,
             },
         ],
     },
@@ -362,10 +363,10 @@ export const mockSearchQueryOCPApplications = {
                 filters: [
                     {
                         property: 'kind',
-                        values: ['cronjob', 'daemonset', 'deployment', 'deploymentconfig', 'job', 'statefulset'],
+                        values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
                     },
                 ],
-                limit: 6500,
+                limit: 20000,
             },
         ],
     },


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-7797

This won't fix the performance issue but it will allow the customer to get all the applications. This might even make the performance issue worse since we're retrieving more data. For now, this will resolve the issue with not seeing all the apps but we need to work with search on a long term solution.

- Increase limit on search query
- Correct resource casing for search query