### PR TITLE
remove deprecated provider rhv from catalog

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateClusterCatalog.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateClusterCatalog.test.tsx
@@ -64,11 +64,6 @@ describe('CreateClusterCatalog', () => {
     await clickByTestId('openstack')
   })
 
-  test('can select rhv', async () => {
-    render(<Component />)
-    await clickByTestId('rhv')
-  })
-
   test('can select vsphere', async () => {
     render(<Component />)
     await clickByTestId('vsphere')

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateClusterCatalog.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateClusterCatalog.tsx
@@ -150,13 +150,6 @@ export function CreateClusterCatalog() {
         provider: Provider.nutanix,
         description: t('A Red Hat OpenShift cluster that is running in a Nutanix environment.'),
       },
-      {
-        id: 'rhv',
-        provider: Provider.redhatvirtualization,
-        description: t(
-          'A Red Hat OpenShift cluster that is running in a Red Hat Virtualization environment in your on-premise data center.'
-        ),
-      },
     ]
   }, [t])
 
@@ -218,19 +211,6 @@ export function CreateClusterCatalog() {
               hasClusterImageSetWithArch(clusterImageSets, ['x86_64', 'x86-64']),
               t,
               <>{t('Nutanix requires x86_64 release image. No other architecture is supported.')}</>
-            ),
-          }
-          break
-        case Provider.redhatvirtualization:
-          card = {
-            ...card,
-            alertTitle: t('Deprecated host platform'),
-            alertVariant: 'info',
-            alertContent: (
-              <>
-                {t('Red Hat Virtualization is deprecated for OpenShift 4.13.')}
-                <ViewDocumentationLink doclink={DOC_LINKS.RHV_DEPRECATION} />
-              </>
             ),
           }
           break


### PR DESCRIPTION
RHV is deprecated starting with OCP 4.13, no longer can be used with OCP 4.14.
In MCE 2.6+, the support matrix will start at min OCP 4.14 version, so RHV is no longer supported.