### PR TITLE
Use the cluster name instead of the namespace in PolicyDetailsResults

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { RecoilRoot } from 'recoil'
 import { policiesState } from '../../../../atoms'
@@ -53,6 +53,36 @@ describe('Policy Details Results', () => {
     )
     await waitForText('Remediation')
     await waitForText('enforce')
+  })
+})
+
+describe('Policy results of policy of a hosted cluster', () => {
+  beforeEach(async () => {
+    nockIgnoreRBAC()
+    nockIgnoreApiPaths()
+  })
+  test('Should display the cluster name and not namespace', async () => {
+    const mockReplicatedPolicyCopy = JSON.parse(JSON.stringify(mockPolicy[1]))
+    mockReplicatedPolicyCopy.metadata.labels['policy.open-cluster-management.io/cluster-namespace'] =
+      'klusterlet-local-cluster'
+
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policiesState, [mockPolicy[0], mockReplicatedPolicyCopy, mockPolicy[2]])
+        }}
+      >
+        <MemoryRouter>
+          <PolicyDetailsResults policy={mockPolicy[0]} />
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    // wait page load
+    await waitForText('Clusters')
+
+    await waitForText('local-cluster')
+    expect(screen.queryAllByText('klusterlet-local-cluster')).toHaveLength(0)
   })
 })
 

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -86,7 +86,7 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
     () => [
       {
         header: t('Cluster'),
-        sort: 'clusterNamespace',
+        sort: 'cluster',
         cell: (item: ResultsTableData) => (
           <Link
             to={{
@@ -96,10 +96,10 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
               }),
             }}
           >
-            {item.clusterNamespace}
+            {item.cluster}
           </Link>
         ),
-        search: (item: ResultsTableData) => item.clusterNamespace,
+        search: (item: ResultsTableData) => item.cluster,
       },
       {
         header: t('Violations'),
@@ -245,7 +245,7 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
             />
           }
           columns={columns}
-          keyFn={(item) => `${item.clusterNamespace}.${item.templateName}`}
+          keyFn={(item) => `${item.cluster}.${item.templateName}`}
           initialSort={
             window.location.search === ''
               ? {


### PR DESCRIPTION
This makes the cluster column use the cluster name directly. These are usually the same, but are different in hosted mode.

Relates:
https://issues.redhat.com/browse/ACM-12033