### PR TITLE
Remove unnecessary global search checks

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
@@ -36,15 +36,13 @@ export function PolicyTemplateDetails(props: {
 }) {
   const { t } = useTranslation()
   const { clusterName, apiGroup, apiVersion, kind, templateName } = props
-  const { managedClusterAddonsState, isGlobalHubState, settingsState } = useSharedAtoms()
+  const { managedClusterAddonsState } = useSharedAtoms()
   const [template, setTemplate] = useState<any>()
   const [relatedObjects, setRelatedObjects] = useState<any>()
   const [templateError, setTemplateError] = useState<string>()
   const [isExpanded, setIsExpanded] = useState<boolean>(true)
   const [editorHeight, setEditorHeight] = useState<number>(250)
   const managedClusterAddOns = useRecoilValue(managedClusterAddonsState)
-  const isGlobalHub = useRecoilValue(isGlobalHubState)
-  const settings = useRecoilValue(settingsState)
 
   let templateClusterName = clusterName
   let templateNamespace = clusterName
@@ -248,11 +246,7 @@ export function PolicyTemplateDetails(props: {
               metadata: { name, namespace = '' },
             },
           } = item
-          if (
-            (isGlobalHub && settings.globalSearchFeatureFlag === 'enabled') ||
-            reason === 'Resource not found but should exist' ||
-            reason === 'Resource not found as expected'
-          ) {
+          if (reason === 'Resource not found but should exist' || reason === 'Resource not found as expected') {
             return ''
           }
           if (cluster && kind && apiVersion && name && name != '-') {
@@ -271,7 +265,7 @@ export function PolicyTemplateDetails(props: {
         },
       },
     ],
-    [isGlobalHub, settings.globalSearchFeatureFlag, t]
+    [t]
   )
 
   if (templateError) {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterNodes/ClusterNodes.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterNodes/ClusterNodes.tsx
@@ -9,7 +9,6 @@ import { PluginContext } from '../../../../../../lib/PluginContext'
 import { quantityToScalar, scalarToQuantity } from '../../../../../../lib/units'
 import { NavigationPath } from '../../../../../../NavigationPath'
 import { getRoles, NodeInfo } from '../../../../../../resources'
-import { useRecoilValue, useSharedAtoms } from '../../../../../../shared-recoil'
 import {
   AcmEmptyState,
   AcmInlineStatus,
@@ -92,18 +91,12 @@ export function NodesPoolsTable() {
   const { t } = useTranslation()
   const { cluster } = useContext(ClusterContext)
   const { isSearchAvailable } = useContext(PluginContext)
-  const { isGlobalHubState, settingsState } = useSharedAtoms()
-  const isGlobalHub = useRecoilValue(isGlobalHubState)
-  const settings = useRecoilValue(settingsState)
 
   const nodes: NodeInfo[] = cluster?.nodes?.nodeList!
 
   function getSearchLink(node: NodeInfo) {
-    // if globalHub & global search are enabled OR search is unavailable - return the Node name text
-    if (
-      (isGlobalHub && settings.globalSearchFeatureFlag && settings.globalSearchFeatureFlag === 'enabled') ||
-      !isSearchAvailable
-    ) {
+    // if search is unavailable - return the Node name text
+    if (!isSearchAvailable) {
       return node.name
     }
     return (


### PR DESCRIPTION
The global search checks were not needed. These resources are only available in the hub and thus search will always function correctly. 