### PR TITLE
ACM-10148 Fix KubeVirt ui creation fails if clusters ns doesn't exist

### DIFF
--- a/frontend/src/lib/create-cluster.ts
+++ b/frontend/src/lib/create-cluster.ts
@@ -75,7 +75,9 @@ export async function createCluster(resources: any[]) {
   response = await Promise.allSettled(results.map((result: any) => result.promise))
   response.forEach((result) => {
     if (result.status === 'rejected') {
-      errors.push({ message: result.reason.message })
+      if (result.reason && !result.reason.message.startsWith('namespaces "clusters" already exists')) {
+        errors.push({ message: result.reason.message })
+      }
     }
   })
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/kubevirt-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/kubevirt-template.hbs
@@ -1,3 +1,7 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: clusters
 ---
 apiVersion: hypershift.openshift.io/v1beta1
 kind: HostedCluster


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10148

- Add project to YAML template
- Ignore namespace already exists error

This is not the best solution, need to revisit https://github.com/stolostron/console/blob/main/frontend/src/lib/create-cluster.ts in the next release for a better fix. I'm hesitant to making too many changes this late in the releaase in create-cluster.ts as it involves the Agent HostedCluster as well.