### PR TITLE
ACM-6976 Backport fix to disable AWS hosted cluster card when Hypershift featu…

### DIFF
--- a/frontend/src/hooks/use-hypershift-enabled.ts
+++ b/frontend/src/hooks/use-hypershift-enabled.ts
@@ -1,20 +1,20 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { useState, useEffect } from 'react'
-import { listMultiClusterEngines } from '../resources'
 import { useRecoilState, useSharedAtoms } from '../shared-recoil'
 
 export const useIsHypershiftEnabled = () => {
   const [isHypershiftEnabled, setIsHypershiftEnabled] = useState<boolean>(false)
-  const { managedClusterAddonsState } = useSharedAtoms()
+  const { managedClusterAddonsState, multiClusterEnginesState } = useSharedAtoms()
+  const [[multiClusterEngine]] = useRecoilState(multiClusterEnginesState)
   const [managedClusterAddOns] = useRecoilState(managedClusterAddonsState)
+
   const hypershiftAddon = managedClusterAddOns.find(
     (mca) => mca.metadata.namespace === 'local-cluster' && mca.metadata.name === 'hypershift-addon'
   )
   useEffect(() => {
     const getHypershiftStatus = async () => {
       try {
-        const [multiClusterEngine] = await listMultiClusterEngines().promise
         const components = multiClusterEngine.spec?.overrides.components
         const hypershiftPreview = components?.find((component) => component.name === 'hypershift-preview')
         setIsHypershiftEnabled(
@@ -27,6 +27,6 @@ export const useIsHypershiftEnabled = () => {
       }
     }
     getHypershiftStatus()
-  }, [hypershiftAddon?.status?.conditions])
+  }, [hypershiftAddon?.status?.conditions, multiClusterEngine.spec?.overrides.components])
   return isHypershiftEnabled
 }

--- a/frontend/src/lib/test-util.ts
+++ b/frontend/src/lib/test-util.ts
@@ -360,3 +360,7 @@ export async function clickHostAction(text: string) {
   await clickByText('ai:Add hosts')
   await clickByText(text)
 }
+
+export function isCardEnabled(card: HTMLElement) {
+  return card.style.cursor === 'pointer'
+}

--- a/frontend/src/routes/Credentials/CreateCredentialsType/CreateCredentialsAWS.test.tsx
+++ b/frontend/src/routes/Credentials/CreateCredentialsType/CreateCredentialsAWS.test.tsx
@@ -7,7 +7,10 @@ import { clickByTestId } from '../../../lib/test-util'
 import { NavigationPath } from '../../../NavigationPath'
 import { CreateCredentialsAWS } from './CreateCredentialsAWS'
 import { managedClusterAddonsState, multiClusterEnginesState } from '../../../atoms'
