### PR TITLE
ACM-11980 Add back YAML separator for appsub template

### DIFF
--- a/frontend/src/routes/Applications/CreateApplication/Subscription/templates/templatePlacement.hbs
+++ b/frontend/src/routes/Applications/CreateApplication/Subscription/templates/templatePlacement.hbs
@@ -38,6 +38,7 @@
 {{/if}}
 
 {{#if isDeprecatedPR}}
+---
 {{{deprecated-rule}}}
 {{else}}
 {{#unless existingrule-checkbox}} 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-11980

Seems like we need this or elso AppSub edit breaks. Even this will make an extra `---` appear in the editor during AppSub creation.

- Add back YAML separator for appsub template