### PR TITLE
ACM-12214: Default data for import of OCP discovered clusters

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -899,4 +899,15 @@ describe('Import Discovered Cluster', () => {
 
     await waitForNocks([projectNock, managedClusterNock, kacNock, importCommandNock, autoImportSecretNock])
   })
+
+  test('sets discovered OCP cluster URL field', async () => {
+    const { getAllByText, getAllByLabelText, getByDisplayValue } = render(<Component />) // Render component
+
+    await waitFor(() => expect(getAllByText(mockDiscoveredClusters[0].metadata.name!)[0]!).toBeInTheDocument()) // Wait for Discovered ROSA Cluster to appear in table
+    userEvent.click(getAllByLabelText('Actions')[0]) // Click on Kebab menu
+
+    await clickByText('Import cluster')
+    await waitForText('Enter your server URL and API token for the existing cluster', true)
+    getByDisplayValue(mockDiscoveredClusters[0].spec.apiUrl!)
+  })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -345,6 +345,22 @@ export default function ImportClusterPage() {
         type: 'auto-import/rosa',
       })
     }
+    if (state.importMode === ImportMode.token) {
+      resources.push({
+        apiVersion: SecretApiVersion,
+        kind: SecretKind,
+        metadata: {
+          name: secretName,
+          namespace: initialClusterName,
+        },
+        stringData: {
+          autoImportRetry: '2',
+          token: '',
+          server: initialServer,
+        },
+        type: 'Opaque',
+      })
+    }
     if (isACMAvailable) {
       resources.push({
         apiVersion: KlusterletAddonConfigApiVersion,
@@ -365,6 +381,7 @@ export default function ImportClusterPage() {
   }, [
     discovered,
     initialClusterName,
+    initialServer,
     isACMAvailable,
     initialAPIToken,
     initialClusterID,


### PR DESCRIPTION
Similar to [ACM-12079](https://issues.redhat.com/browse/ACM-12079), I forgot to add this data as well, it is necessary because Non-ROSA cluster discovery import also has a new default import mode (server URL & token import), and that flow needs a default data template.

Steps to Reproduce:
  1.  From a OCP discovered cluster, on the discovered cluster list, click row action menu
  2. Click "Import cluster"
  3. See fields


Before:
<img width="1393" alt="Screenshot 2024-06-14 at 3 41 53 PM" src="https://github.com/stolostron/console/assets/21374229/6d3e8150-2277-4a57-b536-81ff32ece825">


After: 
<img width="1419" alt="Screenshot 2024-06-14 at 3 41 35 PM" src="https://github.com/stolostron/console/assets/21374229/bdfb2740-8d59-458a-97cb-84b4ad744c5f">

