### PR TITLE
ACM-9664 cluster deployment ref fix (release 2.9.z)

### DIFF
--- a/frontend/src/resources/cluster-deployment.ts
+++ b/frontend/src/resources/cluster-deployment.ts
@@ -62,8 +62,8 @@ export interface ClusterDeployment {
       namespace: string
       poolName: string
     }
-    pullSecretRef: {
-      name: string
+    pullSecretRef?: {
+      name?: string
     }
     clusterInstallRef?: {
       group: string

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -559,7 +559,7 @@ export function getHiveConfig(clusterDeployment?: ClusterDeployment, clusterClai
       kubeconfig: clusterDeployment?.spec?.clusterMetadata?.adminKubeconfigSecretRef?.name,
       kubeadmin: clusterDeployment?.spec?.clusterMetadata?.adminPasswordSecretRef?.name,
       installConfig: clusterDeployment?.spec?.provisioning?.installConfigSecretRef?.name,
-      pullSecret: clusterDeployment?.spec?.pullSecretRef.name,
+      pullSecret: clusterDeployment?.spec?.pullSecretRef?.name,
     },
     lifetime: clusterClaim?.spec?.lifetime,
   }


### PR DESCRIPTION
Regarding: https://issues.redhat.com/browse/ACM-9664


Adding optional chaining to clusterDeployment reference and optional field to its type definition.