### PR TITLE
ACM-11227 Support partial matching using * in searchbar suggestions

### DIFF
--- a/frontend/src/routes/Home/Search/components/Searchbar.test.tsx
+++ b/frontend/src/routes/Home/Search/components/Searchbar.test.tsx
@@ -44,6 +44,12 @@ export const BlankSearchbar = () => {
           name: 'namespace',
           kind: 'filter',
         },
+        {
+          id: 'id-label',
+          key: 'key-label',
+          name: 'label',
+          kind: 'filter',
+        },
       ]
     }
     if (lastTag && lastTag.name.includes('kind:')) {
@@ -67,6 +73,13 @@ export const BlankSearchbar = () => {
         { id: '2', name: 'namespace1', kind: 'value' },
         { id: '3', name: 'namespace2', kind: 'value' },
         { id: '4', name: 'namespace3', kind: 'value' },
+      ]
+    } else if (lastTag && lastTag.name.includes('label:')) {
+      return [
+        { id: '1', name: 'Values', kind: 'label', disabled: true },
+        { id: '2', name: 'app=search', kind: 'value' },
+        { id: '3', name: 'app=governance', kind: 'value' },
+        { id: '4', name: 'app=application', kind: 'value' },
       ]
     }
     return [{ id: '1', name: 'No filters', kind: 'label', disabled: true }]
@@ -276,6 +289,19 @@ describe('Searchbar tests', () => {
     userEvent.type(searchbar, 'name1 ')
 
     expect(screen.queryByText('name:name1')).toBeInTheDocument()
+  })
+
+  it('Searchbar should render correctly and add a partial search via typing', async () => {
+    render(<BlankSearchbar />)
+
+    const searchbar = screen.getByLabelText('Search input')
+    expect(searchbar).toBeTruthy()
+    userEvent.click(searchbar)
+
+    userEvent.type(searchbar, 'label ')
+    userEvent.type(searchbar, 'app=*rch ')
+
+    expect(screen.queryByText('label:app=*rch')).toBeInTheDocument()
   })
 
   it('Searchbar should correctly delete existing tags', async () => {

--- a/frontend/src/routes/Home/Search/components/Searchbar.tsx
+++ b/frontend/src/routes/Home/Search/components/Searchbar.tsx
@@ -197,7 +197,7 @@ export function Searchbar(props: SearchbarProps) {
     const parsedInputValue = stripOperators(inputValue)
     function handleSuggestionMark(currentValue: DropdownSuggestionsProps) {
       if (parsedInputValue.includes('*')) {
-        const replacedSpecialChars = parsedInputValue.replace(/[\/,!?_\-.<>:;"'[\]{}\\+=()!&@^#%$]/g, '\\$&') // insert \ before all special characters so Regex doesn't break in processing
+        const replacedSpecialChars = parsedInputValue.replace(/[/,!?_\-.<>:;"'[\]{}\\+=()!&@^#%$]/g, '\\$&') // insert \ before all special characters so Regex doesn't break in processing
         const regex = handlePartialRegex(replacedSpecialChars)
         const regexMatch = currentValue.name.toLowerCase().match(regex)?.[0] ?? ''
         if (regexMatch === '') {
@@ -226,7 +226,7 @@ export function Searchbar(props: SearchbarProps) {
     filteredMenuItems = suggestions
       .filter((item, index) => {
         if (parsedInputValue.includes('*')) {
-          const replacedSpecialChars = parsedInputValue.replace(/[\/,!?_\-.<>:;"'[\]{}\\+=()!&@^#%$]/g, '\\$&') // insert \ before all special characters so Regex doesn't break in processing
+          const replacedSpecialChars = parsedInputValue.replace(/[/,!?_\-.<>:;"'[\]{}\\+=()!&@^#%$]/g, '\\$&') // insert \ before all special characters so Regex doesn't break in processing
           const regex = handlePartialRegex(replacedSpecialChars)
           return (
             index !== 0 && // filter the headerItem suggestion


### PR DESCRIPTION
Supports partial string matching using `*` as key char. 
ex: 
`kind:Pod name:search-*` will match all pods that start with name `search-` (search-api, search-collector, etc.)

* - matches 0 or more chars. 
