### PR TITLE
ACM-12311 Fix Kubevirt import error in import modal

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
@@ -47,6 +47,7 @@ export function ClusterActionDropdown(props: { cluster: Cluster; isKebab: boolea
   const history = useHistory()
   const { isSearchAvailable } = useContext(PluginContext)
   const toastContext = useContext(AcmToastContext)
+  const { isACMAvailable } = useContext(PluginContext)
 
   const [showUpgradeModal, setShowUpgradeModal] = useState<boolean>(false)
   const [showChannelSelectModal, setShowChannelSelectModal] = useState<boolean>(false)
@@ -462,7 +463,8 @@ export function ClusterActionDropdown(props: { cluster: Cluster; isKebab: boolea
                   (hc) => hc.metadata?.name === cluster.name && hc.metadata?.namespace === cluster.namespace
                 ) as HostedClusterK8sResource,
                 t,
-                toastContext
+                toastContext,
+                isACMAvailable
               ) as IRequestResult
           ),
         },
@@ -511,6 +513,7 @@ export function ClusterActionDropdown(props: { cluster: Cluster; isKebab: boolea
       toastContext,
       importTemplate,
       isHypershiftUpdateAvailable,
+      isACMAvailable,
     ]
   )
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12311

This is caused by the UI trying to create a KlusterletAddonConfig CR in MCE only clusters. The KlusterletAddonConfig kind does not exist in MCE so we get the no resource found error. The fix is to ignore the error for MCE only clusters.