### PR TITLE
chore: CVE-2024-28849 | update deps to bring follow-redirects pkg to latest

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "@octokit/rest": "19.0.3",
         "@octokit/types": "6.40.0",
         "@openshift-assisted/locales": "2.10.2-cim",
-        "@openshift-assisted/ui-lib": "2.10.2-cim",
+        "@openshift-assisted/ui-lib": "^2.10.2-cim",
         "@patternfly-labs/react-form-wizard": "^1.27.0",
         "@patternfly/patternfly": "4.196.7",
         "@patternfly/react-charts": "^6.74.3",
@@ -4984,9 +4984,9 @@
       }
     },
     "node_modules/@openshift-assisted/ui-lib/node_modules/swr": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.4.tgz",
-      "integrity": "sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
       "dependencies": {
         "client-only": "^0.0.1",
         "use-sync-external-store": "^1.2.0"
@@ -5140,9 +5140,9 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5570,9 +5570,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "3.11.10",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.11.10.tgz",
-      "integrity": "sha512-mpEBGluL6R4e8UZbMjTv7FuXbvuxLNLCvCc/NBIKZ5QyzsuMvEo8alZJ6n718whGIQq8Bc0dpxuoGNbbrHdFvQ==",
+      "version": "3.11.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.11.11.tgz",
+      "integrity": "sha512-JCdI6Ybjudih8DzUnA/LHKa6zXAwSeUyQ7MLNFesxhShbUQfiGMP4rOU1Xpz5bqijghvzt6lfWaRMhyJFcbFXA==",
       "dependencies": {
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
         "@redhat-cloud-services/types": "^0.0.24",
@@ -14780,9 +14780,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.17.43",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
+      "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -23956,9 +23956,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -35970,9 +35970,9 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.11.0.tgz",
-      "integrity": "sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
+      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -40665,9 +40665,9 @@
       }
     },
     "node_modules/webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^2.0.10",
@@ -44690,9 +44690,9 @@
           }
         },
         "swr": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.4.tgz",
-          "integrity": "sha512-njiZ/4RiIhoOlAaLYDqwz5qH/KZXVilRLvomrx83HjzCWTfa+InyfAjv05PSFxnmLzZkNO9ZfvgoqzAaEI4sGQ==",
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+          "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
           "requires": {
             "client-only": "^0.0.1",
             "use-sync-external-store": "^1.2.0"
@@ -44825,9 +44825,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -45132,9 +45132,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "3.11.10",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.11.10.tgz",
-      "integrity": "sha512-mpEBGluL6R4e8UZbMjTv7FuXbvuxLNLCvCc/NBIKZ5QyzsuMvEo8alZJ6n718whGIQq8Bc0dpxuoGNbbrHdFvQ==",
+      "version": "3.11.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.11.11.tgz",
+      "integrity": "sha512-JCdI6Ybjudih8DzUnA/LHKa6zXAwSeUyQ7MLNFesxhShbUQfiGMP4rOU1Xpz5bqijghvzt6lfWaRMhyJFcbFXA==",
       "requires": {
         "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
         "@redhat-cloud-services/types": "^0.0.24",
@@ -52116,9 +52116,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.17.43",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.43.tgz",
+      "integrity": "sha512-oaYtiBirUOPQGSWNGPWnzyAFJ0BP3cwvN4oWZQY+zUBwpVIGsKUkpBpSztp74drYcjavs7SKFZ4DX1V2QeN8rg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -59462,9 +59462,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.15.5",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
-      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -68624,9 +68624,9 @@
       }
     },
     "sanitize-html": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.11.0.tgz",
-      "integrity": "sha512-BG68EDHRaGKqlsNjJ2xUB7gpInPA8gVx/mvjO743hZaeMCZ2DwzW7xvsqZ+KNU4QKwj86HJ3uu2liISf2qBBUA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
+      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
       "requires": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -72318,9 +72318,9 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
-      "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz",
+      "integrity": "sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==",
       "dev": true,
       "requires": {
         "colorette": "^2.0.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "@octokit/rest": "19.0.3",
     "@octokit/types": "6.40.0",
     "@openshift-assisted/locales": "2.10.2-cim",
-    "@openshift-assisted/ui-lib": "2.10.2-cim",
+    "@openshift-assisted/ui-lib": "^2.10.2-cim",
     "@patternfly-labs/react-form-wizard": "^1.27.0",
     "@patternfly/patternfly": "4.196.7",
     "@patternfly/react-charts": "^6.74.3",


### PR DESCRIPTION
Related issue: https://issues.redhat.com/browse/ACM-10466

Commands:
```shell
npm uninstall axios webpack-dev-server
npm uninstall @openshift-assisted/ui-lib @pmmmwh/react-refresh-webpack-plugin
npm uninstall @redhat-cloud-services/rule-components @types/webpack-dev-server

npm install @openshift-assisted/ui-lib@2.10.2-cim @redhat-cloud-services/rule-components@3.2.6 axios@0.27.2
npm install @pmmmwh/react-refresh-webpack-plugin@0.5.7 @types/webpack-dev-server@4.7.1 webpack-dev-server@4.9.3 --save-dev
``` 
| Before  | After |
| ------------- | ------------- |
| ![Screenshot 2024-03-19 at 4 18 25 PM](https://github.com/stolostron/console/assets/10394596/a8c1daf5-c189-44ac-8bbe-d4d161935c99)  | ![Screenshot 2024-03-19 at 4 18 35 PM](https://github.com/stolostron/console/assets/10394596/cd628b04-608c-4547-9726-0df7c442f83c)  |
