### PR TITLE
ACM-7903 Port app search limit fix to 2.8

### DIFF
--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -60,10 +60,11 @@ export function queryRemoteArgoApps(): IRequestResult<ISearchResult> {
       input: [
         {
           filters: [
-            { property: 'kind', values: ['application'] },
+            { property: 'kind', values: ['Application'] },
             { property: 'apigroup', values: ['argoproj.io'] },
             { property: 'cluster', values: ['!local-cluster'] },
           ],
+          limit: 20000,
         },
       ],
     },
@@ -80,10 +81,10 @@ export function queryOCPAppResources(): IRequestResult<ISearchResult> {
           filters: [
             {
               property: 'kind',
-              values: ['cronjob', 'daemonset', 'deployment', 'deploymentconfig', 'job', 'statefulset'],
+              values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
             },
           ],
-          limit: 6500, // search said not to use unlimited results so use this for now until pagination is available
+          limit: 20000, // search said not to use unlimited results so use this for now until pagination is available
         },
       ],
     },

--- a/frontend/src/routes/Applications/Application.sharedmocks.tsx
+++ b/frontend/src/routes/Applications/Application.sharedmocks.tsx
@@ -414,10 +414,11 @@ export const mockSearchQueryArgoApps = {
     input: [
       {
         filters: [
-          { property: 'kind', values: ['application'] },
+          { property: 'kind', values: ['Application'] },
           { property: 'apigroup', values: ['argoproj.io'] },
           { property: 'cluster', values: ['!local-cluster'] },
         ],
+        limit: 20000,
       },
     ],
   },
@@ -488,10 +489,10 @@ export const mockSearchQueryOCPApplications = {
         filters: [
           {
             property: 'kind',
-            values: ['cronjob', 'daemonset', 'deployment', 'deploymentconfig', 'job', 'statefulset'],
+            values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
           },
         ],
-        limit: 6500,
+        limit: 20000,
       },
     ],
   },


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-7903

This won't fix the performance issue but it will allow the customer to get all the applications. This might even make the performance issue worse since we're retrieving more data. For now, this will resolve the issue with not seeing all the apps but we need to work with search on a long term solution.

- Increase limit on search query
- Correct resource casing for search query