### PR TITLE
ACM-10317 Use custom table headers for search result export when only 1 resourc…

### DIFF
--- a/frontend/src/routes/Home/Search/Details/RelatedResourceDetailsTab.tsx
+++ b/frontend/src/routes/Home/Search/Details/RelatedResourceDetailsTab.tsx
@@ -91,7 +91,7 @@ export default function RelatedResourceDetailsTab(props: {
           emptyState={undefined} // table only shown for kinds with related resources
           columns={_.get(
             searchDefinitions,
-            `[${kind.toLowerCase()}].columns`,
+            `['${kind.toLowerCase()}'].columns`,
             searchDefinitions['genericresource'].columns
           )}
           keyFn={(item: any) => item._uid.toString()}

--- a/frontend/src/routes/Home/Search/SearchResults/RelatedResults.tsx
+++ b/frontend/src/routes/Home/Search/SearchResults/RelatedResults.tsx
@@ -42,7 +42,7 @@ export function RenderItemContent(props: {
   const searchDefinitions = useSearchDefinitions()
   const colDefs = _.get(
     searchDefinitions,
-    `[${relatedKind.toLowerCase()}].columns`,
+    `['${relatedKind.toLowerCase()}'].columns`,
     searchDefinitions['genericresource'].columns
   )
   const relatedResultItems = useMemo(() => data?.searchResult?.[0]?.related?.[0]?.items || [], [data])

--- a/frontend/src/routes/Home/Search/SearchResults/SearchResults.tsx
+++ b/frontend/src/routes/Home/Search/SearchResults/SearchResults.tsx
@@ -81,7 +81,11 @@ function RenderAccordionItem(props: {
         <AcmTable
           items={items}
           emptyState={undefined} // table only shown for kinds with results
-          columns={_.get(searchDefinitions, `[${kindAndGroup}].columns`, searchDefinitions['genericresource'].columns)}
+          columns={_.get(
+            searchDefinitions,
+            `['${kindAndGroup}'].columns`,
+            searchDefinitions['genericresource'].columns
+          )}
           keyFn={(item: any) => item._uid.toString()}
           rowActions={
             isGlobalHub && settings.globalSearchFeatureFlag && settings.globalSearchFeatureFlag === 'enabled'

--- a/frontend/src/routes/Home/Search/SearchResults/utils.test.tsx
+++ b/frontend/src/routes/Home/Search/SearchResults/utils.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 import i18next from 'i18next'
+import { getSearchDefinitions } from '../searchDefinitions'
 import { generateSearchResultExport, GetRowActions } from './utils'
 
 const mockHistoryPush = jest.fn()
@@ -45,7 +46,7 @@ test('Correctly return empty row Actions for Application', () => {
   expect(res).toMatchSnapshot()
 })
 
-test('generateSearchResultExport - Correctly generates and triggers csv download', () => {
+test('generateSearchResultExport - Correctly generates and triggers csv download for single resource kind', () => {
   const toastContextMock: any = {
     addAlert: jest.fn(),
   }
@@ -57,24 +58,69 @@ test('generateSearchResultExport - Correctly generates and triggers csv download
       {
         items: [
           {
-            _hubClusterResource: 'true',
-            _ownerUID: 'local-cluster/1234-abcd',
-            _uid: 'local-cluster/1234-abcd',
-            apiversion: 'v1',
+            apigroup: 'operators.coreos.com',
+            apiversion: 'v1alpha1',
+            channel: 'release-2.11',
             cluster: 'local-cluster',
-            container: 'search-postgres',
-            created: '2024-04-15T14:23:59Z',
-            hostIP: '10.0.68.86',
-            image: 'quay.io/image',
-            kind: 'Pod',
-            kind_plural: 'pods',
-            label: 'app=search; component=search-v2-operator; name=search-postgres; pod-template-hash=d7778bcb6',
-            name: 'search-postgres-d7778bcb6-bf7xq',
+            created: '2024-04-15T14:20:26Z',
+            installplan: 'advanced-cluster-management.v2.11.0',
+            kind: 'Subscription',
+            kind_plural: 'subscriptions',
+            label: 'operators.coreos.com/advanced-cluster-management.open-cluster-management=',
+            name: 'acm-operator-subscription',
             namespace: 'open-cluster-management',
-            podIP: '10.129.0.116',
-            restarts: '0',
-            startedAt: '2024-04-15T14:23:59Z',
-            status: 'Running',
+            package: 'advanced-cluster-management',
+            phase: 'AtLatestKnown',
+            source: 'acm-custom-registry',
+          },
+        ],
+        __typename: 'SearchResult',
+      },
+    ],
+  }
+
+  const searchDefinitions = getSearchDefinitions((key) => key)
+  generateSearchResultExport(searchResultDataMock, searchDefinitions, toastContextMock, t)
+
+  expect(toastContextMock.addAlert).toHaveBeenCalledWith({
+    title: 'Generating data. Download may take a moment to start.',
+    type: 'info',
+    autoClose: true,
+  })
+  expect(window.URL.createObjectURL).toHaveBeenCalledTimes(1)
+  expect(toastContextMock.addAlert).toHaveBeenCalledWith({
+    title: 'Export successful',
+    type: 'success',
+    autoClose: true,
+  })
+})
+
+test('generateSearchResultExport - Correctly generates and triggers csv download for multi resource kind', () => {
+  const toastContextMock: any = {
+    addAlert: jest.fn(),
+  }
+  const t = (key: string) => key
+  window.URL.createObjectURL = jest.fn()
+
+  const searchResultDataMock = {
+    searchResult: [
+      {
+        items: [
+          {
+            apigroup: 'operators.coreos.com',
+            apiversion: 'v1alpha1',
+            channel: 'release-2.11',
+            cluster: 'local-cluster',
+            created: '2024-04-15T14:20:26Z',
+            installplan: 'advanced-cluster-management.v2.11.0',
+            kind: 'Subscription',
+            kind_plural: 'subscriptions',
+            label: 'operators.coreos.com/advanced-cluster-management.open-cluster-management=',
+            name: 'acm-operator-subscription',
+            namespace: 'open-cluster-management',
+            package: 'advanced-cluster-management',
+            phase: 'AtLatestKnown',
+            source: 'acm-custom-registry',
           },
           {
             _hubClusterResource: 'true',
@@ -121,7 +167,8 @@ test('generateSearchResultExport - Correctly generates and triggers csv download
     ],
   }
 
-  generateSearchResultExport(searchResultDataMock, toastContextMock, t)
+  const searchDefinitions = getSearchDefinitions((key) => key)
+  generateSearchResultExport(searchResultDataMock, searchDefinitions, toastContextMock, t)
 
   expect(toastContextMock.addAlert).toHaveBeenCalledWith({
     title: 'Generating data. Download may take a moment to start.',

--- a/frontend/src/routes/Home/Search/__snapshots__/searchDefinitions.test.tsx.snap
+++ b/frontend/src/routes/Home/Search/__snapshots__/searchDefinitions.test.tsx.snap
@@ -1924,7 +1924,7 @@ Array [
 ]
 `;
 
-exports[`Correctly returns all resource definitions: SearchDefinitions-subscription.operators.coreos.io 1`] = `
+exports[`Correctly returns all resource definitions: SearchDefinitions-subscription.operators.coreos.com 1`] = `
 Array [
   Object {
     "cell": <CreateDetailsLink

--- a/frontend/src/routes/Home/Search/components/Searchbar.tsx
+++ b/frontend/src/routes/Home/Search/components/Searchbar.tsx
@@ -26,6 +26,7 @@ import { useSharedAtoms } from '../../../../shared-recoil'
 import { AcmButton, AcmChip, AcmChipGroup, AcmToastContext } from '../../../../ui-components'
 import { operators } from '../search-helper'
 import { SearchResultItemsQuery } from '../search-sdk/search-sdk'
+import { useSearchDefinitions } from '../searchDefinitions'
 import { generateSearchResultExport } from '../SearchResults/utils'
 import { transformBrowserUrlToSearchString } from '../urlQuery'
 
@@ -90,6 +91,7 @@ export function Searchbar(props: SearchbarProps) {
     refetchSearch,
   } = props
   const history = useHistory()
+  const searchDefinitions = useSearchDefinitions()
   const toast = useContext(AcmToastContext)
   const [inputValue, setInputValue] = useState('')
   const [menuIsOpen, setMenuIsOpen] = useState(false)
@@ -492,7 +494,7 @@ export function Searchbar(props: SearchbarProps) {
             <DropdownItem
               style={{ width: '10rem' }}
               key={'item.text'}
-              onClick={() => generateSearchResultExport(searchResultData, toast, t)}
+              onClick={() => generateSearchResultExport(searchResultData, searchDefinitions, toast, t)}
               isDisabled={window.location.search === ''}
             >
               {t('Export as CSV')}

--- a/frontend/src/routes/Home/Search/searchDefinitions.tsx
+++ b/frontend/src/routes/Home/Search/searchDefinitions.tsx
@@ -15,7 +15,48 @@ import { NavigationPath } from '../../../NavigationPath'
 import { useRecoilState, useRecoilValue, useSharedAtoms } from '../../../shared-recoil'
 import { AcmLabels } from '../../../ui-components'
 
-export const getSearchDefinitions = (t: TFunction) => {
+export interface SearchDefinitions {
+  (t: TFunction): ResourceDefinitions
+}
+export interface ResourceDefinitions {
+  application: Record<'columns', SearchColumnDefinition[]>
+  cluster: Record<'columns', SearchColumnDefinition[]>
+  clusteroperator: Record<'columns', SearchColumnDefinition[]>
+  clusterserviceversion: Record<'columns', SearchColumnDefinition[]>
+  channel: Record<'columns', SearchColumnDefinition[]>
+  cronjob: Record<'columns', SearchColumnDefinition[]>
+  daemonset: Record<'columns', SearchColumnDefinition[]>
+  deployable: Record<'columns', SearchColumnDefinition[]>
+  deployment: Record<'columns', SearchColumnDefinition[]>
+  genericresource: Record<'columns', SearchColumnDefinition[]>
+  helmrelease: Record<'columns', SearchColumnDefinition[]>
+  job: Record<'columns', SearchColumnDefinition[]>
+  namespace: Record<'columns', SearchColumnDefinition[]>
+  node: Record<'columns', SearchColumnDefinition[]>
+  persistentvolume: Record<'columns', SearchColumnDefinition[]>
+  persistentvolumeclaim: Record<'columns', SearchColumnDefinition[]>
+  placementbinding: Record<'columns', SearchColumnDefinition[]>
+  placementpolicy: Record<'columns', SearchColumnDefinition[]>
+  placementrule: Record<'columns', SearchColumnDefinition[]>
+  pod: Record<'columns', SearchColumnDefinition[]>
+  policy: Record<'columns', SearchColumnDefinition[]>
+  policyreport: Record<'columns', SearchColumnDefinition[]>
+  release: Record<'columns', SearchColumnDefinition[]>
+  replicaset: Record<'columns', SearchColumnDefinition[]>
+  secret: Record<'columns', SearchColumnDefinition[]>
+  service: Record<'columns', SearchColumnDefinition[]>
+  statefulset: Record<'columns', SearchColumnDefinition[]>
+  'subscription.apps.open-cluster-management.io': Record<'columns', SearchColumnDefinition[]>
+  'subscription.operators.coreos.com': Record<'columns', SearchColumnDefinition[]>
+}
+
+export interface SearchColumnDefinition {
+  header: string
+  sort?: string
+  cell: string | ((item: any) => JSX.Element | '-') | ((item: any) => string)
+}
+
+export const getSearchDefinitions: SearchDefinitions = (t: TFunction) => {
   return {
     application: {
       columns: [
@@ -314,7 +355,7 @@ export const getSearchDefinitions = (t: TFunction) => {
         AddColumn('timeWindow', t('Time window')),
       ]),
     },
-    'subscription.operators.coreos.io': {
+    'subscription.operators.coreos.com': {
       columns: AddDefaultColumns(t, [
         AddColumn('package', t('Package')),
         AddColumn('source', t('Source')),
@@ -537,7 +578,7 @@ function AddDefaultColumns(t: TFunction, customColumns: any[]) {
   ]
 }
 
-function AddColumn(key: string, localizedColumnName: string) {
+function AddColumn(key: string, localizedColumnName: string): SearchColumnDefinition {
   switch (key) {
     case 'name':
       return {


### PR DESCRIPTION
…e kind

- adds interface for searchDefinitions
- Fixes bug with search definitions - custom headers weren't working for Subscription resources.
- When exporting search results that only has one resource kind -> export will grab table headers from searchDefinitions.