### PR TITLE
Update the policy table name Cluster Violations to Cluster Compliance

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -660,6 +660,7 @@
   "Cluster 2": "Cluster 2",
   "Cluster add-ons": "Cluster add-ons",
   "Cluster claim expressions": "Cluster claim expressions",
+  "Cluster compliance": "Cluster compliance",
   "Cluster Conditions": "Cluster Conditions",
   "Cluster decision resource requeue time in seconds": "Cluster decision resource requeue time in seconds",
   "Cluster deploy status": "Cluster deploy status",

--- a/frontend/src/routes/Governance/governance.sharedMocks.tsx
+++ b/frontend/src/routes/Governance/governance.sharedMocks.tsx
@@ -402,6 +402,49 @@ const pendingPolicy0: Policy = {
   },
 }
 
+const policyForOrder1: Policy = {
+  apiVersion: 'policy.open-cluster-management.io/v1',
+  kind: 'Policy',
+  metadata: {
+    name: 'policy-test-order',
+    namespace: 'test',
+    uid: '20761783-5b48-4f9c-b12c-d5a6b2fac4b5',
+    managedFields: [
+      {
+        manager: 'argocd',
+      },
+    ],
+  },
+  spec: {
+    disabled: true,
+    'policy-templates': [
+      {
+        objectDefinition: {
+          apiVersion: 'policy.open-cluster-management.io/v1',
+          kind: 'ConfigurationPolicy',
+          metadata: { name: 'policy-test-order-1' },
+          spec: {
+            namespaceSelector: { exclude: ['kube-*'], include: ['default'] },
+            remediationAction: 'inform',
+            severity: 'low',
+          },
+        },
+      },
+    ],
+    remediationAction: 'inform',
+  },
+  status: {
+    compliant: 'Compliant',
+    placement: [
+      {
+        placement: 'policy-set-with-1-placement',
+        placementBinding: 'policy-set-with-1-placement',
+        policySet: 'policy-set-with-1-placement',
+      },
+    ],
+    status: [{ clustername: 'local-cluster', clusternamespace: 'local-cluster', compliant: 'Compliant' }],
+  },
+}
 const policyWithoutStatus: Policy = {
   apiVersion: PolicyApiVersion,
   kind: PolicyKind,
@@ -760,6 +803,7 @@ export const mockEmptyPolicy: Policy[] = []
 export const mockPolicy: Policy[] = [rootPolicy, policy0, policy1]
 export const mockPolicyBinding: Policy[] = [rootPolicy, policy2]
 export const mockPendingPolicy: Policy[] = [pendingPolicy, pendingPolicy0]
+export const mockOrderPolicy: Policy[] = [pendingPolicy, policyForOrder1]
 
 export const mockPolicyNoStatus: Policy = policyWithoutStatus
 

--- a/frontend/src/routes/Governance/policies/Policies.test.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.test.tsx
@@ -58,7 +58,7 @@ describe('Policies Page', () => {
     await waitForText(mockPolicy[0].metadata.name!)
 
     // Sorting
-    screen.getByRole('button', { name: 'Cluster violations' }).click()
+    screen.getByRole('button', { name: 'Cluster compliance' }).click()
     screen.getByRole('button', { name: 'Namespace' }).click()
     screen.getByRole('button', { name: 'Name' }).click()
 
@@ -86,7 +86,7 @@ describe('Policies Page', () => {
     await waitForText('Name')
     await waitForText('Namespace')
     await waitForText('Remediation')
-    await waitForText('Cluster violations')
+    await waitForText('Cluster compliance')
     await waitForText('Source')
     await waitForText('Policy set')
     expect(screen.queryByRole('columnheader', { name: /Status/ })).not.toBeInTheDocument()
@@ -136,7 +136,7 @@ describe('Policies Page', () => {
         '/multicloud/governance/policy-sets?search%3D%7B%22name%22%3A%5B%22policy-set-with-1-placement%22%5D%2C%22namespace%22%3A%5B%22test%22%5D%7D'
       )
     )
-    // Verify the Cluster violation column has the correct link to policy details page
+    // Verify the Cluster compliance column has the correct link to policy details page
     await waitFor(() =>
       // need to use index [1] because the name column is also an "a" element
       expect(container.querySelectorAll('a')[2]).toHaveAttribute(

--- a/frontend/src/routes/Governance/policies/Policies.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.tsx
@@ -40,6 +40,10 @@ import {
   hasInformOnlyPolicies,
   getPlacementBindingsForResource,
   getPlacementsForResource,
+  getSource,
+  PolicySetList, 
+  resolveExternalStatus,
+  resolveSource 
 } from '../common/util'
 import { checkPermission, rbacCreate, rbacUpdate, rbacPatch } from '../../../lib/rbac-util'
 import { transformBrowserUrlToFilterPresets } from '../../../lib/urlQuery'
@@ -56,7 +60,6 @@ import {
   replaceResource,
 } from '../../../resources'
 import { getResourceLabel } from '../../Applications/helpers/resource-helper'
-import { getSource, PolicySetList, resolveExternalStatus, resolveSource } from '../common/util'
 import { AutomationDetailsSidebar } from '../components/AutomationDetailsSidebar'
 import { ClusterPolicyViolationIcons2 } from '../components/ClusterPolicyViolations'
 import { GovernanceCreatePolicyEmptyState } from '../components/GovernanceEmptyState'
@@ -406,7 +409,7 @@ export default function PoliciesPage() {
         id: 'add-to-set',
         title: t('policy.table.actions.addToPolicySet'),
         click: (item) => {
-          setModal(<AddToPolicySetModal policyTableItems={...item} onClose={() => setModal(undefined)} />)
+          setModal(<AddToPolicySetModal policyTableItems={[...item]} onClose={() => setModal(undefined)} />)
         },
         tooltip: t('Add to policy set'),
         isDisabled: !canPatchPolicy,
@@ -621,7 +624,7 @@ export default function PoliciesPage() {
     () => [
       {
         id: 'violations',
-        label: 'Cluster violations',
+        label: 'Cluster compliance',
         options: [
           {
             label: t('Without violations'),
@@ -722,7 +725,7 @@ export default function PoliciesPage() {
           { label: t('Inform/Enforce/InformOnly'), value: 'inform/enforce/informOnly' },
         ],
         tableFilterFn: (selectedValues, item) => {
-          const policyRemediation = item.policy.remediationResult?.replace(' (overridden)', '') || ''
+          const policyRemediation = item.policy.remediationResult?.replace(' (overridden)', '') ?? ''
           return selectedValues.includes(policyRemediation)
         },
       },
@@ -857,7 +860,7 @@ function usePolicyViolationsColumn(
 ): IAcmTableColumn<PolicyTableItem> {
   const { t } = useTranslation()
   return {
-    header: t('Cluster violations'),
+    header: t('Cluster compliance'),
     cell: (item) => {
       const clusterViolationSummary = policyClusterViolationSummaryMap[item.policy.metadata.uid ?? '']
       if (

--- a/frontend/src/routes/Governance/policies/PolicyTableCell.tsx
+++ b/frontend/src/routes/Governance/policies/PolicyTableCell.tsx
@@ -1,0 +1,133 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { PolicyAutomation, PolicySet } from '../../../resources'
+import { PolicyTableItem } from './Policies'
+import { NavigationPath } from '../../../NavigationPath'
+import { Link } from 'react-router-dom'
+import { t } from 'i18next'
+import { PolicySetList } from '../common/util'
+import moment from 'moment'
+import { PolicyActionDropdown } from '../components/PolicyActionDropdown'
+import { AcmButton } from '../../../ui-components/AcmButton'
+import { AutomationDetailsSidebar } from '../components/AutomationDetailsSidebar'
+import { ButtonVariant } from '@patternfly/react-core'
+
+export function handleNameCell(item: PolicyTableItem) {
+  return (
+    <Link
+      to={{
+        pathname: NavigationPath.policyDetails
+          .replace(':namespace', item.policy.metadata.namespace as string)
+          .replace(':name', item.policy.metadata.name as string),
+        state: {
+          from: NavigationPath.policies,
+        },
+      }}
+    >
+      {item.policy.metadata.name}
+    </Link>
+  )
+}
+
+export function handleStatusCell(item: PolicyTableItem) {
+  const disabled: string = t('Disabled')
+  const enabled: string = t('Enabled')
+  return <span>{item.policy.spec.disabled === true ? disabled : enabled}</span>
+}
+
+export function handlePolicySetCell(item: PolicyTableItem, policySets: PolicySet[]) {
+  const policySetsMatch = policySets.filter(
+    (policySet: PolicySet) =>
+      policySet.metadata.namespace === item.policy.metadata.namespace &&
+      policySet.spec.policies.includes(item.policy.metadata.name!)
+  )
+  if (policySetsMatch.length > 0) {
+    return <PolicySetList policySets={policySetsMatch} />
+  }
+  return '-'
+}
+
+export function handleCreatedCell(item: PolicyTableItem) {
+  if (item.policy.metadata?.creationTimestamp) {
+    return <span>{moment(new Date(item.policy.metadata?.creationTimestamp)).fromNow()}</span>
+  }
+  return '-'
+}
+
+export function handleBtnCell(item: PolicyTableItem, setModal: (modal: React.ReactNode) => void) {
+  return <PolicyActionDropdown setModal={setModal} item={item} isKebab={true} />
+}
+
+export function handleActionGroupCell(item: PolicyTableItem) {
+  const disabled: string = t('policy.table.actionGroup.status.disabled')
+  const enabled: string = t('policy.table.actionGroup.status.enabled')
+  return <span>{item.policy.spec.disabled === true ? disabled : enabled}</span>
+}
+
+export function handleAutomationCell(
+  item: PolicyTableItem,
+  policyAutomations: PolicyAutomation[],
+  canUpdatePolicyAutomation: boolean,
+  unauthorizedMessage: string,
+  setDrawerContext: any,
+  setModal: any,
+  canCreatePolicyAutomation: boolean
+) {
+  const policyAutomationMatch = policyAutomations.find(
+    (pa: PolicyAutomation) => pa.spec.policyRef === item.policy.metadata.name
+  )
+  const configure: string = t('Configure')
+
+  if (policyAutomationMatch) {
+    return (
+      <AcmButton
+        isDisabled={!canUpdatePolicyAutomation}
+        tooltip={!canUpdatePolicyAutomation ? unauthorizedMessage : ''}
+        isInline
+        variant={ButtonVariant.link}
+        onClick={() =>
+          setDrawerContext({
+            isExpanded: true,
+            onCloseClick: () => {
+              setDrawerContext(undefined)
+            },
+            title: policyAutomationMatch.metadata.name,
+            panelContent: (
+              <AutomationDetailsSidebar
+                setModal={setModal}
+                policyAutomationMatch={policyAutomationMatch}
+                policy={item.policy}
+                onClose={() => setDrawerContext(undefined)}
+              />
+            ),
+            panelContentProps: { defaultSize: '40%' },
+            isInline: true,
+            isResizable: true,
+          })
+        }
+      >
+        {policyAutomationMatch.metadata.name}
+      </AcmButton>
+    )
+  } else {
+    return (
+      <AcmButton
+        isDisabled={!canCreatePolicyAutomation}
+        tooltip={!canCreatePolicyAutomation ? unauthorizedMessage : ''}
+        isInline
+        variant={ButtonVariant.link}
+        component={Link}
+        to={{
+          pathname: NavigationPath.createPolicyAutomation
+            .replace(':namespace', item.policy.metadata.namespace as string)
+            .replace(':name', item.policy.metadata.name as string),
+          state: {
+            from: NavigationPath.policies,
+          },
+        }}
+      >
+        {configure}
+      </AcmButton>
+    )
+  }
+}


### PR DESCRIPTION
Currently it is named "Cluster Violations." It is confusing because the naming is not neutral while it generates "Violations" and "Non violations"
Update the name: "Cluster violations" to "**Cluster compliance**." Accordingly we could get the results as "Compliant" and "Non-compliant."

+

There were multiple issues with the sonar cloud.
- Coverage issues
- Code Complexity 
- Deep code 
etc 
This PR will fix these issues

Ref: https://issues.redhat.com/browse/ACM-3338