### PR TITLE
[ACM-9303] Do not block search results on federated error

### DIFF
--- a/frontend/src/components/LoadData.tsx
+++ b/frontend/src/components/LoadData.tsx
@@ -484,7 +484,7 @@ export function LoadData(props: { children?: ReactNode }) {
   // Update global value setters when data has finished
   const isGlobalHub = useRecoilValue(isGlobalHubState)
   if (globalHubRes && !globalHubLoading && !isGlobalHub) {
-    setIsGlobalHub(globalHubRes[0].isGlobalHub)
+    setIsGlobalHub(globalHubRes[0]?.isGlobalHub)
   }
 
   // If all data not loaded (!loaded) & events data is loaded (eventsLoaded) && global hub value is loaded (!globalHubLoading) -> set loaded to true

--- a/frontend/src/routes/Home/Search/SearchPage.tsx
+++ b/frontend/src/routes/Home/Search/SearchPage.tsx
@@ -133,6 +133,9 @@ function RenderSearchBar(props: Readonly<SearchbarProps>) {
   } = props
   const { t } = useTranslation()
   const history = useHistory()
+  const { isGlobalHubState, settingsState } = useSharedAtoms()
+  const isGlobalHub = useRecoilValue(isGlobalHubState)
+  const settings = useRecoilValue(settingsState)
   const [currentSearch, setCurrentSearch] = useState<string>(presetSearchQuery)
   const [saveSearch, setSaveSearch] = useState<SavedSearch>()
   const [toggleOpen, setToggleOpen] = useState<boolean>(false)
@@ -180,11 +183,11 @@ function RenderSearchBar(props: Readonly<SearchbarProps>) {
   })
 
   const hasFederatedError = useMemo(() => {
-    if (
-      searchSchemaError?.graphQLErrors.find((error: any) => error?.includes(federatedErrorText)) ||
-      searchCompleteError?.graphQLErrors.find((error: any) => error?.includes(federatedErrorText))
-    ) {
-      return true
+    if (isGlobalHub && settings.globalSearchFeatureFlag === 'enabled') {
+      return (
+        (searchSchemaError?.graphQLErrors.findIndex((error: any) => error?.includes(federatedErrorText)) ?? -1) > -1 ||
+        (searchCompleteError?.graphQLErrors.findIndex((error: any) => error?.includes(federatedErrorText)) ?? -1) > -1
+      )
     }
     return false
   }, [searchCompleteError?.graphQLErrors, searchSchemaError?.graphQLErrors])

--- a/frontend/src/routes/Home/Search/SearchPage.tsx
+++ b/frontend/src/routes/Home/Search/SearchPage.tsx
@@ -190,7 +190,12 @@ function RenderSearchBar(props: Readonly<SearchbarProps>) {
       )
     }
     return false
