### PR TITLE
Add namspace field when it is not presented

### DIFF
--- a/frontend/src/components/SyncEditor/validation.ts
+++ b/frontend/src/components/SyncEditor/validation.ts
@@ -317,7 +317,7 @@ export const validateTemplateSyntax = (object: any, errors: any[]) => {
         if (
           obj &&
           Array.isArray(obj.$p) &&
-          ['metadata.name', 'metadata.namespacer'].includes(obj.$p.slice(-2).join('.')) &&
+          ['metadata.name', 'metadata.namespace'].includes(obj.$p.slice(-2).join('.')) &&
           typeof obj.$v !== 'string'
         ) {
           /* istanbul ignore next */

--- a/frontend/src/routes/Governance/policies/CreatePolicy.tsx
+++ b/frontend/src/routes/Governance/policies/CreatePolicy.tsx
@@ -26,6 +26,7 @@ export function WizardSyncEditor() {
         update(changes?.resources)
       }}
       editableUidSiblings={true}
+      autoCreateNs
     />
   )
 }

--- a/frontend/src/routes/Governance/policies/CreatePolicyAutomation.tsx
+++ b/frontend/src/routes/Governance/policies/CreatePolicyAutomation.tsx
@@ -26,6 +26,7 @@ export function WizardSyncEditor() {
       onEditorChange={(changes: { resources: any[] }): void => {
         update(changes?.resources)
       }}
+      autoCreateNs
     />
   )
 }

--- a/frontend/src/routes/Governance/policy-sets/CreatePolicySet.tsx
+++ b/frontend/src/routes/Governance/policy-sets/CreatePolicySet.tsx
@@ -25,6 +25,7 @@ export function WizardSyncEditor() {
       onEditorChange={(changes: { resources: any[] }): void => {
         update(changes?.resources)
       }}
+      autoCreateNs
     />
   )
 }


### PR DESCRIPTION
Description of problem:
I tried to paste the policy yaml from a community policy into the console's policy editor. By convention, we don't provide a namespace in these policies, so the policy wizard complained there was no namespace.  Adding the namespace though did not reflect the change in the yaml editor.  Editing the namespace in the yaml editor did not change the policy wizard value.  I expect the namespace value to be handled clearly.

Ref: https://issues.redhat.com/browse/ACM-11387