### PR TITLE
ACM-9466 Optimize app count for cluster details page

### DIFF
--- a/frontend/src/components/GetDiscoveredOCPApps.tsx
+++ b/frontend/src/components/GetDiscoveredOCPApps.tsx
@@ -1,7 +1,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { get } from 'lodash'
 import { useEffect, useState } from 'react'
-import { queryOCPAppResources, queryRemoteArgoApps } from '../lib/search'
+import {
+  queryOCPAppResources,
+  queryRemoteArgoApps,
+  queryRemoteArgoAppsForCluster,
+  queryOCPAppResourcesForCluster,
+  queryEmpty,
+} from '../lib/search'
 import { useQuery } from '../lib/useQuery'
 import { ArgoApplication, Cluster, HelmRelease, OCPAppResource } from '../resources'
 import { getArgoDestinationCluster } from '../routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyArgo'
@@ -11,16 +17,24 @@ import { useSetRecoilState, useSharedAtoms } from '../shared-recoil'
 import { LoadingPage } from './LoadingPage'
 
 /* Copyright Contributors to the Open Cluster Management project */
-export function GetDiscoveredOCPApps(stop: boolean, waitForSearch: boolean) {
+export function GetDiscoveredOCPApps(stop: boolean, waitForSearch: boolean, cluster?: string) {
   const { discoveredApplicationsState, discoveredOCPAppResourcesState } = useSharedAtoms()
-  const { data, loading, startPolling, stopPolling } = useQuery(queryRemoteArgoApps)
+  const queryRemoteArgoAppsFunc = cluster
+    ? cluster == 'local-cluster'
+      ? queryEmpty
+      : () => queryRemoteArgoAppsForCluster(cluster)
+    : queryRemoteArgoApps
+  const { data, loading, startPolling, stopPolling } = useQuery(queryRemoteArgoAppsFunc, undefined, {
+    pollInterval: 15,
+  })
 
+  const queryOCPAppResourcesFunc = cluster ? () => queryOCPAppResourcesForCluster(cluster) : queryOCPAppResources
   const {
     data: dataOCPResources,
     loading: loadingOCPResources,
     startPolling: startPollingOCPResources,
     stopPolling: stopPollingOCPResources,
-  } = useQuery(queryOCPAppResources)
+  } = useQuery(queryOCPAppResourcesFunc, undefined, { pollInterval: 15 })
 
   const [timedOut, setTimedOut] = useState<boolean>()
   const setDiscoveredApplications = useSetRecoilState(discoveredApplicationsState)

--- a/frontend/src/components/GetDiscoveredOCPApps.tsx
+++ b/frontend/src/components/GetDiscoveredOCPApps.tsx
@@ -1,13 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { get } from 'lodash'
 import { useEffect, useState } from 'react'
-import {
-  queryOCPAppResources,
-  queryRemoteArgoApps,
-  queryRemoteArgoAppsForCluster,
-  queryOCPAppResourcesForCluster,
-  queryEmpty,
-} from '../lib/search'
+import { queryOCPAppResources, queryRemoteArgoApps, queryEmpty } from '../lib/search'
 import { useQuery } from '../lib/useQuery'
 import { ArgoApplication, Cluster, HelmRelease, OCPAppResource } from '../resources'
 import { getArgoDestinationCluster } from '../routes/Applications/ApplicationDetails/ApplicationTopology/model/topologyArgo'
@@ -22,13 +16,13 @@ export function GetDiscoveredOCPApps(stop: boolean, waitForSearch: boolean, clus
   const queryRemoteArgoAppsFunc = cluster
     ? cluster == 'local-cluster'
       ? queryEmpty
-      : () => queryRemoteArgoAppsForCluster(cluster)
+      : () => queryRemoteArgoApps(cluster)
     : queryRemoteArgoApps
   const { data, loading, startPolling, stopPolling } = useQuery(queryRemoteArgoAppsFunc, undefined, {
     pollInterval: 15,
   })
 
-  const queryOCPAppResourcesFunc = cluster ? () => queryOCPAppResourcesForCluster(cluster) : queryOCPAppResources
+  const queryOCPAppResourcesFunc = cluster ? () => queryOCPAppResources(cluster) : queryOCPAppResources
   const {
     data: dataOCPResources,
     loading: loadingOCPResources,

--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -53,17 +53,24 @@ export function queryStatusCount(cluster: string): IRequestResult<ISearchResult>
   })
 }
 
