### PR TITLE
ACM-9906 Default namespace to clusters for KubeVirt

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/kubevirt-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/kubevirt-template.hbs
@@ -3,7 +3,7 @@ apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster
 metadata:
   name: '{{{clusterName}}}'
-  namespace: '{{{clusterName}}}'
+  namespace: 'clusters'
   labels:
   {{#if clusterSet}}
     "cluster.open-cluster-management.io/clusterset": '{{{clusterSet}}}'
@@ -55,7 +55,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: pullsecret-cluster-{{{clusterName}}}
-  namespace: {{{clusterName}}}
+  namespace: clusters
 data:
   '.dockerconfigjson': {{{pullSecret}}}
 type: kubernetes.io/dockerconfigjson
@@ -65,7 +65,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: sshkey-cluster-{{{clusterName}}}
-  namespace: '{{{clusterName}}}'
+  namespace: 'clusters'
 stringData:
   id_rsa.pub: {{{ssh-publickey}}}
 
@@ -75,7 +75,7 @@ apiVersion: hypershift.openshift.io/v1beta1
 kind: NodePool
 metadata:
   name: '{{{this.nodePoolName}}}'
-  namespace: '{{{@root.clusterName}}}'
+  namespace: 'clusters'
 spec:
   arch: amd64
   clusterName: '{{{@root.clusterName}}}'


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-9906

The hostedclusters created from the UI is created in their own namespace whereas hostedclusters created from the CLI is in clusters namespace. When a managedcluster CR gets deleted, I think there's a CLC controller that goes and deletes the namespace with the same name as the managedcluster and because the hostedcluster CR is in that namespace the hostedcluster get deleted as well. For now we will just default the namespace to clusters.

- Default namespace to clusters for KubeVirt