-import { mockManagedClusterAddOn, mockMultiClusterEngine } from '../../Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/sharedMocks'
+import {
+  mockManagedClusterAddOn,
+  mockMultiClusterEngine,
+} from '../../Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/sharedMocks'
 
 describe('CreateCredentialsAWS', () => {
   beforeEach(() => {

--- a/frontend/src/routes/Credentials/CreateCredentialsType/CreateCredentialsAWS.test.tsx
+++ b/frontend/src/routes/Credentials/CreateCredentialsType/CreateCredentialsAWS.test.tsx
@@ -2,36 +2,12 @@
 import { render } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
-import { nockIgnoreApiPaths, nockList } from '../../../lib/nock-util'
-import { clickByTestId, waitForNocks } from '../../../lib/test-util'
+import { nockIgnoreApiPaths } from '../../../lib/nock-util'
+import { clickByTestId } from '../../../lib/test-util'
 import { NavigationPath } from '../../../NavigationPath'
-import { MultiClusterEngine, MultiClusterEngineApiVersion, MultiClusterEngineKind } from '../../../resources'
 import { CreateCredentialsAWS } from './CreateCredentialsAWS'
-
-const multiclusterEngine: MultiClusterEngine = {
-  apiVersion: MultiClusterEngineApiVersion,
-  kind: MultiClusterEngineKind,
-  spec: {
-    availabilityConfig: 'High',
-    imagePullSecret: 'multiclusterhub-operator-pull-secret',
-    overrides: {
-      components: [
-        { enabled: true, name: 'hypershift-local-hosting' },
-        {
-          enabled: true,
-          name: 'hypershift-preview',
-        },
-      ],
-    },
-    targetNamespace: 'multicluster-engine',
-    tolerations: [],
-  },
-  metadata: {
-    name: 'multiclusterengine',
-    generation: 2,
-  },
-}
-const mockMulticlusterEngine = [multiclusterEngine]
+import { managedClusterAddonsState, multiClusterEnginesState } from '../../../atoms'
+import { mockManagedClusterAddOn, mockMultiClusterEngine } from '../../Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/sharedMocks'
 
 describe('CreateCredentialsAWS', () => {
   beforeEach(() => {
@@ -40,7 +16,12 @@ describe('CreateCredentialsAWS', () => {
 
   const Component = () => {
     return (
-      <RecoilRoot>
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClusterAddonsState, [mockManagedClusterAddOn])
+          snapshot.set(multiClusterEnginesState, [mockMultiClusterEngine])
+        }}
+      >
         <MemoryRouter initialEntries={[NavigationPath.addAWSType]}>
           <Route path={NavigationPath.addAWSType}>
             <CreateCredentialsAWS />
@@ -51,16 +32,12 @@ describe('CreateCredentialsAWS', () => {
   }
 
   test('can click aws', async () => {
-    const initialNocks = [nockList(multiclusterEngine, mockMulticlusterEngine)]
     render(<Component />)
-    await waitForNocks(initialNocks)
     await clickByTestId('aws-standard')
   })
 
   test('can click aws S3', async () => {
-    const initialNocks = [nockList(multiclusterEngine, mockMulticlusterEngine)]
     render(<Component />)
-    await waitForNocks(initialNocks)
     await clickByTestId('aws-bucket')
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAWSControlPlane.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAWSControlPlane.test.tsx
@@ -5,11 +5,62 @@ import { RecoilRoot } from 'recoil'
 import { clickByTestId } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { CreateAWSControlPlane } from './CreateAWSControlPlane'
+import { nockIgnoreApiPaths, nockList } from '../../../../../lib/nock-util'
+import { multiClusterEnginesState } from '../../../../../atoms'
+import { MultiClusterEngine, MultiClusterEngineApiVersion, MultiClusterEngineKind } from '../../../../../resources'
 
-describe('CreateAWSControlPlane', () => {
+const mockMultiClusterEngine: MultiClusterEngine = {
+  apiVersion: MultiClusterEngineApiVersion,
+  kind: MultiClusterEngineKind,
+  spec: {
+    availabilityConfig: 'High',
+    imagePullSecret: 'multiclusterhub-operator-pull-secret',
+    overrides: {
+      components: [
+        { enabled: true, name: 'hypershift-local-hosting' },
+        {
+          enabled: true,
+          name: 'hypershift',
+        },
+      ],
+    },
+    targetNamespace: 'multicluster-engine',
+    tolerations: [],
+  },
+  metadata: {
+    name: 'multiclusterengine',
+    generation: 2,
+  },
+  status: {
+    conditions: [
+      {
+        reason: 'ManagedClusterAddOnLeaseUpdated',
+        status: 'True',
+      },
+    ],
+  },
+}
+
+const listMulticlusterengines1 = {
+  req: {
+    apiVersion: 'multicluster.openshift.io/v1',
+    kind: 'multiclusterengines',
+  },
+  res: [],
+}
+
+describe('CreateAWSControlPlane hosted', () => {
+  beforeEach(() => {
+    nockIgnoreApiPaths()
+  })
+
   const Component = () => {
     return (
-      <RecoilRoot>
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(multiClusterEnginesState, [mockMultiClusterEngine])
+        }}
+      >
         <MemoryRouter initialEntries={[NavigationPath.createAWSControlPlane]}>
           <Route path={NavigationPath.createAWSControlPlane}>
             <CreateAWSControlPlane />
@@ -25,6 +76,8 @@ describe('CreateAWSControlPlane', () => {
   })
 
   test('can click standalone', async () => {
+    nockList(listMulticlusterengines1.req, listMulticlusterengines1.res)
+    nockList(listMulticlusterengines1.req, listMulticlusterengines1.res)
     render(<Component />)
     await clickByTestId('standalone')
   })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAWSControlPlane.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAWSControlPlane.tsx
@@ -18,12 +18,14 @@ import { NavigationPath, useBackCancelNavigation } from '../../../../../Navigati
 import { AcmButton, AcmPage, AcmPageHeader, Provider } from '../../../../../ui-components'
 import { getTypedCreateClusterPath } from '../ClusterInfrastructureType'
 import { HypershiftDiagram } from './HypershiftDiagram'
+import { useIsHypershiftEnabled } from '../../../../../hooks/use-hypershift-enabled'
 
 export function CreateAWSControlPlane() {
   const [t] = useTranslation()
   const { nextStep, back, cancel } = useBackCancelNavigation()
   const [isDiagramExpanded, setIsDiagramExpanded] = useState(true)
   const [isMouseOverControlPlaneLink, setIsMouseOverControlPlaneLink] = useState(false)
+  const isHypershiftEnabled = useIsHypershiftEnabled()
 
   const onDiagramToggle = (isExpanded: boolean) => {
     if (!isMouseOverControlPlaneLink) {
@@ -54,8 +56,21 @@ export function CreateAWSControlPlane() {
             ],
           },
         ],
-        onClick: nextStep(NavigationPath.createAWSCLI),
+        onClick: isHypershiftEnabled ? nextStep(NavigationPath.createAWSCLI) : undefined,
+        alertTitle: isHypershiftEnabled
+          ? undefined
+          : t('Hosted control plane operator must be enabled in order to continue'),
+        alertVariant: 'info',
+        alertContent: (
+          <a href={DOC_LINKS.HOSTED_ENABLE_FEATURE_AWS} target="_blank" rel="noopener noreferrer">
+            {t('View documentation')} <ExternalLinkAltIcon />
+          </a>
+        ),
         badgeList: [
+          {
+            badge: t('Technology preview'),
+            badgeColor: CatalogColor.orange,
+          },
           {
             badge: t('CLI-based'),
             badgeColor: CatalogColor.purple,
@@ -87,7 +102,7 @@ export function CreateAWSControlPlane() {
       },
     ]
     return newCards
-  }, [nextStep, t])
+  }, [nextStep, t, isHypershiftEnabled])
 
   const keyFn = useCallback((card: ICatalogCard) => card.id, [])
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateControlPlane.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateControlPlane.test.tsx
@@ -2,36 +2,15 @@
 import { render } from '@testing-library/react'
 import { MemoryRouter, Route } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
-import { nockIgnoreApiPaths, nockList } from '../../../../../lib/nock-util'
-import { clickByTestId, waitForNocks } from '../../../../../lib/test-util'
+import { nockIgnoreApiPaths } from '../../../../../lib/nock-util'
+import { clickByTestId } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
-import { MultiClusterEngine, MultiClusterEngineApiVersion, MultiClusterEngineKind } from '../../../../../resources'
 import { CreateControlPlane } from './CreateControlPlane'
-
-const multiclusterEngine: MultiClusterEngine = {
-  apiVersion: MultiClusterEngineApiVersion,
-  kind: MultiClusterEngineKind,
-  spec: {
-    availabilityConfig: 'High',
-    imagePullSecret: 'multiclusterhub-operator-pull-secret',
-    overrides: {
-      components: [
-        { enabled: true, name: 'hypershift-local-hosting' },
-        {
-          enabled: true,
-          name: 'hypershift-preview',
-        },
-      ],
-    },
-    targetNamespace: 'multicluster-engine',
-    tolerations: [],
-  },
-  metadata: {
-    name: 'multiclusterengine',
-    generation: 2,
-  },
-}
-const mockMulticlusterEngine = [multiclusterEngine]
+import { managedClusterAddonsState, multiClusterEnginesState } from '../../../../../atoms'
+import {
+  mockManagedClusterAddOn,
+  mockMultiClusterEngine,
+} from './sharedMocks'
 
 describe('CreateControlPlane', () => {
   beforeEach(() => {
@@ -39,7 +18,12 @@ describe('CreateControlPlane', () => {
   })
   const Component = () => {
     return (
-      <RecoilRoot>
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClusterAddonsState, [mockManagedClusterAddOn])
+          snapshot.set(multiClusterEnginesState, [mockMultiClusterEngine])
+        }}
+      >
         <MemoryRouter initialEntries={[NavigationPath.createBMControlPlane]}>
           <Route path={NavigationPath.createBMControlPlane}>
             <CreateControlPlane />
@@ -50,16 +34,12 @@ describe('CreateControlPlane', () => {
   }
 
   test('can click hosted', async () => {
-    const initialNocks = [nockList(multiclusterEngine, mockMulticlusterEngine)]
     render(<Component />)
-    await waitForNocks(initialNocks)
     await clickByTestId('hosted')
   })
 
   test('can click standalone', async () => {
-    const initialNocks = [nockList(multiclusterEngine, mockMulticlusterEngine)]
     render(<Component />)
-    await waitForNocks(initialNocks)
     await clickByTestId('standalone')
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateControlPlane.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateControlPlane.test.tsx
@@ -7,10 +7,7 @@ import { clickByTestId } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { CreateControlPlane } from './CreateControlPlane'
 import { managedClusterAddonsState, multiClusterEnginesState } from '../../../../../atoms'
-import {
-  mockManagedClusterAddOn,
-  mockMultiClusterEngine,
-} from './sharedMocks'
+import { mockManagedClusterAddOn, mockMultiClusterEngine } from './sharedMocks'
 
 describe('CreateControlPlane', () => {
   beforeEach(() => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/sharedMocks.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/sharedMocks.ts
@@ -1,0 +1,70 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import {
+  MultiClusterEngine,
+  MultiClusterEngineApiVersion,
+  MultiClusterEngineKind,
+  ManagedClusterAddOn,
+} from '../../../../../resources'
+
+export const mockMultiClusterEngine: MultiClusterEngine = {
+  apiVersion: MultiClusterEngineApiVersion,
+  kind: MultiClusterEngineKind,
+  spec: {
+    availabilityConfig: 'High',
+    imagePullSecret: 'multiclusterhub-operator-pull-secret',
+    overrides: {
+      components: [
+        {
+          enabled: true,
+          name: 'hypershift-preview',
+        },
+      ],
+    },
+    targetNamespace: 'multicluster-engine',
+    tolerations: [],
+  },
+  metadata: {
+    name: 'multiclusterengine',
+    generation: 2,
+  },
+  status: {
+    conditions: [
+      {
+        reason: 'ManagedClusterAddOnLeaseUpdated',
+        status: 'True',
+      },
+    ],
+  },
+}
+
+export const mockMultiClusterEngineWithHypershiftDisabled: MultiClusterEngine = {
+  ...mockMultiClusterEngine,
+  spec: {
+    ...mockMultiClusterEngine.spec,
+    overrides: {
+      ...mockMultiClusterEngine.spec?.overrides,
+      components: [{ enabled: false, name: 'hypershift-preview' }],
+    },
+  },
+} as MultiClusterEngine
+
+export const mockManagedClusterAddOn: ManagedClusterAddOn = {
+  apiVersion: 'addon.open-cluster-management.io/v1alpha1',
+  kind: 'ManagedClusterAddOn',
+  metadata: {
+    name: 'hypershift-addon',
+    namespace: 'local-cluster',
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: undefined,
+        message: 'application-manager add-on is available.',
+        reason: 'ManagedClusterAddOnLeaseUpdated',
+        status: 'True',
+        type: 'Available',
+      },
+    ],
+  },
+} as ManagedClusterAddOn


### PR DESCRIPTION
…re is disable 2.8

https://issues.redhat.com/browse/ACM-6976

- Add disable logic to AWS hosted cluster card
- Fix missing TP label
- Removed direct call to list multiclusterengine, used recoilstate instead. This helps unit testing as the nocks were being call randomly causing random test failures