-export function queryRemoteArgoApps(): IRequestResult<ISearchResult> {
+export function queryRemoteArgoApps(cluster?: string): IRequestResult<ISearchResult> {
+  const filtersArr = [
+    { property: 'kind', values: ['Application'] },
+    { property: 'apigroup', values: ['argoproj.io'] },
+  ]
+
+  if (cluster) {
+    filtersArr.push({ property: 'cluster', values: [cluster] })
+  } else {
+    filtersArr.push({ property: 'cluster', values: ['!local-cluster'] })
+  }
+
   return postRequest<SearchQuery, ISearchResult>(getBackendUrl() + apiSearchUrl, {
     operationName: 'searchResult',
     variables: {
       input: [
         {
-          filters: [
-            { property: 'kind', values: ['Application'] },
-            { property: 'apigroup', values: ['argoproj.io'] },
-            { property: 'cluster', values: ['!local-cluster'] },
-          ],
+          filters: filtersArr,
           limit: 20000,
         },
       ],
@@ -72,61 +79,27 @@ export function queryRemoteArgoApps(): IRequestResult<ISearchResult> {
   })
 }
 
-export function queryRemoteArgoAppsForCluster(cluster: string): IRequestResult<ISearchResult> {
-  return postRequest<SearchQuery, ISearchResult>(getBackendUrl() + apiSearchUrl, {
-    operationName: 'searchResult',
-    variables: {
-      input: [
-        {
-          filters: [
-            { property: 'kind', values: ['Application'] },
-            { property: 'apigroup', values: ['argoproj.io'] },
-            { property: 'cluster', values: [cluster] },
-          ],
-          limit: 20000,
-        },
-      ],
+export function queryOCPAppResources(cluster?: string): IRequestResult<ISearchResult> {
+  const filtersArr = [
+    {
+      property: 'kind',
+      values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
     },
-    query: searchFilterQuery,
-  })
-}
+  ]
 
-export function queryOCPAppResources(): IRequestResult<ISearchResult> {
+  if (cluster) {
+    filtersArr.push({
+      property: 'cluster',
+      values: [cluster],
+    })
+  }
+
   return postRequest<SearchQuery, ISearchResult>(getBackendUrl() + apiSearchUrl, {
     operationName: 'searchResult',
     variables: {
       input: [
         {
-          filters: [
-            {
-              property: 'kind',
-              values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
-            },
-          ],
-          limit: 20000, // search said not to use unlimited results so use this for now until pagination is available
-        },
-      ],
-    },
-    query: searchFilterQuery,
-  })
-}
-
-export function queryOCPAppResourcesForCluster(cluster: string): IRequestResult<ISearchResult> {
-  return postRequest<SearchQuery, ISearchResult>(getBackendUrl() + apiSearchUrl, {
-    operationName: 'searchResult',
-    variables: {
-      input: [
-        {
-          filters: [
-            {
-              property: 'kind',
-              values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
-            },
-            {
-              property: 'cluster',
-              values: [cluster],
-            },
-          ],
+          filters: filtersArr,
           limit: 20000, // search said not to use unlimited results so use this for now until pagination is available
         },
       ],

--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -72,6 +72,25 @@ export function queryRemoteArgoApps(): IRequestResult<ISearchResult> {
   })
 }
 
+export function queryRemoteArgoAppsForCluster(cluster: string): IRequestResult<ISearchResult> {
+  return postRequest<SearchQuery, ISearchResult>(getBackendUrl() + apiSearchUrl, {
+    operationName: 'searchResult',
+    variables: {
+      input: [
+        {
+          filters: [
+            { property: 'kind', values: ['Application'] },
+            { property: 'apigroup', values: ['argoproj.io'] },
+            { property: 'cluster', values: [cluster] },
+          ],
+          limit: 20000,
+        },
+      ],
+    },
+    query: searchFilterQuery,
+  })
+}
+
 export function queryOCPAppResources(): IRequestResult<ISearchResult> {
   return postRequest<SearchQuery, ISearchResult>(getBackendUrl() + apiSearchUrl, {
     operationName: 'searchResult',
@@ -82,6 +101,30 @@ export function queryOCPAppResources(): IRequestResult<ISearchResult> {
             {
               property: 'kind',
               values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
+            },
+          ],
+          limit: 20000, // search said not to use unlimited results so use this for now until pagination is available
+        },
+      ],
+    },
+    query: searchFilterQuery,
+  })
+}
+
+export function queryOCPAppResourcesForCluster(cluster: string): IRequestResult<ISearchResult> {
+  return postRequest<SearchQuery, ISearchResult>(getBackendUrl() + apiSearchUrl, {
+    operationName: 'searchResult',
+    variables: {
+      input: [
+        {
+          filters: [
+            {
+              property: 'kind',
+              values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
+            },
+            {
+              property: 'cluster',
+              values: [cluster],
             },
           ],
           limit: 20000, // search said not to use unlimited results so use this for now until pagination is available
@@ -113,4 +156,17 @@ export function querySearchDisabledManagedClusters(): IRequestResult<ISearchResu
 export function useSearchParams() {
   const { search } = useLocation()
   return useMemo(() => new URLSearchParams(search), [search])
+}
+
+// Used when need to maintain same number of hooks called
+export function queryEmpty(): IRequestResult<ISearchResult> {
+  const abortController = new AbortController()
+  return {
+    promise: Promise.resolve<ISearchResult>({
+      data: {
+        searchResult: [],
+      },
+    }),
+    abort: () => abortController.abort(),
+  }
 }

--- a/frontend/src/routes/Applications/Application.sharedmocks.tsx
+++ b/frontend/src/routes/Applications/Application.sharedmocks.tsx
@@ -469,6 +469,41 @@ export const mockSearchQueryArgoApps = {
   },
   query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
 }
+
+export const mockSearchQueryArgoAppsStatusSummaryCount = {
+  operationName: 'searchResult',
+  variables: {
+    input: [
+      {
+        filters: [
+          { property: 'kind', values: ['Application'] },
+          { property: 'apigroup', values: ['argoproj.io'] },
+          { property: 'cluster', values: ['test-cluster'] },
+        ],
+        limit: 20000,
+      },
+    ],
+  },
+  query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
+}
+
+export const mockSearchQueryArgoAppsClusterOverview = {
+  operationName: 'searchResult',
+  variables: {
+    input: [
+      {
+        filters: [
+          { property: 'kind', values: ['Application'] },
+          { property: 'apigroup', values: ['argoproj.io'] },
+          { property: 'cluster', values: ['feng-hypershift-test'] },
+        ],
+        limit: 20000,
+      },
+    ],
+  },
+  query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
+}
+
 export const mockSearchResponseArgoApps = {
   data: {
     searchResult: [
@@ -543,6 +578,51 @@ export const mockSearchQueryOCPApplications = {
   },
   query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
 }
+
+export const mockSearchQueryOCPApplicationsStatusSummaryCount = {
+  operationName: 'searchResult',
+  variables: {
+    input: [
+      {
+        filters: [
+          {
+            property: 'kind',
+            values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
+          },
+          {
+            property: 'cluster',
+            values: ['test-cluster'],
+          },
+        ],
+        limit: 20000,
+      },
+    ],
+  },
+  query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
+}
+
+export const mockSearchQueryOCPApplicationsClusterOverview = {
+  operationName: 'searchResult',
+  variables: {
+    input: [
+      {
+        filters: [
+          {
+            property: 'kind',
+            values: ['CronJob', 'DaemonSet', 'Deployment', 'DeploymentConfig', 'Job', 'StatefulSet'],
+          },
+          {
+            property: 'cluster',
+            values: ['feng-hypershift-test'],
+          },
+        ],
+        limit: 20000,
+      },
+    ],
+  },
+  query: 'query searchResult($input: [SearchInput]) {\n  searchResult: search(input: $input) {\n    items\n  }\n}',
+}
+
 export const mockSearchResponseOCPApplications = {
   data: {
     searchResult: [

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.test.tsx
@@ -43,8 +43,8 @@ import { HostedClusterK8sResource } from '@openshift-assisted/ui-lib/cim'
 import userEvent from '@testing-library/user-event'
 import { AcmToastGroup, AcmToastProvider } from '../../../../../../ui-components'
 import {
-  mockSearchQueryArgoApps,
-  mockSearchQueryOCPApplications,
+  mockSearchQueryArgoAppsClusterOverview,
+  mockSearchQueryOCPApplicationsClusterOverview,
   mockSearchResponseArgoApps1,
   mockSearchResponseOCPApplications,
 } from '../../../../../Applications/Application.sharedmocks'
@@ -117,8 +117,8 @@ describe('ClusterOverview with AWS hypershift cluster', () => {
   beforeEach(() => {
     nockIgnoreRBAC()
     nockSearch(mockSearchQuery, mockSearchResponse)
-    nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-    nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps1)
+    nockSearch(mockSearchQueryOCPApplicationsClusterOverview, mockSearchResponseOCPApplications)
+    nockSearch(mockSearchQueryArgoAppsClusterOverview, mockSearchResponseArgoApps1)
     nockIgnoreApiPaths()
     render(
       <RecoilRoot
@@ -164,8 +164,8 @@ describe('ClusterOverview with BM hypershift cluster', () => {
   beforeEach(() => {
     nockIgnoreRBAC()
     nockSearch(mockSearchQuery, mockSearchResponse)
-    nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-    nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps1)
+    nockSearch(mockSearchQueryOCPApplicationsClusterOverview, mockSearchResponseOCPApplications)
+    nockSearch(mockSearchQueryArgoAppsClusterOverview, mockSearchResponseArgoApps1)
     nockGet(kubeConfigSecret)
     nockGet(kubeAdminPassSecret)
     nockIgnoreApiPaths()
@@ -213,8 +213,8 @@ describe('ClusterOverview with BM hypershift cluster no namespace', () => {
   beforeEach(() => {
     nockIgnoreRBAC()
     nockSearch(mockSearchQuery, mockSearchResponse)
-    nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-    nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps1)
+    nockSearch(mockSearchQueryOCPApplicationsClusterOverview, mockSearchResponseOCPApplications)
+    nockSearch(mockSearchQueryArgoAppsClusterOverview, mockSearchResponseArgoApps1)
     nockGet(kubeConfigSecret)
     nockGet(kubeAdminPassSecret)
     nockIgnoreApiPaths()
@@ -262,8 +262,8 @@ describe('ClusterOverview with AWS hypershift cluster no hypershift', () => {
   beforeEach(() => {
     nockIgnoreRBAC()
     nockSearch(mockSearchQuery, mockSearchResponse)
-    nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-    nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps1)
+    nockSearch(mockSearchQueryOCPApplicationsClusterOverview, mockSearchResponseOCPApplications)
+    nockSearch(mockSearchQueryArgoAppsClusterOverview, mockSearchResponseArgoApps1)
     nockGet(kubeConfigSecret)
     nockGet(kubeAdminPassSecret)
     nockIgnoreApiPaths()
@@ -311,8 +311,8 @@ describe('ClusterOverview with AWS hypershift cluster no hostedCluster', () => {
   beforeEach(() => {
     nockIgnoreRBAC()
     nockSearch(mockSearchQuery, mockSearchResponse)
-    nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-    nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps1)
+    nockSearch(mockSearchQueryOCPApplicationsClusterOverview, mockSearchResponseOCPApplications)
+    nockSearch(mockSearchQueryArgoAppsClusterOverview, mockSearchResponseArgoApps1)
     nockIgnoreApiPaths()
     render(
       <RecoilRoot
@@ -358,8 +358,8 @@ describe('ClusterOverview with regional hub cluster information', () => {
   beforeEach(() => {
     nockIgnoreRBAC()
     nockSearch(mockSearchQuery, mockSearchResponse)
-    nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-    nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps1)
+    nockSearch(mockSearchQueryOCPApplicationsClusterOverview, mockSearchResponseOCPApplications)
+    nockSearch(mockSearchQueryArgoAppsClusterOverview, mockSearchResponseArgoApps1)
     nockIgnoreApiPaths()
     render(
       <RecoilRoot
@@ -407,8 +407,8 @@ describe('ClusterOverview with regional hub cluster information with hostedClust
     mockRegionalHubCluster.isHostedCluster = true
     nockIgnoreRBAC()
     nockSearch(mockSearchQuery, mockSearchResponse)
-    nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-    nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps1)
+    nockSearch(mockSearchQueryOCPApplicationsClusterOverview, mockSearchResponseOCPApplications)
+    nockSearch(mockSearchQueryArgoAppsClusterOverview, mockSearchResponseArgoApps1)
     nockIgnoreApiPaths()
     render(
       <RecoilRoot
@@ -667,8 +667,8 @@ describe('ClusterOverview with AWS hypershift cluster', () => {
 
     nockIgnoreRBAC()
     nockSearch(mockSearchQuery, mockSearchResponse)
-    nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-    nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps1)
+    nockSearch(mockSearchQueryOCPApplicationsClusterOverview, mockSearchResponseOCPApplications)
+    nockSearch(mockSearchQueryArgoAppsClusterOverview, mockSearchResponseArgoApps1)
     nockIgnoreApiPaths()
     nockGet(getSecrets1.req, getSecrets1.req) // get 'secrets' in 'clusters' namespace
     nockGet(getSecrets2.req, getSecrets2.req)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.test.tsx
@@ -10,8 +10,8 @@ import { PluginDataContext } from '../../../../../lib/PluginDataContext'
 import { clickByText, waitForNotText, waitForText, ocpApi } from '../../../../../lib/test-util'
 import { Cluster, ClusterStatus, Policy, PolicyReport } from '../../../../../resources'
 import {
-  mockSearchQueryArgoApps,
-  mockSearchQueryOCPApplications,
+  mockSearchQueryArgoAppsStatusSummaryCount,
+  mockSearchQueryOCPApplicationsStatusSummaryCount,
   mockSearchResponseArgoApps1,
   mockSearchResponseOCPApplications,
 } from '../../../../Applications/Application.sharedmocks'
@@ -258,8 +258,8 @@ const mockPolicies: Policy[] = [
 
 describe('StatusSummaryCount', () => {
   beforeEach(() => {
-    nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
-    nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps1)
+    nockSearch(mockSearchQueryOCPApplicationsStatusSummaryCount, mockSearchResponseOCPApplications)
+    nockSearch(mockSearchQueryArgoAppsStatusSummaryCount, mockSearchResponseArgoApps1)
   })
 
   const Component = () => (

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.tsx
@@ -44,9 +44,9 @@ export function StatusSummaryCount() {
   const [placementDecisions] = useRecoilState(placementDecisionsState)
   const [subscriptions] = useRecoilState(subscriptionsState)
   const policies = usePolicies()
-
-  GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length)
   const { cluster } = useContext(ClusterContext)
+
+  GetDiscoveredOCPApps(applicationsMatch.isExact, !ocpApps.length && !discoveredApplications.length, cluster?.name)
   const clusters = useAllClusters(true)
   const { setDrawerContext } = useContext(AcmDrawerContext)
   const { t } = useTranslation()
@@ -133,8 +133,6 @@ export function StatusSummaryCount() {
     return tempApps
   }, [filteredOCPApps, cluster?.name])
 
-  const clusterDiscoveredArgoApps = discoveredApplications.filter((app) => app.cluster === cluster?.name)
-
   const appSets: ApplicationSet[] = useMemo(() => {
     const filteredAppSets = applicationSets.filter((appSet) => {
       // Get the Placement name so we can find PlacementDecision
@@ -156,8 +154,13 @@ export function StatusSummaryCount() {
   }, [applicationSets, placementDecisions, cluster?.name])
 
   const appsCount = useMemo(
-    () => [...applicationList, ...clusterDiscoveredArgoApps, ...clusterOcpApps, ...appSets, ...argoAppList].length,
-    [applicationList, argoAppList, clusterDiscoveredArgoApps, clusterOcpApps, appSets]
+    () =>
+      applicationList.length +
+      discoveredApplications.length +
+      clusterOcpApps.length +
+      appSets.length +
+      argoAppList.length,
+    [applicationList, argoAppList, discoveredApplications, clusterOcpApps, appSets]
   )
 
   const nodesCount = useMemo(() => (cluster?.nodes?.nodeList ?? []).length, [cluster])


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9466 
More info this slack thread https://redhat-internal.slack.com/archives/C04EYRKRXGF/p1705346214521019

- Removed spreading all apps into a new array and just add the length together
- Changed discovered Argo and OCP app queries to only get apps from the current cluster

