### PR TITLE
Set the Gatekeeper operator channel back to stable

### DIFF
--- a/frontend/src/wizards/Governance/Policy/stable/CM-Configuration-Management/policy-gatekeeper-operator-downstream.yaml
+++ b/frontend/src/wizards/Governance/Policy/stable/CM-Configuration-Management/policy-gatekeeper-operator-downstream.yaml
@@ -31,7 +31,7 @@ spec:
                   name: gatekeeper-operator-product
                   namespace: openshift-operators
                 spec:
-                  channel: '3.11'
+                  channel: stable
                   installPlanApproval: Automatic
                   name: gatekeeper-operator-product
                   source: redhat-operators


### PR DESCRIPTION
The new 3.11.1 operator now is part of the 3.11 and stable channels.

Relates:
https://issues.redhat.com/browse/ACM-7906