### PR TITLE
ACM-10168 Remove required condition for AppSub placement cluster label selector

### DIFF
--- a/frontend/src/routes/Applications/CreateApplication/Subscription/common/ClusterSelector/index.tsx
+++ b/frontend/src/routes/Applications/CreateApplication/Subscription/common/ClusterSelector/index.tsx
@@ -262,7 +262,6 @@ const ClusterSelector = (props: {
                         id={`labelName-${id}-${controlId}`}
                         label={i18n('clusterSelector.label.field.ui')}
                         value={value}
-                        isRequired
                         placeholder={i18n('Select the label')}
                         onChange={(label) => {
                           handleChange(label!, 'labelName', id)
@@ -281,7 +280,6 @@ const ClusterSelector = (props: {
                         id={`operator-${id}-${controlId}`}
                         label={i18n('Operator')}
                         value={operator}
-                        isRequired
                         onChange={(operator) => {
                           handleChange(operator!, 'operatorValue', id)
                           switch (operator) {
@@ -308,7 +306,6 @@ const ClusterSelector = (props: {
                           value={matchLabelValue}
                           placeholder={i18n('Select the values')}
                           onChange={(value) => handleChange(value!, 'labelValue', id)}
-                          isRequired
                         >
                           {labelValuesMap[labelName]?.map((value: any) => (
                             <SelectOption key={value} value={value}>

--- a/frontend/src/routes/Applications/SubscriptionApplication.test.tsx
+++ b/frontend/src/routes/Applications/SubscriptionApplication.test.tsx
@@ -687,7 +687,7 @@ describe('Create Subscription Application page', () => {
     userEvent.type(screen.getByLabelText(/path/i), 'test-path2')
 
     // pick existing Placement
-    await screen.getByPlaceholderText(/select an existing placement configuration/i)
+    await waitForText('Select an existing placement configuration')
     screen.getByPlaceholderText(/select an existing placement configuration/i).click()
     await clickByText(mockPlacement.metadata.name!)
     const patchNocks: Scope[] = [


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10168

Removing the required condition for AppSub placement cluster label selector since the user might want to select all the clusters from the ClusterSet, in this case no labels are required.