### PR TITLE
Fix the resource not found bug after creating policy submit

### DIFF
--- a/frontend/public/locales/ko/translation.json
+++ b/frontend/public/locales/ko/translation.json
@@ -525,7 +525,7 @@
   "B-series burstable virtual machine sizes": "B 시리즈 버스트 가능 가상 머신 크기",
   "back": "이전",
   "Back": "이전",
-  "Back to policies": "정책으로 돌아가기",
+  "Back to policies": "정책리스트으로 돌아가기",
   "background": "배경",
   "Bad gateway": "잘못된 게이트웨이",
   "Bad request": "잘못된 요청",


### PR DESCRIPTION
Description of problem:

Drafted a policy and clicked "Submit" on the console. The console would intermittently be redirected to a "resources not found" page (see attachment.) However, once the policy page has been refreshed, the deployed policy did show up.

Ref: https://issues.redhat.com/browse/ACM-10416