### PR TITLE
Create service account secret if not found

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,20 @@ INSTALLATION_NAMESPACE_MCE=`oc get multiclusterengine -A -o jsonpath='{.items[0]
 
 SA=$(oc get serviceaccounts -n $INSTALLATION_NAMESPACE_MCE console-mce -o jsonpath='{.metadata.name}')
 SA_SECRET=$(oc get secrets -n $INSTALLATION_NAMESPACE_MCE -o json | jq -r "[.items[] | select(.metadata.annotations[\"kubernetes.io/service-account.name\"] == \"$SA\" and .type == \"kubernetes.io/service-account-token\")][0].metadata.name")
+if [[ -z "$SA_SECRET" ]]; then
+  oc apply -f - << EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: console-mce-token
+  namespace: $INSTALLATION_NAMESPACE_MCE
+  annotations:
+    kubernetes.io/service-account.name: $SA 
+type: kubernetes.io/service-account-token 
+EOF
+  SA_SECRET="console-mce-token"
+fi
+
 SA_TOKEN=`oc get secret -n $INSTALLATION_NAMESPACE_MCE ${SA_SECRET} -o="jsonpath={.data.token}" | base64 -d`
 CA_CERT=`oc get secret -n $INSTALLATION_NAMESPACE_MCE ${SA_SECRET} -o="jsonpath={.data.ca\.crt}"`
 SERVICE_CA_CERT=`oc get secret -n $INSTALLATION_NAMESPACE_MCE ${SA_SECRET} -o="jsonpath={.data.service-ca\.crt}"`

--- a/setup.sh
+++ b/setup.sh
@@ -27,7 +27,7 @@ INSTALLATION_NAMESPACE=`oc get multiclusterhub -A -o jsonpath='{.items[0].metada
 INSTALLATION_NAMESPACE_MCE=`oc get multiclusterengine -A -o jsonpath='{.items[0].spec.targetNamespace}'`
 
 SA=$(oc get serviceaccounts -n $INSTALLATION_NAMESPACE_MCE console-mce -o jsonpath='{.metadata.name}')
-SA_SECRET=$(oc get secrets -n $INSTALLATION_NAMESPACE_MCE -o json | jq -r "[.items[] | select(.metadata.annotations[\"kubernetes.io/service-account.name\"] == \"$SA\" and .type == \"kubernetes.io/service-account-token\")][0].metadata.name")
+SA_SECRET=$(oc get secrets -n $INSTALLATION_NAMESPACE_MCE -o json | jq -r "[.items[] | select(.metadata.annotations[\"kubernetes.io/service-account.name\"] == \"$SA\" and .type == \"kubernetes.io/service-account-token\")][0].metadata.name // \"\"")
 if [[ -z "$SA_SECRET" ]]; then
   oc apply -f - << EOF
 apiVersion: v1

--- a/start-ocp-console.sh
+++ b/start-ocp-console.sh
@@ -7,7 +7,8 @@ oc process -f ocp-console-oauth-client.yaml | oc apply -f -
 
 oc get oauthclient console-oauth-client -o jsonpath='{.secret}' > ocp-console/console-client-secret
 
-oc get secrets -n default --field-selector type=kubernetes.io/service-account-token -o json | \
+INSTALLATION_NAMESPACE_MCE=`oc get multiclusterengine -A -o jsonpath='{.items[0].spec.targetNamespace}'`
+oc get secrets -n $INSTALLATION_NAMESPACE_MCE --field-selector type=kubernetes.io/service-account-token -o json | \
     jq '.items[0].data."ca.crt"' -r | python -m base64 -d > ocp-console/ca.crt
 
 CONSOLE_VERSION=${CONSOLE_VERSION:=4.13}


### PR DESCRIPTION
Followed these instructions:
https://docs.openshift.com/container-platform/4.16/nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-creating-sa_nodes-pods-secrets

We might want to look into using the TokenRequest API instead, but I'm not sure if we can get the certificates that way - though they can be accessed by `oc debug` on the console pod if not.