### PR TITLE
Remove validation on operator policy sub name

### DIFF
--- a/frontend/src/wizards/Governance/Policy/PolicyWizard.tsx
+++ b/frontend/src/wizards/Governance/Policy/PolicyWizard.tsx
@@ -673,7 +673,6 @@ function OperatorPolicy() {
               'This is the package name of the Operator to install, which might be different from the Display Name used in the catalog.'
             )}
             required
-            validation={validateKubernetesResourceName}
           />
           <WizTextInput
             path="objectDefinition.spec.subscription.channel"


### PR DESCRIPTION
No other policy resources like this have validation, and it was not allowing templates.

Refs:
 - https://issues.redhat.com/browse/ACM-11585