### PR TITLE
ACM-8436: remove tech preview from kubevirt hosted card

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/common/GetHostedCard.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/common/GetHostedCard.tsx
@@ -45,10 +45,6 @@ function GetHostedCard(onNext: () => void, t: TFunction, isHypershiftEnabled: bo
     ),
     badgeList: [
       {
-        badge: t('Technology preview'),
-        badgeColor: CatalogColor.orange,
-      },
-      {
         badge: t('CLI-based'),
         badgeColor: CatalogColor.purple,
       },


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-8436
- Removes "tech preview" from kubevirt hosted card in the catalog
 
<img width="450" alt="image" src="https://github.com/stolostron/console/assets/53154476/2f9d8b65-0065-4270-8063-d544d45cffc7">

- AWS continues to show "tech preview":
<img width="450" alt="image" src="https://github.com/stolostron/console/assets/53154476/d769b1f1-02c3-4c48-b03e-c9908f5fa109">

