### PR TITLE
ACM-10432 Remove required for AppSet labels

### DIFF
--- a/frontend/src/wizards/Placement/MatchExpression.tsx
+++ b/frontend/src/wizards/Placement/MatchExpression.tsx
@@ -28,14 +28,12 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
           path="key"
           options={Object.keys(labelValuesMap)}
           isCreatable
-          required
           onValueChange={(_value, item) => set(item as object, 'values', [])}
         />
       ) : (
         <WizTextInput
           label={t('Label')}
           path="key"
-          required
           onValueChange={(_value, item) => set(item as object, 'values', [])}
         />
       )}
@@ -48,7 +46,6 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
           { label: t('exists'), value: 'Exists' },
           { label: t('does not exist'), value: 'DoesNotExist' },
         ]}
-        required
         onValueChange={(value, item) => {
           switch (value) {
             case 'Exists':
@@ -69,7 +66,6 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
                 placeholder={t('Select the values')}
                 path="values"
                 isCreatable
-                required
                 hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector?.operator)}
                 options={values}
               />
@@ -80,7 +76,6 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
         <WizStringsInput
           label={t('Values')}
           path="values"
-          required
           hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector?.operator)}
         />
       )}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-10432

I'm removing the required asterisk from the Placement label selection because:

1. The Placement API actually doesn't require them to be filled ie. you can leave them blank and the Placement CR will still be created
2. I don't think there's a good way for us to validate the control being required