### PR TITLE
Fix warning about polyfill for vm

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -197,6 +197,7 @@
         "type-fest": "2.16.0",
         "typescript": "^4.9.5",
         "v8-compile-cache": "2.3.0",
+        "vm-browserify": "^1.1.2",
         "webpack": "^5.91.0",
         "webpack-bundle-analyzer": "4.5.0",
         "webpack-cli": "4.10.0",
@@ -31460,6 +31461,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
+    },
     "node_modules/void-elements": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
@@ -56083,6 +56090,12 @@
           }
         }
       }
+    },
+    "vm-browserify": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+      "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+      "dev": true
     },
     "void-elements": {
       "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -224,6 +224,7 @@
     "type-fest": "2.16.0",
     "typescript": "^4.9.5",
     "v8-compile-cache": "2.3.0",
+    "vm-browserify": "^1.1.2",
     "webpack": "^5.91.0",
     "webpack-bundle-analyzer": "4.5.0",
     "webpack-cli": "4.10.0",

--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -32,6 +32,7 @@ module.exports = function (env: any, argv: { hot?: boolean; mode: string | undef
         util: require.resolve('node-util'),
         crypto: require.resolve('crypto-browserify'),
         process: require.resolve('process/browser'),
+        vm: require.resolve('vm-browserify'),
       },
       alias: {
         handlebars: 'handlebars/dist/handlebars.js',


### PR DESCRIPTION
Fix error when running console:
```
[start:frontend] WARNING in ./node_modules/asn1.js/lib/asn1/api.js 21:12-42
[start:frontend] Module not found: Error: Can't resolve 'vm' in '/Users/kcormier/stolostron/console/frontend/node_modules/asn1.js/lib/asn1'
[start:frontend] 
[start:frontend] BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
[start:frontend] This is no longer the case. Verify if you need this module and configure a polyfill for it.
[start:frontend] 
[start:frontend] If you want to include a polyfill, you need to:
[start:frontend]        - add a fallback 'resolve.fallback: { "vm": require.resolve("vm-browserify") }'
[start:frontend]        - install 'vm-browserify'
[start:frontend] If you don't want to include a polyfill, you can use an empty module like this:
[start:frontend]        resolve.fallback: { "vm": false }
```