### PR TITLE
ACM-9914: Fix add nodepool tooltip text to use hcp CLI

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -397,7 +397,7 @@
   "Add namespace": "Add namespace",
   "Add new hosts": "Add new hosts",
   "Add node pool": "Add node pool",
-  "Add node pool is only supported for AWS. Use the HyperShift CLI to add additional node pools.": "Add node pool is only supported for AWS. Use the HyperShift CLI to add additional node pools.",
+  "Add node pool is only supported for AWS. Use the hcp CLI to add additional node pools.": "Add node pool is only supported for AWS. Use the hcp CLI to add additional node pools.",
   "Add placement": "Add placement",
   "Add placement binding": "Add placement binding",
   "Add placement rule": "Add placement rule",

--- a/frontend/public/locales/ja/translation.json
+++ b/frontend/public/locales/ja/translation.json
@@ -389,7 +389,7 @@
   "Add namespace": "namespace の追加",
   "Add new hosts": "新規ホストの追加",
   "Add node pool": "ノードプールの追加",
-  "Add node pool is only supported for AWS. Use the HyperShift CLI to add additional node pools.": "ノードプールの追加は、AWS でのみサポートされています。HyperShift CLI を使用して、追加のノードプールを追加します。",
+  "Add node pool is only supported for AWS. Use the hcp CLI to add additional node pools.": "ノードプールの追加は、AWS hcp CLI を使用して、追加のノードプールを追加します。",
   "Add placement": "配置の追加",
   "Add placement binding": "配置バインディングの追加",
   "Add placement rule": "配置ルールの追加",

--- a/frontend/public/locales/ko/translation.json
+++ b/frontend/public/locales/ko/translation.json
@@ -389,7 +389,7 @@
   "Add namespace": "네임스페이스 추가",
   "Add new hosts": "새 호스트 추가",
   "Add node pool": "노드 풀 추가",
-  "Add node pool is only supported for AWS. Use the HyperShift CLI to add additional node pools.": "노드 풀 추가는 AWS에서만 지원됩니다. HyperShift CLI를 사용하여 노드 풀을 추가합니다.",
+  "Add node pool is only supported for AWS. Use the hcp CLI to add additional node pools.": "노드 풀 추가는 AWS에서만 지원됩니다. hcp CLI를 사용하여 노드 풀을 추가합니다.",
   "Add placement": "배치 추가",
   "Add placement binding": "배치 바인딩 추가",
   "Add placement rule": "배치 규칙 추가",

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -389,7 +389,7 @@
   "Add namespace": "添加命名空间",
   "Add new hosts": "添加新主机",
   "Add node pool": "添加节点池",
-  "Add node pool is only supported for AWS. Use the HyperShift CLI to add additional node pools.": "仅 AWS 支持添加节点池。使用 HyperShift CLI 添加额外节点池。",
+  "Add node pool is only supported for AWS. Use the hcp CLI to add additional node pools.": "仅 AWS 支持添加节点池。使用 hcp CLI 添加额外节点池。",
   "Add placement": "添加放置",
   "Add placement binding": "添加放置绑定",
   "Add placement rule": "添加放置规则",

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.tsx
@@ -99,7 +99,7 @@ const NodePoolsProgress = ({ nodePools, ...rest }: NodePoolsProgressProps) => {
 
   const addNodePoolStatusMessage = useMemo(() => {
     if (hostedCluster?.spec?.platform?.type !== HypershiftCloudPlatformType.AWS) {
-      return t('Add node pool is only supported for AWS. Use the HyperShift CLI to add additional node pools.')
+      return t('Add node pool is only supported for AWS. Use the hcp CLI to add additional node pools.')
     }
     if (cluster?.hypershift?.isUpgrading) {
       return t('Node pools cannot be added during hosted cluster upgrade.')

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsTable.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsTable.tsx
@@ -249,7 +249,7 @@ const NodePoolsTable = ({ nodePools, clusterImages }: NodePoolsTableProps): JSX.
 
   const addNodePoolStatusMessage = useMemo(() => {
     if (hostedCluster?.spec?.platform?.type !== HypershiftCloudPlatformType.AWS) {
-      return t('Add node pool is only supported for AWS. Use the HyperShift CLI to add additional node pools.')
+      return t('Add node pool is only supported for AWS. Use the hcp CLI to add additional node pools.')
     }
     if (cluster?.hypershift?.isUpgrading) {
       return t('Node pools cannot be added during hosted cluster upgrade.')


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9914

Fix the add node pool tool tip text to use `hcp` CLI.