### PR TITLE
ACM-11046 Refactor table filters

### DIFF
--- a/frontend/.storybook/preview.js
+++ b/frontend/.storybook/preview.js
@@ -16,6 +16,7 @@ import '@patternfly/react-core/dist/styles/base.css'
 import React, { Suspense, useEffect } from 'react'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '../src/lib/i18n.ts'
+import { MemoryRouter } from 'react-router-dom'
 
 // wrap stories in the I18nextProvider component
 const withI18next = (Story, context) => {
@@ -41,7 +42,9 @@ const withI18next = (Story, context) => {
 export const decorators = [
   (Story) => (
     <div style={{ height: '100vh' }}>
-      <Story />
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
     </div>
   ),
   withI18next,

--- a/frontend/src/routes/Applications/ApplicationsPage.tsx
+++ b/frontend/src/routes/Applications/ApplicationsPage.tsx
@@ -16,11 +16,11 @@ export default function ApplicationsPage() {
   const applicationsMatch = useRouteMatch()
   const advancedMatch = matchPath(location.pathname, NavigationPath.advancedConfiguration)
   const appTableFilter: any = window.localStorage.getItem('acm-table-filter.applicationTable') || '{}'
-  const appTableFilterItems = JSON.parse(appTableFilter)['table-filter-type-acm-application-label'] || []
+  const appTableFilterItems = JSON.parse(appTableFilter)['type'] || []
   const waitForSearch =
-    appTableFilterItems.includes('openshiftapps') ||
+    appTableFilterItems.includes('openshift') ||
     appTableFilterItems.includes('openshift-default') ||
-    appTableFilterItems.includes('fluxapps') ||
+    appTableFilterItems.includes('flux') ||
     !appTableFilterItems.length
 
   GetDiscoveredOCPApps(applicationsMatch.isExact, waitForSearch)

--- a/frontend/src/routes/Applications/Overview.test.tsx
+++ b/frontend/src/routes/Applications/Overview.test.tsx
@@ -170,7 +170,7 @@ describe('Applications Page', () => {
     userEvent.click(screen.getByText('Filter'))
     await waitForText('OpenShift', true)
     expect(screen.getAllByText(/openshift/i)).toBeTruthy()
-    userEvent.click(screen.queryAllByRole('checkbox', { name: /openshift/i })[0])
+    userEvent.click(screen.getByRole('checkbox', { name: /openshift/i }))
 
     // Close filter
     userEvent.click(screen.getByText('Filter'))

--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -43,7 +43,6 @@ import {
   IAcmRowAction,
   IAcmTableColumn,
 } from '../../ui-components'
-import { getResourceParams } from '../Home/Search/Details/DetailsPage'
 import { useAllClusters } from '../Infrastructure/Clusters/ManagedClusters/components/useAllClusters'
 import { getArgoDestinationCluster } from './ApplicationDetails/ApplicationTopology/model/topologyArgo'
 import { DeleteResourceModal, IDeleteResourceModalProps } from './components/DeleteResourceModal'
@@ -89,7 +88,7 @@ const labelArr: string[] = [
   'app.kubernetes.io/part-of=',
 ]
 
-const filterId = 'table-filter-type-acm-application-label'
+const filterId = 'type'
 
 type IApplicationResource = IResource | OCPAppResource
 
@@ -354,7 +353,6 @@ export function parseOcpAppResources(
 export default function ApplicationsOverview() {
   usePageVisitMetricHandler(Pages.application)
   const { t } = useTranslation()
-  const { cluster } = getResourceParams()
   const {
     applicationSetsState,
     applicationsState,
@@ -699,24 +697,24 @@ export default function ApplicationsOverview() {
         options: [
           {
             label: t('Application set'),
-            value: `${getApiVersionResourceGroup(ApplicationSetApiVersion)}/${ApplicationSetKind}`,
+            value: 'appset',
           },
           {
             label: t('Argo CD'),
-            value: `${getApiVersionResourceGroup(ArgoApplicationApiVersion)}/${ArgoApplicationKind}`,
+            value: 'argo',
           },
           {
             label: t('Flux'),
-            value: 'fluxapps',
+            value: 'flux',
           },
           {
             label: 'OpenShift',
-            value: 'openshiftapps',
+            value: 'openshift',
           },
           { label: t('Default OpenShift'), value: 'openshift-default' },
           {
             label: t('Subscription'),
-            value: `${getApiVersionResourceGroup(ApplicationApiVersion)}/${ApplicationKind}`,
+            value: 'subscription',
           },
         ],
         tableFilterFn: (selectedValues: string[], item: IApplicationResource) => {
@@ -724,7 +722,7 @@ export default function ApplicationsOverview() {
             if (isOCPAppResource(item)) {
               const isFlux = isFluxApplication(item.label)
               switch (value) {
-                case 'openshiftapps':
+                case 'openshift':
                   return (
                     !isFlux &&
                     !item.metadata?.namespace?.startsWith('openshift-') &&
@@ -735,11 +733,19 @@ export default function ApplicationsOverview() {
                     !isFlux &&
                     (item.metadata?.namespace?.startsWith('openshift-') || item.metadata?.namespace === 'openshift')
                   )
-                case 'fluxapps':
+                case 'flux':
                   return isFlux
               }
             } else {
-              return selectedValues.includes(`${getApiVersionResourceGroup(item.apiVersion)}/${item.kind}`)
+              switch (`${getApiVersionResourceGroup(item.apiVersion)}/${item.kind}`) {
+                case `${getApiVersionResourceGroup(ApplicationSetApiVersion)}/${ApplicationSetKind}`:
+                  return selectedValues.includes('appset')
+                case `${getApiVersionResourceGroup(ArgoApplicationApiVersion)}/${ArgoApplicationKind}`:
+                  return selectedValues.includes('argo')
+                case `${getApiVersionResourceGroup(ApplicationApiVersion)}/${ApplicationKind}`:
+                  return selectedValues.includes('subscription')
+              }
+              return false
             }
           })
         },
@@ -1113,7 +1119,6 @@ export default function ApplicationsOverview() {
         keyFn={keyFn}
         items={tableItems}
         filters={filters}
-        initialFilters={cluster ? { ['cluster']: [cluster] } : undefined}
         customTableAction={
           <>
             {appCreationButton}

--- a/frontend/src/routes/Governance/policies/Policies.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.tsx
@@ -43,7 +43,6 @@ import {
   resolveSource,
 } from '../common/util'
 import { checkPermission, rbacCreate, rbacUpdate, rbacPatch } from '../../../lib/rbac-util'
-import { transformBrowserUrlToFilterPresets } from '../../../lib/urlQuery'
 import { NavigationPath } from '../../../NavigationPath'
 import {
   patchResource,
@@ -81,7 +80,6 @@ export interface PolicyTableItem {
 export default function PoliciesPage() {
   const { t } = useTranslation()
   const unauthorizedMessage = t('rbac.unauthorized')
-  const presets = transformBrowserUrlToFilterPresets(window.location.search)
   const {
     channelsState,
     helmReleaseState,
@@ -648,9 +646,6 @@ export default function PoliciesPage() {
         items={tableItems}
         emptyState={undefined} // only shown when tableItems.length > 0
         tableActions={tableActions}
-        initialFilters={
-          presets.initialFilters.violations ? { violations: presets.initialFilters.violations } : undefined
-        }
         filters={filters}
         tableActionButtons={[
           {

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -563,7 +563,7 @@ export default function OverviewPage() {
   }, [cloudLabelFilter, offline, ready, t])
 
   function buildClusterAddonLinks(addonType: string): string {
-    return `${NavigationPath.managedClusters}?addons=${addonType}`
+    return `${NavigationPath.managedClusters}?add-ons=${addonType}`
   }
 
   const clusterAddonData = useMemo(() => {

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/ClusterSetActionDropdown.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/ClusterSetActionDropdown.test.tsx
@@ -22,6 +22,7 @@ import {
   waitForText,
 } from '../../../../../lib/test-util'
 import { ClusterSetActionDropdown } from './ClusterSetActionDropdown'
+import { MemoryRouter } from 'react-router-dom'
 
 const firstNamespace: Namespace = {
   apiVersion: NamespaceApiVersion,
@@ -382,7 +383,9 @@ const Component = () => (
       snapshot.set(managedClusterSetBindingsState, [firstNamespaceBinding])
     }}
   >
-    <ClusterSetActionDropdown managedClusterSet={mockManagedClusterSet} isKebab={false} />
+    <MemoryRouter>
+      <ClusterSetActionDropdown managedClusterSet={mockManagedClusterSet} isKebab={false} />
+    </MemoryRouter>
   </RecoilRoot>
 )
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterMachinePools/ClusterMachinePools.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterMachinePools/ClusterMachinePools.test.tsx
@@ -14,6 +14,7 @@ import {
   mockMachinePoolManual,
   mockMachinePoolOther,
 } from '../ClusterDetails.sharedmocks'
+import { MemoryRouter } from 'react-router-dom'
 
 describe('ClusterMachinePools', () => {
   beforeEach(() => {
@@ -25,9 +26,11 @@ describe('ClusterMachinePools', () => {
           snapshot.set(machinePoolsState, [mockMachinePoolManual, mockMachinePoolAuto, mockMachinePoolOther])
         }}
       >
-        <ClusterContext.Provider value={{ cluster: mockCluster, addons: undefined }}>
-          <MachinePoolsPageContent />
-        </ClusterContext.Provider>
+        <MemoryRouter>
+          <ClusterContext.Provider value={{ cluster: mockCluster, addons: undefined }}>
+            <MachinePoolsPageContent />
+          </ClusterContext.Provider>
+        </MemoryRouter>
       </RecoilRoot>
     )
   })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -21,7 +21,6 @@ import { Pages, usePageVisitMetricHandler } from '../../../../hooks/console-metr
 import { Trans, useTranslation } from '../../../../lib/acm-i18next'
 import { deleteCluster, detachCluster } from '../../../../lib/delete-cluster'
 import { canUser } from '../../../../lib/rbac-util'
-import { transformBrowserUrlToFilterPresets } from '../../../../lib/urlQuery'
 import { createBackCancelLocation, getClusterNavPath, NavigationPath } from '../../../../NavigationPath'
 import {
   addonPathKey,
@@ -85,7 +84,7 @@ export default function ManagedClusters() {
   const alertContext = useContext(AcmAlertContext)
   const clusters = useAllClusters(true)
 
-  const onBoardingModalID = `${window.location.href}/clusteronboardingmodal`
+  const onBoardingModalID = 'clusteronboardingmodal'
   const [openOnboardingModal, setOpenOnboardingModal] = useState<boolean>(
     localStorage.getItem(onBoardingModalID)
       ? localStorage.getItem(onBoardingModalID) === 'show'
@@ -199,7 +198,6 @@ export function ClustersTable(props: {
   const infraEnvs = useRecoilValue(infraEnvironmentsState)
 
   const { t } = useTranslation()
-  const presets = transformBrowserUrlToFilterPresets(window.location.search)
   const [upgradeClusters, setUpgradeClusters] = useState<Array<Cluster> | undefined>()
   const [updateAutomationTemplates, setUpdateAutomationTemplates] = useState<Array<Cluster> | undefined>()
   const [removeAutomationTemplates, setRemoveAutomationTemplates] = useState<Array<Cluster> | undefined>()
@@ -592,7 +590,6 @@ export function ClustersTable(props: {
         tableActions={tableActions}
         rowActions={rowActions}
         emptyState={props.emptyState}
-        initialFilters={presets.initialFilters.addons ? { 'add-ons': presets.initialFilters.addons } : undefined}
         filters={filters}
         id="managedClusters"
       />

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchChannelSelectModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchChannelSelectModal.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event'
 import { act } from 'react-dom/test-utils'
 import { nockCreate, nockIgnoreApiPaths, nockPatch } from '../../../../../lib/nock-util'
 import { BatchChannelSelectModal } from './BatchChannelSelectModal'
+import { MemoryRouter } from 'react-router-dom'
 const mockClusterNoAvailable: Cluster = {
   name: 'cluster-0-no-available',
   displayName: 'cluster-0-no-available',
@@ -218,7 +219,9 @@ describe('BatchChannelSelectModal', () => {
   beforeEach(() => nockIgnoreApiPaths())
   it('should only show selectable ones, and select current channel as default', () => {
     const { queryAllByText, queryByText } = render(
-      <BatchChannelSelectModal clusters={allClusters} open={true} close={() => {}} />
+      <MemoryRouter>
+        <BatchChannelSelectModal clusters={allClusters} open={true} close={() => {}} />
+      </MemoryRouter>
     )
     expect(queryByText('cluster-0-no-available')).toBeFalsy()
     expect(queryByText('cluster-1-ready1')).toBeTruthy()
@@ -233,13 +236,15 @@ describe('BatchChannelSelectModal', () => {
   it('should close modal when succeed', async () => {
     let isClosed = false
     const { getByText, queryByText } = render(
-      <BatchChannelSelectModal
-        clusters={allClusters}
-        open={true}
-        close={() => {
-          isClosed = true
-        }}
-      />
+      <MemoryRouter>
+        <BatchChannelSelectModal
+          clusters={allClusters}
+          open={true}
+          close={() => {
+            isClosed = true
+          }}
+        />
+      </MemoryRouter>
     )
     const mockNockUpgrade2 = nockPatch(clusterCuratorReady2, getPatchUpdate('stable-2.3'), undefined, 404)
     const mockNockUpgrade2backup = nockCreate({ ...clusterCuratorReady2, ...getPatchUpdate('stable-2.3') })
@@ -257,13 +262,15 @@ describe('BatchChannelSelectModal', () => {
   it('should show loading when click select, and select button should be disabled when loading', async () => {
     let isClosed = false
     const { getByText, queryByText } = render(
-      <BatchChannelSelectModal
-        clusters={allClusters}
-        open={true}
-        close={() => {
-          isClosed = true
-        }}
-      />
+      <MemoryRouter>
+        <BatchChannelSelectModal
+          clusters={allClusters}
+          open={true}
+          close={() => {
+            isClosed = true
+          }}
+        />
+      </MemoryRouter>
     )
     const mockNockUpgrade2 = nockPatch(clusterCuratorReady2, getPatchUpdate('stable-2.3'))
     expect(getByText('Save')).toBeTruthy()
@@ -283,13 +290,15 @@ describe('BatchChannelSelectModal', () => {
   it('should close modal if click cancel', () => {
     let isClosed = false
     const { getByText } = render(
-      <BatchChannelSelectModal
-        clusters={allClusters}
-        open={true}
-        close={() => {
-          isClosed = true
-        }}
-      />
+      <MemoryRouter>
+        <BatchChannelSelectModal
+          clusters={allClusters}
+          open={true}
+          close={() => {
+            isClosed = true
+          }}
+        />
+      </MemoryRouter>
     )
     userEvent.click(getByText('Cancel'))
     expect(isClosed).toBe(true)
@@ -297,7 +306,9 @@ describe('BatchChannelSelectModal', () => {
   it('should show alert when failed; keep failed rows in table with error messages', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {})
     const { getByText, queryByText } = render(
-      <BatchChannelSelectModal clusters={allClusters} open={true} close={() => {}} />
+      <MemoryRouter>
+        <BatchChannelSelectModal clusters={allClusters} open={true} close={() => {}} />
+      </MemoryRouter>
     )
     const mockNockUpgrade2 = nockPatch(clusterCuratorReady2, getPatchUpdate('stable-2.3'), undefined, 400)
     expect(queryByText('cluster-1-ready1')).toBeTruthy()

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchUpgradeModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/BatchUpgradeModal.test.tsx
@@ -8,6 +8,7 @@ import { nockCreate, nockIgnoreApiPaths, nockPatch, nockUpgradeRiskRequest } fro
 import { waitForNocks } from '../../../../../lib/test-util'
 import { Cluster, ClusterCuratorDefinition, ClusterStatus } from '../../../../../resources'
 import { BatchUpgradeModal } from './BatchUpgradeModal'
+import { MemoryRouter } from 'react-router-dom'
 const mockClusterNoAvailable: Cluster = {
   name: 'cluster-0-no-available',
   displayName: 'cluster-0-no-available',
@@ -337,7 +338,9 @@ describe('BatchUpgradeModal', () => {
   it('should only show upgradeable ones, and select latest version as default', () => {
     const { queryByText } = render(
       <RecoilRoot>
-        <BatchUpgradeModal clusters={allClusters} open={true} close={() => {}} />
+        <MemoryRouter>
+          <BatchUpgradeModal clusters={allClusters} open={true} close={() => {}} />
+        </MemoryRouter>
       </RecoilRoot>
     )
     expect(queryByText('cluster-0-no-available')).toBeFalsy()
@@ -355,13 +358,15 @@ describe('BatchUpgradeModal', () => {
     let isClosed = false
     const { getByText, queryByText } = render(
       <RecoilRoot>
-        <BatchUpgradeModal
-          clusters={allClusters}
-          open={true}
-          close={() => {
-            isClosed = true
-          }}
-        />
+        <MemoryRouter>
+          <BatchUpgradeModal
+            clusters={allClusters}
+            open={true}
+            close={() => {
+              isClosed = true
+            }}
+          />
+        </MemoryRouter>
       </RecoilRoot>
     )
     const mockNockUpgrade1 = nockPatch(clusterCuratorReady1, getPatchUpdate('1.2.9'))
@@ -383,13 +388,15 @@ describe('BatchUpgradeModal', () => {
     let isClosed = false
     const { getByText, queryByText } = render(
       <RecoilRoot>
-        <BatchUpgradeModal
-          clusters={allClusters}
-          open={true}
-          close={() => {
-            isClosed = true
-          }}
-        />
+        <MemoryRouter>
+          <BatchUpgradeModal
+            clusters={allClusters}
+            open={true}
+            close={() => {
+              isClosed = true
+            }}
+          />
+        </MemoryRouter>
       </RecoilRoot>
     )
     const mockNockUpgrade1 = nockPatch(clusterCuratorReady1, getPatchUpdate('1.2.9'))
@@ -411,13 +418,15 @@ describe('BatchUpgradeModal', () => {
     let isClosed = false
     const { getByText } = render(
       <RecoilRoot>
-        <BatchUpgradeModal
-          clusters={allClusters}
-          open={true}
-          close={() => {
-            isClosed = true
-          }}
-        />
+        <MemoryRouter>
+          <BatchUpgradeModal
+            clusters={allClusters}
+            open={true}
+            close={() => {
+              isClosed = true
+            }}
+          />
+        </MemoryRouter>
       </RecoilRoot>
     )
     userEvent.click(getByText('Cancel'))
@@ -427,7 +436,9 @@ describe('BatchUpgradeModal', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {})
     const { getByText, queryByText } = render(
       <RecoilRoot>
-        <BatchUpgradeModal clusters={allClusters} open={true} close={() => {}} />
+        <MemoryRouter>
+          <BatchUpgradeModal clusters={allClusters} open={true} close={() => {}} />
+        </MemoryRouter>
       </RecoilRoot>
     )
     const mockNockUpgrade1 = nockPatch(clusterCuratorReady1, getPatchUpdate('1.2.9'))
@@ -453,7 +464,9 @@ describe('BatchUpgradeModal', () => {
     )
     const { getByText } = render(
       <RecoilRoot>
-        <BatchUpgradeModal clusters={[mockClusterWithUpgrade]} open={true} close={() => {}} />
+        <MemoryRouter>
+          <BatchUpgradeModal clusters={[mockClusterWithUpgrade]} open={true} close={() => {}} />
+        </MemoryRouter>
       </RecoilRoot>
     )
     // Wait for prometheus nocks to finish

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterPolicySidebar.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterPolicySidebar.test.tsx
@@ -6,6 +6,7 @@ import { configMapsState } from '../../../../../atoms'
 import { clickByText, waitForText } from '../../../../../lib/test-util'
 import { ConfigMap, PolicyReport } from '../../../../../resources'
 import { ClusterPolicySidebar } from './ClusterPolicySidebar'
+import { MemoryRouter } from 'react-router-dom'
 
 const mockPolicyReports: PolicyReport = {
   apiVersion: 'wgpolicyk8s.io/v1alpha2',
@@ -104,7 +105,9 @@ const mockConfigmap: ConfigMap[] = [
 describe('ClusterPolicySidebar', () => {
   const Component = () => (
     <RecoilRoot initializeState={(snapshot) => snapshot.set(configMapsState, mockConfigmap)}>
-      <ClusterPolicySidebar data={mockPolicyReports} />
+      <MemoryRouter>
+        <ClusterPolicySidebar data={mockPolicyReports} />
+      </MemoryRouter>
     </RecoilRoot>
   )
   test('renders', async () => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.test.tsx
@@ -9,6 +9,7 @@ import NodePoolsProgress, { getNodePoolsStatus, getNodePoolStatus } from './Node
 import { ClusterImageSetApiVersion, ClusterImageSetKind } from '../../../../../resources'
 import userEvent from '@testing-library/user-event'
 import { ClusterImageSetK8sResource } from '@openshift-assisted/ui-lib/cim'
+import { MemoryRouter } from 'react-router-dom'
 
 const t = (string: string) => {
   return string
@@ -396,7 +397,9 @@ describe('NodePoolsProgress', () => {
     nockIgnoreApiPaths()
     render(
       <RecoilRoot>
-        <NodePoolsProgress nodePools={nodePools} clusterImages={[mockClusterImageSet0]} />
+        <MemoryRouter>
+          <NodePoolsProgress nodePools={nodePools} clusterImages={[mockClusterImageSet0]} />
+        </MemoryRouter>
       </RecoilRoot>
     )
   })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsTable.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsTable.test.tsx
@@ -16,6 +16,7 @@ import {
 import { ClusterContext } from '../ClusterDetails/ClusterDetails'
 import NodePoolsTable from './NodePoolsTable'
 import { ClusterImageSetK8sResource, HostedClusterK8sResource } from '@openshift-assisted/ui-lib/cim'
+import { MemoryRouter } from 'react-router-dom'
 
 const mockHostedCluster0: HostedClusterK8sResource = {
   apiVersion: 'hypershift.openshift.io/v1alpha1',
@@ -788,15 +789,17 @@ describe('NodePoolsTable', () => {
           snapshot.set(namespacesState, mockNamespaces)
         }}
       >
-        <ClusterContext.Provider
-          value={{
-            hostedCluster: mockHostedCluster0,
-            cluster: undefined,
-            addons: undefined,
-          }}
-        >
-          <NodePoolsTable nodePools={nodePools} clusterImages={[mockClusterImageSet0]} />
-        </ClusterContext.Provider>
+        <MemoryRouter>
+          <ClusterContext.Provider
+            value={{
+              hostedCluster: mockHostedCluster0,
+              cluster: undefined,
+              addons: undefined,
+            }}
+          >
+            <NodePoolsTable nodePools={nodePools} clusterImages={[mockClusterImageSet0]} />
+          </ClusterContext.Provider>
+        </MemoryRouter>
       </RecoilRoot>
     )
 
@@ -875,15 +878,17 @@ describe('NodePoolsTable no status', () => {
     nockIgnoreApiPaths()
     render(
       <RecoilRoot>
-        <ClusterContext.Provider
-          value={{
-            hostedCluster: mockHostedCluster0,
-            cluster: undefined,
-            addons: undefined,
-          }}
-        >
-          <NodePoolsTable nodePools={nodePools} clusterImages={[]} />
-        </ClusterContext.Provider>
+        <MemoryRouter>
+          <ClusterContext.Provider
+            value={{
+              hostedCluster: mockHostedCluster0,
+              cluster: undefined,
+              addons: undefined,
+            }}
+          >
+            <NodePoolsTable nodePools={nodePools} clusterImages={[]} />
+          </ClusterContext.Provider>
+        </MemoryRouter>
       </RecoilRoot>
     )
   })
@@ -945,15 +950,17 @@ describe('NodePoolsTable no conditions', () => {
     nockIgnoreApiPaths()
     render(
       <RecoilRoot>
-        <ClusterContext.Provider
-          value={{
-            hostedCluster: mockHostedCluster0,
-            cluster: undefined,
-            addons: undefined,
-          }}
-        >
-          <NodePoolsTable nodePools={nodePools} clusterImages={[]} />
-        </ClusterContext.Provider>
+        <MemoryRouter>
+          <ClusterContext.Provider
+            value={{
+              hostedCluster: mockHostedCluster0,
+              cluster: undefined,
+              addons: undefined,
+            }}
+          >
+            <NodePoolsTable nodePools={nodePools} clusterImages={[]} />
+          </ClusterContext.Provider>
+        </MemoryRouter>
       </RecoilRoot>
     )
   })
@@ -1083,15 +1090,17 @@ describe('NodePoolsTable - Azure', () => {
     nockIgnoreApiPaths()
     render(
       <RecoilRoot>
-        <ClusterContext.Provider
-          value={{
-            hostedCluster: mockHostedCluster1,
-            cluster: undefined,
-            addons: undefined,
-          }}
-        >
-          <NodePoolsTable nodePools={nodePools} clusterImages={[]} />
-        </ClusterContext.Provider>
+        <MemoryRouter>
+          <ClusterContext.Provider
+            value={{
+              hostedCluster: mockHostedCluster1,
+              cluster: undefined,
+              addons: undefined,
+            }}
+          >
+            <NodePoolsTable nodePools={nodePools} clusterImages={[]} />
+          </ClusterContext.Provider>
+        </MemoryRouter>
       </RecoilRoot>
     )
   })
@@ -1145,15 +1154,17 @@ describe('NodePoolsTable - PowerVS', () => {
     nockIgnoreApiPaths()
     render(
       <RecoilRoot>
-        <ClusterContext.Provider
-          value={{
-            hostedCluster: mockHostedCluster2,
-            cluster: undefined,
-            addons: undefined,
-          }}
-        >
-          <NodePoolsTable nodePools={nodePools} clusterImages={[]} />
-        </ClusterContext.Provider>
+        <MemoryRouter>
+          <ClusterContext.Provider
+            value={{
+              hostedCluster: mockHostedCluster2,
+              cluster: undefined,
+              addons: undefined,
+            }}
+          >
+            <NodePoolsTable nodePools={nodePools} clusterImages={[]} />
+          </ClusterContext.Provider>
+        </MemoryRouter>
       </RecoilRoot>
     )
   })

--- a/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
@@ -10,6 +10,7 @@ import { AcmDropdown } from '../AcmDropdown/AcmDropdown'
 import { AcmEmptyState } from '../AcmEmptyState'
 import { AcmTable, AcmTablePaginationContextProvider, AcmTableProps } from './AcmTable'
 import { exampleData } from './AcmTable.stories'
+import { MemoryRouter } from 'react-router-dom'
 const axe = configureAxe({
   rules: {
     'scope-attr-valid': { enabled: false },
@@ -58,189 +59,193 @@ describe('AcmTable', () => {
     } = props
     const [items, setItems] = useState<IExampleData[]>(testItems)
     return (
-      <AcmTable<IExampleData>
-        emptyState={<AcmEmptyState title="No addresses found" message="You do not have any addresses yet" />}
-        items={items}
-        columns={[
-          {
-            header: 'First Name',
-            sort: 'firstName',
-            cell: 'firstName',
-            search: useSearch ? 'firstName' : undefined,
-          },
-          {
-            header: 'Last Name',
-            sort: 'last_name',
-            cell: 'last_name',
-          },
-          {
-            header: 'EMail',
-            cell: 'email',
-            search: useSearch ? 'email' : undefined,
-          },
-          {
-            header: 'Gender',
-            sort: 'gender',
-            cell: (item) => item.gender,
-            search: useSearch ? 'gender' : undefined,
-          },
-          {
-            header: 'IP Address',
-            sort: sortFunction,
-            cell: 'ip_address',
-            search: useSearch ? (item) => item['ip_address'] : undefined,
-          },
-          {
-            header: 'UID',
-            sort: 'uid',
-            cell: 'uid',
-            search: useSearch ? 'uid' : undefined,
-            tooltip: 'Tooltip Example',
-            transforms: props.transforms ? [fitContent] : undefined,
-          },
-        ]}
-        keyFn={(item: IExampleData) => item.uid.toString()}
-        tableActionButtons={
-          useTableActions
-            ? [
-                {
-                  id: 'primary-table-button',
-                  title: 'Primary action',
-                  click: () => primaryTableActionFunction(),
-                  isDisabled: false,
-                  variant: ButtonVariant.primary,
-                },
-                {
-                  id: 'secondary-table-button',
-                  title: 'Secondary action',
-                  click: () => secondaryTableActionFunction(),
-                  variant: ButtonVariant.secondary,
-                },
-              ]
-            : undefined
-        }
-        tableActions={
-          useTableActions
-            ? [
-                {
-                  id: 'status-group',
-                  title: 'Status',
-                  actions: [
-                    {
-                      id: 'status-1',
-                      title: 'Status 1',
-                      click: () => null,
-                      variant: 'dropdown-action',
+      <MemoryRouter>
+        <AcmTable<IExampleData>
+          emptyState={<AcmEmptyState title="No addresses found" message="You do not have any addresses yet" />}
+          items={items}
+          columns={[
+            {
+              header: 'First Name',
+              sort: 'firstName',
+              cell: 'firstName',
+              search: useSearch ? 'firstName' : undefined,
+            },
+            {
+              header: 'Last Name',
+              sort: 'last_name',
+              cell: 'last_name',
+            },
+            {
+              header: 'EMail',
+              cell: 'email',
+              search: useSearch ? 'email' : undefined,
+            },
+            {
+              header: 'Gender',
+              sort: 'gender',
+              cell: (item) => item.gender,
+              search: useSearch ? 'gender' : undefined,
+            },
+            {
+              header: 'IP Address',
+              sort: sortFunction,
+              cell: 'ip_address',
+              search: useSearch ? (item) => item['ip_address'] : undefined,
+            },
+            {
+              header: 'UID',
+              sort: 'uid',
+              cell: 'uid',
+              search: useSearch ? 'uid' : undefined,
+              tooltip: 'Tooltip Example',
+              transforms: props.transforms ? [fitContent] : undefined,
+            },
+          ]}
+          keyFn={(item: IExampleData) => item.uid.toString()}
+          tableActionButtons={
+            useTableActions
+              ? [
+                  {
+                    id: 'primary-table-button',
+                    title: 'Primary action',
+                    click: () => primaryTableActionFunction(),
+                    isDisabled: false,
+                    variant: ButtonVariant.primary,
+                  },
+                  {
+                    id: 'secondary-table-button',
+                    title: 'Secondary action',
+                    click: () => secondaryTableActionFunction(),
+                    variant: ButtonVariant.secondary,
+                  },
+                ]
+              : undefined
+          }
+          tableActions={
+            useTableActions
+              ? [
+                  {
+                    id: 'status-group',
+                    title: 'Status',
+                    actions: [
+                      {
+                        id: 'status-1',
+                        title: 'Status 1',
+                        click: () => null,
+                        variant: 'dropdown-action',
+                      },
+                      {
+                        id: 'status-2',
+                        title: 'Status 2',
+                        click: () => null,
+                        variant: 'dropdown-action',
+                      },
+                    ],
+                    variant: 'action-group',
+                  },
+                  {
+                    id: 'separator-1',
+                    variant: 'action-seperator',
+                  },
+                  {
+                    id: 'delete',
+                    title: 'Delete',
+                    click: (it: IExampleData[]) => {
+                      setItems(
+                        items ? items.filter((i: { uid: number }) => !it.find((item) => item.uid === i.uid)) : []
+                      )
+                      bulkDeleteAction(it)
                     },
-                    {
-                      id: 'status-2',
-                      title: 'Status 2',
-                      click: () => null,
-                      variant: 'dropdown-action',
+                    variant: 'bulk-action',
+                  },
+                ]
+              : undefined
+          }
+          rowActions={
+            useRowActions
+              ? [
+                  {
+                    id: 'delete',
+                    title: 'Delete item',
+                    click: (item: IExampleData) => {
+                      deleteAction(item)
+                      setItems(items.filter((i) => i.uid !== item.uid))
                     },
-                  ],
-                  variant: 'action-group',
-                },
-                {
-                  id: 'separator-1',
-                  variant: 'action-seperator',
-                },
-                {
-                  id: 'delete',
-                  title: 'Delete',
-                  click: (it: IExampleData[]) => {
-                    setItems(items ? items.filter((i: { uid: number }) => !it.find((item) => item.uid === i.uid)) : [])
-                    bulkDeleteAction(it)
                   },
-                  variant: 'bulk-action',
-                },
-              ]
-            : undefined
-        }
-        rowActions={
-          useRowActions
-            ? [
-                {
-                  id: 'delete',
-                  title: 'Delete item',
-                  click: (item: IExampleData) => {
-                    deleteAction(item)
-                    setItems(items.filter((i) => i.uid !== item.uid))
+                  {
+                    id: 'deletedisabled',
+                    title: 'Disabled delete item',
+                    isDisabled: true,
+                    tooltip: 'This button is disabled',
+                    click: (item: IExampleData) => {
+                      deleteAction(item)
+                      setItems(items.filter((i) => i.uid !== item.uid))
+                    },
                   },
-                },
-                {
-                  id: 'deletedisabled',
-                  title: 'Disabled delete item',
-                  isDisabled: true,
-                  tooltip: 'This button is disabled',
-                  click: (item: IExampleData) => {
-                    deleteAction(item)
-                    setItems(items.filter((i) => i.uid !== item.uid))
+                  {
+                    id: 'deletetooltipped',
+                    title: 'Tooltipped delete item',
+                    isDisabled: false,
+                    tooltip: 'This button is not disabled',
+                    click: (item: IExampleData) => {
+                      deleteAction(item)
+                      setItems(items.filter((i) => i.uid !== item.uid))
+                    },
                   },
-                },
-                {
-                  id: 'deletetooltipped',
-                  title: 'Tooltipped delete item',
-                  isDisabled: false,
-                  tooltip: 'This button is not disabled',
-                  click: (item: IExampleData) => {
-                    deleteAction(item)
-                    setItems(items.filter((i) => i.uid !== item.uid))
+                  {
+                    id: 'disablednotooltip',
+                    title: 'Disabled item',
+                    isDisabled: true,
+                    click: (item: IExampleData) => {
+                      deleteAction(item)
+                      setItems(items.filter((i) => i.uid !== item.uid))
+                    },
                   },
-                },
-                {
-                  id: 'disablednotooltip',
-                  title: 'Disabled item',
-                  isDisabled: true,
-                  click: (item: IExampleData) => {
-                    deleteAction(item)
-                    setItems(items.filter((i) => i.uid !== item.uid))
+                ]
+              : undefined
+          }
+          extraToolbarControls={
+            useExtraToolbarControls ? (
+              <ToggleGroup>
+                <ToggleGroupItem isSelected={true} text="View 1" />
+                <ToggleGroupItem text="View 2" />
+              </ToggleGroup>
+            ) : undefined
+          }
+          customTableAction={
+            useCustomTableAction ? (
+              <AcmDropdown
+                isDisabled={false}
+                tooltip="Disabled"
+                id="create"
+                onSelect={() => null}
+                text="Create"
+                dropdownItems={[
+                  {
+                    id: 'action1',
+                    text: 'Action 1',
+                    tooltip: 'Disabled',
+                    href: '/action1',
+                    tooltipPosition: TooltipPosition.right,
                   },
-                },
-              ]
-            : undefined
-        }
-        extraToolbarControls={
-          useExtraToolbarControls ? (
-            <ToggleGroup>
-              <ToggleGroupItem isSelected={true} text="View 1" />
-              <ToggleGroupItem text="View 2" />
-            </ToggleGroup>
-          ) : undefined
-        }
-        customTableAction={
-          useCustomTableAction ? (
-            <AcmDropdown
-              isDisabled={false}
-              tooltip="Disabled"
-              id="create"
-              onSelect={() => null}
-              text="Create"
-              dropdownItems={[
-                {
-                  id: 'action1',
-                  text: 'Action 1',
-                  tooltip: 'Disabled',
-                  href: '/action1',
-                  tooltipPosition: TooltipPosition.right,
-                },
-                {
-                  id: 'action2',
-                  text: 'Action 2',
-                  tooltip: 'Disabled',
-                  href: '/action1',
-                  tooltipPosition: TooltipPosition.right,
-                },
-              ]}
-              isKebab={false}
-              isPlain={true}
-              isPrimary={true}
-              tooltipPosition={TooltipPosition.right}
-            />
-          ) : undefined
-        }
-        {...props}
-      />
+                  {
+                    id: 'action2',
+                    text: 'Action 2',
+                    tooltip: 'Disabled',
+                    href: '/action1',
+                    tooltipPosition: TooltipPosition.right,
+                  },
+                ]}
+                isKebab={false}
+                isPlain={true}
+                isPrimary={true}
+                tooltipPosition={TooltipPosition.right}
+              />
+            ) : undefined
+          }
+          {...props}
+        />
+      </MemoryRouter>
     )
   }
   test('renders', () => {
@@ -289,59 +294,61 @@ describe('AcmTable', () => {
       }
     }
     const { container } = render(
-      <AcmTable<IExampleData>
-        emptyState={<AcmEmptyState title="No addresses found" message="You do not have any addresses yet" />}
-        showToolbar={false}
-        items={exampleData.slice(0, 10)}
-        addSubRows={(item: IExampleData) => {
-          if (item.uid === 1) {
-            return [
-              {
-                cells: [
-                  {
-                    title: <div id="expanded">{item.uid}</div>,
-                  },
-                ],
-              },
-            ]
-          } else {
-            return undefined
-          }
-        }}
-        columns={[
-          {
-            header: 'First Name',
-            sort: 'firstName',
-            cell: 'firstName',
-          },
-          {
-            header: 'Last Name',
-            sort: 'last_name',
-            cell: 'last_name',
-          },
-          {
-            header: 'EMail',
-            cell: 'email',
-          },
-          {
-            header: 'Gender',
-            sort: 'gender',
-            cell: (item) => item.gender,
-          },
-          {
-            header: 'IP Address',
-            sort: sortFunction,
-            cell: 'ip_address',
-          },
-          {
-            header: 'UID',
-            sort: 'uid',
-            cell: 'uid',
-          },
-        ]}
-        keyFn={(item: IExampleData) => item.uid.toString()}
-        rowActionResolver={tableActionResolver}
-      />
+      <MemoryRouter>
+        <AcmTable<IExampleData>
+          emptyState={<AcmEmptyState title="No addresses found" message="You do not have any addresses yet" />}
+          showToolbar={false}
+          items={exampleData.slice(0, 10)}
+          addSubRows={(item: IExampleData) => {
+            if (item.uid === 1) {
+              return [
+                {
+                  cells: [
+                    {
+                      title: <div id="expanded">{item.uid}</div>,
+                    },
+                  ],
+                },
+              ]
+            } else {
+              return undefined
+            }
+          }}
+          columns={[
+            {
+              header: 'First Name',
+              sort: 'firstName',
+              cell: 'firstName',
+            },
+            {
+              header: 'Last Name',
+              sort: 'last_name',
+              cell: 'last_name',
+            },
+            {
+              header: 'EMail',
+              cell: 'email',
+            },
+            {
+              header: 'Gender',
+              sort: 'gender',
+              cell: (item) => item.gender,
+            },
+            {
+              header: 'IP Address',
+              sort: sortFunction,
+              cell: 'ip_address',
+            },
+            {
+              header: 'UID',
+              sort: 'uid',
+              cell: 'uid',
+            },
+          ]}
+          keyFn={(item: IExampleData) => item.uid.toString()}
+          rowActionResolver={tableActionResolver}
+        />
+      </MemoryRouter>
     )
     expect(container.querySelector('table')).toBeInTheDocument()
     expect(container.querySelector('table .pf-c-dropdown__toggle')).toBeInTheDocument()
@@ -727,76 +734,78 @@ describe('AcmTable', () => {
   test('renders a table with expandable rows', () => {
     const expandedDeleteAction = jest.fn()
     const { getAllByLabelText, getByRole, getByTestId, getByText } = render(
-      <AcmTable<IExampleData>
-        emptyState={<AcmEmptyState title="No addresses found" message="You do not have any addresses yet" />}
-        showToolbar={false}
-        items={exampleData.slice(0, 10)}
-        addSubRows={(item: IExampleData) => {
-          if (item.uid === 1) {
-            return [
-              {
-                cells: [
-                  {
-                    title: <div id="expanded">{item.uid}</div>,
-                  },
-                ],
+      <MemoryRouter>
+        <AcmTable<IExampleData>
+          emptyState={<AcmEmptyState title="No addresses found" message="You do not have any addresses yet" />}
+          showToolbar={false}
+          items={exampleData.slice(0, 10)}
+          addSubRows={(item: IExampleData) => {
+            if (item.uid === 1) {
+              return [
+                {
+                  cells: [
+                    {
+                      title: <div id="expanded">{item.uid}</div>,
+                    },
+                  ],
+                },
+              ]
+            } else {
+              return undefined
+            }
+          }}
+          columns={[
+            {
+              header: 'First Name',
+              sort: 'firstName',
+              cell: 'firstName',
+            },
+            {
+              header: 'Last Name',
+              sort: 'last_name',
+              cell: 'last_name',
+            },
+            {
+              header: 'EMail',
+              cell: 'email',
+            },
+            {
+              header: 'Gender',
+              sort: 'gender',
+              cell: (item) => item.gender,
+            },
+            {
+              header: 'IP Address',
+              sort: sortFunction,
+              cell: 'ip_address',
+            },
+            {
+              header: 'UID',
+              sort: 'uid',
+              cell: 'uid',
+            },
+          ]}
+          keyFn={(item: IExampleData) => item.uid.toString()}
+          rowActions={[
+            {
+              id: 'delete',
+              title: 'Delete item',
+              click: () => {
+                expandedDeleteAction()
               },
-            ]
-          } else {
-            return undefined
-          }
-        }}
-        columns={[
-          {
-            header: 'First Name',
-            sort: 'firstName',
-            cell: 'firstName',
-          },
-          {
-            header: 'Last Name',
-            sort: 'last_name',
-            cell: 'last_name',
-          },
-          {
-            header: 'EMail',
-            cell: 'email',
-          },
-          {
-            header: 'Gender',
-            sort: 'gender',
-            cell: (item) => item.gender,
-          },
-          {
-            header: 'IP Address',
-            sort: sortFunction,
-            cell: 'ip_address',
-          },
-          {
-            header: 'UID',
-            sort: 'uid',
-            cell: 'uid',
-          },
-        ]}
-        keyFn={(item: IExampleData) => item.uid.toString()}
-        rowActions={[
-          {
-            id: 'delete',
-            title: 'Delete item',
-            click: () => {
-              expandedDeleteAction()
             },
-          },
-          {
-            id: 'deleteTT',
-            title: 'Delete item tooltip',
-            tooltip: 'delete',
-            click: () => {
-              expandedDeleteAction()
+            {
+              id: 'deleteTT',
+              title: 'Delete item tooltip',
+              tooltip: 'delete',
+              click: () => {
+                expandedDeleteAction()
+              },
             },
-          },
-        ]}
-        fuseThreshold={0}
-      />
+          ]}
+          fuseThreshold={0}
+        />
+      </MemoryRouter>
     )
     userEvent.click(getByTestId('expandable-toggle0'))
     expect(getByTestId('expanded')).toBeInTheDocument()


### PR DESCRIPTION
The main goal of this PR is to make table filters accessible in other parts of the code by moving handling to a reusable hook. This hook will be used to adjust the search queries for the applications table based on current filters.

The change also makes all filters appear in the location bar as query params, so that links to filtered results can be shared. This removes the need to handle links to filtered pages on a case-by-case basis.

Fixes several other minor issues:
- When following add-on status links from the Overview page to the Cluster list, the "Get started with Multicluster Hub" modal would appear for each new status. Local storage was keyed by full URL, which is unnecessary.
- If you applied a filter like `?cluster=foo` to the Applications page, but there is no cluster named "foo" then no filter chip would appear, but the results would still be filtered, so you would see no results. Filters are now always validated against what is currently available.
- If you filtered by a value that is no longer present, the chip for that filter will show even if `showEmptyOptions` is false if it has been saved in local storage. For example, if a user filtered by add-ons that are in degraded status, and then resolved the problem with add-ons, they will now be able to remove the filter. Previously it may have been stuck on.