### PR TITLE
Fix bug Cannot filter policies by policy set

### DIFF
--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -767,7 +767,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       const fuse = new Fuse(tableItems, {
         ignoreLocation: true,
         threshold: threshold,
-        keys: columns
+        keys: selectedSortedCols
           .map((column, i) => (column.search ? `column-${i}` : undefined))
           .filter((value) => value !== undefined) as string[],
         // TODO use FuseOptionKeyObject to allow for weights
@@ -777,7 +777,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     } else {
       return { filtered: tableItems, filteredCount: totalCount }
     }
-  }, [props.fuseThreshold, internalSearch, tableItems, columns, totalCount])
+  }, [props.fuseThreshold, internalSearch, tableItems, totalCount, selectedSortedCols])
 
   const { sorted, itemCount } = useMemo<{
     sorted: ITableItem<T>[]


### PR DESCRIPTION
if you go to govenance > policies, you cannot filter policies by policy sets to apply all policies of a set

Actual results:
there is no result if searching for the policy set name (previous versions could do that) - and there is no filter you can use for policy set. As it is not possible to use policy sets to apply all policies in a set (no action) you also can't use that.

Expected results:
Able to apply all policies that are part of a policy set by using select all and an action
Ref: https://issues.redhat.com/browse/ACM-12273
Signed-off-by: yiraeChristineKim <yikim@redhat.com>