-  }, [searchCompleteError?.graphQLErrors, searchSchemaError?.graphQLErrors])
+  }, [
+    isGlobalHub,
+    settings.globalSearchFeatureFlag,
+    searchCompleteError?.graphQLErrors,
+    searchSchemaError?.graphQLErrors,
+  ])
 
   useEffect(() => {
     if ((searchSchemaError || searchCompleteError) && !hasFederatedError) {

--- a/frontend/src/routes/Home/Search/SearchResults/RelatedResults.tsx
+++ b/frontend/src/routes/Home/Search/SearchResults/RelatedResults.tsx
@@ -12,7 +12,7 @@ import {
 import _ from 'lodash'
 import { useMemo } from 'react'
 import { useTranslation } from '../../../../lib/acm-i18next'
-import { useSharedAtoms } from '../../../../shared-recoil'
+import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { AcmLoadingPage, AcmTable, compareStrings } from '../../../../ui-components'
 import { useAllClusters } from '../../../Infrastructure/Clusters/ManagedClusters/components/useAllClusters'
 import { IDeleteExternalResourceModalProps } from '../components/Modals/DeleteExternalResourceModal'
@@ -28,8 +28,9 @@ export function RenderItemContent(props: {
   relatedKind: string
   setDeleteResource: React.Dispatch<React.SetStateAction<IDeleteModalProps>>
   setDeleteExternalResource: React.Dispatch<React.SetStateAction<IDeleteExternalResourceModalProps>>
+  hasFederatedError: boolean
 }) {
-  const { currentQuery, relatedKind, setDeleteResource, setDeleteExternalResource } = props
+  const { currentQuery, relatedKind, setDeleteResource, setDeleteExternalResource, hasFederatedError } = props
   const { t } = useTranslation()
   const { useSearchResultLimit } = useSharedAtoms()
   const clusters = useAllClusters(true)
@@ -49,7 +50,7 @@ export function RenderItemContent(props: {
   )
   const relatedResultItems = useMemo(() => data?.searchResult?.[0]?.related?.[0]?.items || [], [data])
 
-  if (error) {
+  if (error && !hasFederatedError) {
     return (
       <Alert variant={'danger'} isInline title={t('Query error related to the search results.')}>
         <Stack>
@@ -92,7 +93,9 @@ export default function RelatedResults(props: {
   const { currentQuery, selectedRelatedKinds, setSelectedRelatedKinds, setDeleteResource, setDeleteExternalResource } =
     props
   const { t } = useTranslation()
-  const { useSearchResultLimit } = useSharedAtoms()
+  const { useSearchResultLimit, isGlobalHubState, settingsState } = useSharedAtoms()
+  const isGlobalHub = useRecoilValue(isGlobalHubState)
+  const settings = useRecoilValue(settingsState)
   const searchResultLimit = useSearchResultLimit()
   // Related count should not have limit
   const queryFilters = convertStringToQuery(currentQuery, searchResultLimit)
@@ -104,11 +107,15 @@ export default function RelatedResults(props: {
   })
 
   const hasFederatedError = useMemo(() => {
-    if (error?.graphQLErrors.find((error: any) => error?.includes(federatedErrorText))) {
+    if (
+      isGlobalHub &&
+      settings.globalSearchFeatureFlag === 'enabled' &&
+      error?.graphQLErrors.find((error: any) => error?.includes(federatedErrorText))
+    ) {
       return true
     }
     return false
-  }, [error?.graphQLErrors])
+  }, [isGlobalHub, settings.globalSearchFeatureFlag, error?.graphQLErrors])
 
   const relatedCounts = useMemo(() => {
     const dataArray = data?.searchResult?.[0]?.related || []
@@ -191,6 +198,7 @@ export default function RelatedResults(props: {
                   relatedKind={currentKind}
                   setDeleteResource={setDeleteResource}
                   setDeleteExternalResource={setDeleteExternalResource}
+                  hasFederatedError={hasFederatedError}
                 />
               )}
             </AccordionContent>

--- a/frontend/src/routes/Home/Search/SearchResults/SearchResults.tsx
+++ b/frontend/src/routes/Home/Search/SearchResults/SearchResults.tsx
@@ -20,7 +20,7 @@ import { ExclamationCircleIcon, InfoCircleIcon, OutlinedQuestionCircleIcon } fro
 import _ from 'lodash'
 import { Fragment, useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from '../../../../lib/acm-i18next'
-import { useSharedAtoms } from '../../../../shared-recoil'
+import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { AcmAlert, AcmLoadingPage, AcmTable, compareStrings } from '../../../../ui-components'
 import { useAllClusters } from '../../../Infrastructure/Clusters/ManagedClusters/components/useAllClusters'
 import {
@@ -203,8 +203,10 @@ export default function SearchResults(props: {
 }) {
   const { currentQuery, error, loading, data, preSelectedRelatedResources } = props
   const { t } = useTranslation()
-  const { useSearchResultLimit } = useSharedAtoms()
+  const { useSearchResultLimit, isGlobalHubState, settingsState } = useSharedAtoms()
   const searchResultLimit = useSearchResultLimit()
+  const isGlobalHub = useRecoilValue(isGlobalHubState)
+  const settings = useRecoilValue(settingsState)
   const [selectedRelatedKinds, setSelectedRelatedKinds] = useState<string[]>(preSelectedRelatedResources)
   const [deleteResource, setDeleteResource] = useState<IDeleteModalProps>(ClosedDeleteModalProps)
   const [deleteExternalResource, setDeleteExternalResource] = useState<IDeleteExternalResourceModalProps>(
@@ -213,11 +215,15 @@ export default function SearchResults(props: {
   const [showRelatedResources, setShowRelatedResources] = useState<boolean>(false)
 
   const hasFederatedError = useMemo(() => {
-    if (error?.graphQLErrors.find((error: any) => error?.includes(federatedErrorText))) {
+    if (
+      isGlobalHub &&
+      settings.globalSearchFeatureFlag === 'enabled' &&
+      error?.graphQLErrors.find((error: any) => error?.includes(federatedErrorText))
+    ) {
       return true
     }
     return false
-  }, [error?.graphQLErrors])
+  }, [isGlobalHub, settings.globalSearchFeatureFlag, error?.graphQLErrors])
 
   useEffect(() => {
     // If the current search query changes -> hide related resources

--- a/frontend/src/routes/Home/Search/SearchResults/SearchResults.tsx
+++ b/frontend/src/routes/Home/Search/SearchResults/SearchResults.tsx
@@ -33,6 +33,7 @@ import {
   DeleteResourceModal,
   IDeleteModalProps,
 } from '../components/Modals/DeleteResourceModal'
+import { federatedErrorText } from '../search-helper'
 import { SearchResultItemsQuery } from '../search-sdk/search-sdk'
 import { useSearchDefinitions } from '../searchDefinitions'
 import RelatedResults from './RelatedResults'
@@ -211,6 +212,13 @@ export default function SearchResults(props: {
   )
   const [showRelatedResources, setShowRelatedResources] = useState<boolean>(false)
 
+  const hasFederatedError = useMemo(() => {
+    if (error?.graphQLErrors.find((error: any) => error?.includes(federatedErrorText))) {
+      return true
+    }
+    return false
+  }, [error?.graphQLErrors])
+
   useEffect(() => {
     // If the current search query changes -> hide related resources
     if (preSelectedRelatedResources.length === 0) {
@@ -232,7 +240,7 @@ export default function SearchResults(props: {
     )
   }
 
-  if (error) {
+  if (error && !hasFederatedError) {
     return (
       <PageSection>
         <EmptyState>

--- a/frontend/src/routes/Home/Search/components/HeaderWithNotification.tsx
+++ b/frontend/src/routes/Home/Search/components/HeaderWithNotification.tsx
@@ -5,7 +5,7 @@ import { Card, CardBody } from '@patternfly/react-core'
 import { useTranslation } from '../../../../lib/acm-i18next'
 import { NavigationPath } from '../../../../NavigationPath'
 import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
-import { AcmAlert, AcmInlineStatus, AcmPageHeader, StatusType } from '../../../../ui-components'
+import { AcmInlineStatus, AcmPageHeader, StatusType } from '../../../../ui-components'
 import { Message } from '../search-sdk/search-sdk'
 
 export default function HeaderWithNotification(props: { messages: Message[] }) {
@@ -18,16 +18,13 @@ export default function HeaderWithNotification(props: { messages: Message[] }) {
   return (
     <div style={{ outline: 'none', display: 'flex', justifyContent: 'flex-end' }}>
       <div style={{ flex: 1 }}>
-        {isGlobalHub && settings.globalSearchFeatureFlag === 'enabled' && (
-          <AcmAlert
-            variant="info"
-            noClose
-            isInline
-            title={t('Global search is enabled. Resources across all your managed hubs and clusters will be shown.')}
-          />
-        )}
         <AcmPageHeader
           title={isGlobalHub && settings.globalSearchFeatureFlag === 'enabled' ? t('Global search') : t('Search')}
+          titleTooltip={
+            isGlobalHub &&
+            settings.globalSearchFeatureFlag === 'enabled' &&
+            t('Global search is enabled. Resources across all your managed hubs and clusters will be shown.')
+          }
         />
       </div>
 

--- a/frontend/src/routes/Home/Search/components/__snapshots__/HeaderWithNotification.test.tsx.snap
+++ b/frontend/src/routes/Home/Search/components/__snapshots__/HeaderWithNotification.test.tsx.snap
@@ -308,54 +308,6 @@ exports[`renders with Global Search alert & no message 1`] = `
       <div
         style="flex: 1;"
       >
-        <div
-          class="MuiCollapse-root MuiCollapse-vertical css-1fkrdiv-MuiCollapse-root"
-          style="min-height: 0px; height: 0px; transition-duration: 150ms;"
-        >
-          <div
-            class="MuiCollapse-wrapper MuiCollapse-vertical css-smkl36-MuiCollapse-wrapper"
-          >
-            <div
-              class="MuiCollapse-wrapperInner MuiCollapse-vertical css-9l5vo-MuiCollapse-wrapperInner"
-            >
-              <div
-                aria-label="Info Alert"
-                class="pf-c-alert pf-m-inline pf-m-info"
-                data-ouia-component-id="OUIA-Generated-Alert-info-1"
-                data-ouia-component-type="PF4/Alert"
-                data-ouia-safe="true"
-              >
-                <div
-                  class="pf-c-alert__icon"
-                >
-                  <svg
-                    aria-hidden="true"
-                    fill="currentColor"
-                    height="1em"
-                    role="img"
-                    style="vertical-align: -0.125em;"
-                    viewBox="0 0 512 512"
-                    width="1em"
-                  >
-                    <path
-                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
-                    />
-                  </svg>
-                </div>
-                <h4
-                  class="pf-c-alert__title"
-                >
-                  <span
-                    class="pf-u-screen-reader"
-                  >
-                    Info alert:
-                  </span>
-                  Global search is enabled. Resources across all your managed hubs and clusters will be shown.
-                </h4>
-              </div>
-            </div>
-          </div>
-        </div>
         <section
           class="pf-c-page__main-section pf-m-no-padding pf-m-light"
         >
@@ -396,6 +348,29 @@ exports[`renders with Global Search alert & no message 1`] = `
                                 data-ouia-safe="true"
                               >
                                 Global search
+                                <button
+                                  aria-disabled="false"
+                                  class="pf-c-button pf-m-plain"
+                                  data-ouia-component-id="OUIA-Generated-Button-plain-1"
+                                  data-ouia-component-type="PF4/Button"
+                                  data-ouia-safe="true"
+                                  style="padding: 0px; margin-left: 8px; vertical-align: middle;"
+                                  type="button"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    fill="currentColor"
+                                    height="1em"
+                                    role="img"
+                                    style="vertical-align: -0.125em;"
+                                    viewBox="0 0 512 512"
+                                    width="1em"
+                                  >
+                                    <path
+                                      d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm107.244-255.2c0 67.052-72.421 68.084-72.421 92.863V300c0 6.627-5.373 12-12 12h-45.647c-6.627 0-12-5.373-12-12v-8.659c0-35.745 27.1-50.034 47.579-61.516 17.561-9.845 28.324-16.541 28.324-29.579 0-17.246-21.999-28.693-39.784-28.693-23.189 0-33.894 10.977-48.942 29.969-4.057 5.12-11.46 6.071-16.666 2.124l-27.824-21.098c-5.107-3.872-6.251-11.066-2.644-16.363C184.846 131.491 214.94 112 261.794 112c49.071 0 101.45 38.304 101.45 88.8zM298 368c0 23.159-18.841 42-42 42s-42-18.841-42-42 18.841-42 42-42 42 18.841 42 42z"
+                                    />
+                                  </svg>
+                                </button>
                               </h1>
                             </div>
                           </div>

--- a/frontend/src/routes/Home/Search/search-helper.ts
+++ b/frontend/src/routes/Home/Search/search-helper.ts
@@ -5,6 +5,7 @@
 import { TFunction } from 'react-i18next'
 import { DropdownSuggestionsProps } from './components/Searchbar'
 
+export const federatedErrorText = 'error sending federated request'
 export const operators = ['<=', '>=', '!=', '!', '=', '<', '>']
 const dateValues = ['hour', 'day', 'week', 'month', 'year']
 


### PR DESCRIPTION
Search should not block search results when a query returns a federated error.

In global search context some managed hubs can stop reporting for various reasons. The UI should still show results for the clusters that are available.