### PR TITLE
ACM-7943 Only use multi arch OCP images for hosted clusters

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
@@ -602,6 +602,39 @@ const mockClusterImageSet2: ClusterImageSet = {
   },
 }
 
+const mockClusterImageSet3: ClusterImageSet = {
+  apiVersion: ClusterImageSetApiVersion,
+  kind: ClusterImageSetKind,
+  metadata: {
+    name: 'img4.11.8-multi',
+  },
+  spec: {
+    releaseImage: 'quay.io/openshift-release-dev/ocp-release:4.11.8-multi',
+  },
+}
+
+const mockClusterImageSet4: ClusterImageSet = {
+  apiVersion: ClusterImageSetApiVersion,
+  kind: ClusterImageSetKind,
+  metadata: {
+    name: 'img4.11.9-multi',
+  },
+  spec: {
+    releaseImage: 'quay.io/openshift-release-dev/ocp-release:4.11.9-multi',
+  },
+}
+
+const mockClusterImageSet5: ClusterImageSet = {
+  apiVersion: ClusterImageSetApiVersion,
+  kind: ClusterImageSetKind,
+  metadata: {
+    name: 'img4.12.0-multi',
+  },
+  spec: {
+    releaseImage: 'quay.io/openshift-release-dev/ocp-release:4.12.0-multi',
+  },
+}
+
 const mockHostedCluster: HostedClusterK8sResource = {
   apiVersion: HostedClusterApiVersion,
   kind: HostedClusterKind,
@@ -824,7 +857,16 @@ describe('DistributionField hypershift clusters', () => {
           snapshot.set(nodePoolsState, mockNodepools)
           snapshot.set(
             clusterImageSetsState,
-            setClusterImageSet ? [mockClusterImageSet0, mockClusterImageSet1, mockClusterImageSet2] : []
+            setClusterImageSet
+              ? [
+                  mockClusterImageSet0,
+                  mockClusterImageSet1,
+                  mockClusterImageSet2,
+                  mockClusterImageSet3,
+                  mockClusterImageSet4,
+                  mockClusterImageSet5,
+                ]
+              : []
           )
         }}
       >

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -79,12 +79,14 @@ export function DistributionField(props: {
     }
     const updates: any = {}
     clusterImageSets.forEach((cis) => {
-      const releaseImageVersion = getVersionFromReleaseImage(cis.spec?.releaseImage)
-      if (
-        releaseImageVersion &&
-        isUpdateVersionAcceptable(props.cluster?.distribution?.ocp?.version || '', releaseImageVersion)
-      ) {
-        updates[releaseImageVersion] = cis.spec?.releaseImage
+      if (cis.spec?.releaseImage.includes('multi')) {
+        const releaseImageVersion = getVersionFromReleaseImage(cis.spec?.releaseImage)
+        if (
+          releaseImageVersion &&
+          isUpdateVersionAcceptable(props.cluster?.distribution?.ocp?.version || '', releaseImageVersion)
+        ) {
+          updates[releaseImageVersion] = cis.spec?.releaseImage
+        }
       }
     })
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-7943

Turns out the x86 images were overwriting the multi arch images.

- Change to only use multi arch images