### PR TITLE
[ACM-8903] Added ROSA-HCP type for discovered clusters

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2903,6 +2903,7 @@
   "type.ocp": "OpenShift Container Platform",
   "type.osd": "OpenShift Dedicated",
   "type.rosa": "Red Hat OpenShift Service on AWS",
+  "type.rosa.hcp": "Red Hat OpenShift Service on AWS Hosted Control Plane",
   "type.to.confirm": "Confirm by typing \"{{confirm}}\" below:",
   "Unable to communicate with the server because of a bad gateway.": "Unable to communicate with the server because of a bad gateway.",
   "Unable to communicate with the server because of a network error.": "Unable to communicate with the server because of a network error.",

--- a/frontend/public/locales/ja/translation.json
+++ b/frontend/public/locales/ja/translation.json
@@ -2866,6 +2866,7 @@
   "type.ocp": "OpenShift Container Platform",
   "type.osd": "OpenShift Dedicated",
   "type.rosa": "Red Hat OpenShift Service on AWS",
+  "type.rosa.hcp": "Red Hat OpenShift Service on AWS Hosted Control Plane",
   "type.to.confirm": "以下に \"{{confirm}}\" と入力して確定します:",
   "Unable to communicate with the server because of a bad gateway.": "bad gateway のため、サーバーと通信できません。",
   "Unable to communicate with the server because of a network error.": "ネットワークエラーが原因でサーバーと通信できません。",

--- a/frontend/public/locales/ko/translation.json
+++ b/frontend/public/locales/ko/translation.json
@@ -2866,6 +2866,7 @@
   "type.ocp": "OpenShift Container Platform",
   "type.osd": "OpenShift Dedicated",
   "type.rosa": "Red Hat OpenShift Service on AWS",
+  "type.rosa.hcp": "Red Hat OpenShift Service on AWS Hosted Control Plane",
   "type.to.confirm": "아래에 \"{{confirm}}\"을 입력하여 확인합니다.",
   "Unable to communicate with the server because of a bad gateway.": "잘못된 게이트웨이로 인해 서버와 통신할 수 없습니다.",
   "Unable to communicate with the server because of a network error.": "네트워크 오류로 인해 서버와 통신할 수 없습니다.",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -2866,6 +2866,7 @@
   "type.ocp": "OpenShift Container Platform",
   "type.osd": "OpenShift Dedicated",
   "type.rosa": "Red Hat OpenShift Service on AWS",
+  "type.rosa.hcp": "Red Hat OpenShift Service on AWS Hosted Control Plane",
   "type.to.confirm": "在下面键入 \"{{confirm}}\" 进行确认：",
   "Unable to communicate with the server because of a bad gateway.": "由于网关问题，无法与服务器通信。",
   "Unable to communicate with the server because of a network error.": "由于网络错误，无法与服务器通信。",

--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
@@ -311,6 +311,10 @@ export function DiscoveredClustersTable(props: {
         return t('type.rosa')
       case 'ROSA':
         return t('type.rosa')
+      case 'MOA-HostedControlPlane':
+        return t('type.rosa.hcp')
+      case 'ROSA-HCP':
+        return t('type.rosa.hcp')
       case 'OCP-ASSISTEDINSTALL':
         return t('type.ocp')
       case 'OCP':


### PR DESCRIPTION
Adding a type mapping for `ROSA-HCP` / `MOA-HostedControlPlane`. Currently, within the UI these discovered clusters are shown as `MOA-HostedControlPlane`, which is not the desire type for the console.

Jira Issue: https://issues.redhat.com/browse/ACM-8903