### PR TITLE
Remove 'View YAML' link when resource is unnamed

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
@@ -255,8 +255,8 @@ export function PolicyTemplateDetails(props: {
           ) {
             return ''
           }
-          if (cluster && kind && apiVersion && name) {
-            const nameArg = name != '*' ? `&name=${name}` : ''
+          if (cluster && kind && apiVersion && (name && name != '*' && name != '-')) {
+            const nameArg = `&name=${name}`
             const namespaceArg = namespace ? `&namespace=${namespace}` : ''
             return (
               <a


### PR DESCRIPTION
In some situations, a policy will list a group of objects as related to the policy via the name `-` or `*`. In those cases, linking to a YAML list of all of those objects is not generally helpful, since that list is not filtered by other details in the policy.

Refs:
 - https://issues.redhat.com/browse/ACM-10202