### PR TITLE
ACM-7920 yaml-editor-not-works-well

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1391,6 +1391,7 @@
   "For Subscription applications, displays the number of remote and local clusters where resources for the application are deployed. For Argo applications, this is the name of the destination cluster. For OpenShift applications, this is the cluster where the application is deployed.": "For Subscription applications, displays the number of remote and local clusters where resources for the application are deployed. For Argo applications, this is the name of the destination cluster. For OpenShift applications, this is the cluster where the application is deployed.",
   "Forbidden": "Forbidden",
   "foreground": "foreground",
+  "Form edits will be ignored until YAML syntax errors are fixed.": "Form edits will be ignored until YAML syntax errors are fixed.",
   "formerror.valid.baseDNSPeriod": "The base DNS domain must not begin with a period.",
   "formerror.valid.name": "Must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
   "G3 - NVIDIA Tesla M60 GPUs": "G3 - NVIDIA Tesla M60 GPUs",

--- a/frontend/src/components/SyncEditor/SyncEditor.css
+++ b/frontend/src/components/SyncEditor/SyncEditor.css
@@ -37,7 +37,7 @@
   background-color: #25282c;
 }
 
-.sync-editor__container .pf-c-button.pf-m-plain,
+.sync-editor__container .sy-toolbar-buttons .pf-c-button.pf-m-plain,
 .pf-c-code-editor__controls .pf-c-button.pf-m-control:not([disabled]) {
   color: #ededed;
 }

--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -665,7 +665,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
       {editorHasErrors && (
         <Alert
           variant="danger"
-          title="Changes will be ignored until errors are fixed."
+          title={t('Form edits will be ignored until YAML syntax errors are fixed.')}
           actionClose={<AlertActionCloseButton onClose={() => setEditorHasErrors(false)} />}
         />
       )}

--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -5,7 +5,7 @@ import useResizeObserver from '@react-hook/resize-observer'
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor'
 import { global_BackgroundColor_dark_100 as editorBackground } from '@patternfly/react-tokens'
 import { RedoIcon, UndoIcon, SearchIcon, EyeIcon, EyeSlashIcon, CloseIcon } from '@patternfly/react-icons'
-import { Alert, AlertActionCloseButton, ClipboardCopyButton } from '@patternfly/react-core'
+import { Alert, ClipboardCopyButton } from '@patternfly/react-core'
 import { debounce, noop, isEqual, cloneDeep } from 'lodash'
 import { processForm, processUser, ProcessedType } from './process'
 import { compileAjvSchemas, ErrorType, formatErrors } from './validation'
@@ -654,7 +654,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
       height -= 36
     }
     if (editorHasErrors) {
-      height -= 36
+      height -= 75
     }
     editorRef?.current?.layout({ width, height })
     setShowCondensed(width < 500)
@@ -663,11 +663,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
   return (
     <div ref={pageRef} className="sync-editor__container">
       {editorHasErrors && (
-        <Alert
-          variant="danger"
-          title={t('Form edits will be ignored until YAML syntax errors are fixed.')}
-          actionClose={<AlertActionCloseButton onClose={() => setEditorHasErrors(false)} />}
-        />
+        <Alert variant="danger" title={t('Form edits will be ignored until YAML syntax errors are fixed.')} />
       )}
       <CodeEditor
         isLineNumbersVisible={true}

--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -5,7 +5,7 @@ import useResizeObserver from '@react-hook/resize-observer'
 import { CodeEditor, CodeEditorControl, Language } from '@patternfly/react-code-editor'
 import { global_BackgroundColor_dark_100 as editorBackground } from '@patternfly/react-tokens'
 import { RedoIcon, UndoIcon, SearchIcon, EyeIcon, EyeSlashIcon, CloseIcon } from '@patternfly/react-icons'
-import { ClipboardCopyButton } from '@patternfly/react-core'
+import { Alert, AlertActionCloseButton, ClipboardCopyButton } from '@patternfly/react-core'
 import { debounce, noop, isEqual, cloneDeep } from 'lodash'
 import { processForm, processUser, ProcessedType } from './process'
 import { compileAjvSchemas, ErrorType, formatErrors } from './validation'
@@ -112,6 +112,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
   const [showFiltered, setShowFiltered] = useState<boolean>(false)
   const [clickedOnFilteredLine, setClickedOnFilteredLine] = useState<boolean>(false)
   const [editorHasFocus, setEditorHasFocus] = useState<boolean>(false)
+  const [editorHasErrors, setEditorHasErrors] = useState<boolean>(false)
   const [showCondensed, setShowCondensed] = useState<boolean>(false)
   const [hasUndo, setHasUndo] = useState<boolean>(false)
   const [hasRedo, setHasRedo] = useState<boolean>(false)
@@ -303,7 +304,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
   useEffect(() => {
     // debounce changes from form
     const formChange = () => {
-      if (editorHasFocus) {
+      if (editorHasFocus || editorHasErrors) {
         return
       }
       // parse/validate/secrets
@@ -448,16 +449,16 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
 
       // report new resources/errors/useredits to form
       // if there are validation errors still pass it to form
+      const editorHasErrors =
+        errors.syntax.length > 0 || errors.validation.filter(({ errorType }) => errorType === 'error').length > 0
       let customErrors = []
-      if (
-        errors.syntax.length === 0 &&
-        errors.validation.filter(({ errorType }) => errorType === 'error').length === 0
-      ) {
+      if (!editorHasErrors) {
         const clonedUnredactedChange = cloneDeep(unredactedChange)
         setResourceChanges(clonedUnredactedChange)
         customErrors = setFormValues(syncs, clonedUnredactedChange) || []
         setCustomValidationErrors(customErrors)
       }
+      setEditorHasErrors(editorHasErrors)
       setStatusChanges(cloneDeep({ changes, redactedChange: change, errors: allErrors }))
 
       // decorate errors, changes
@@ -545,7 +546,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
     return (
       <>
         <div className="sy-c-code-editor__title">{editorTitle || 'YAML'}</div>
-        <div style={{ display: 'flex' }}>
+        <div className="sy-toolbar-buttons" style={{ display: 'flex' }}>
           {/* undo */}
           {!readonly && (
             <CodeEditorControl
@@ -652,12 +653,22 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
     if (variant === 'toolbar') {
       height -= 36
     }
+    if (editorHasErrors) {
+      height -= 36
+    }
     editorRef?.current?.layout({ width, height })
     setShowCondensed(width < 500)
   })
 
   return (
     <div ref={pageRef} className="sync-editor__container">
+      {editorHasErrors && (
+        <Alert
+          variant="danger"
+          title="Changes will be ignored until errors are fixed."
+          actionClose={<AlertActionCloseButton onClose={() => setEditorHasErrors(false)} />}
+        />
+      )}
       <CodeEditor
         isLineNumbersVisible={true}
         isReadOnly={readonly}


### PR DESCRIPTION
caused because when there are errors in the yaml pasted into the editor, the yaml is ignored
then when the user went to change anything outside of the editor, the editor would be reset with the form version

fixed by prevent form updates until yaml is fixed--alert user:

<img width="767" alt="CleanShot 2023-10-20 at 12 03 14@2x" src="https://github.com/stolostron/console/assets/60980397/f377ba9c-58ba-46e0-abc8-204a63990830">


Signed-off-by: John Swanke <jswanke@redhat.com>