### PR TITLE
AcmTable csv export button addition

### DIFF
--- a/frontend/src/routes/Home/Overview/SavedSearchesCard.test.tsx
+++ b/frontend/src/routes/Home/Overview/SavedSearchesCard.test.tsx
@@ -11,7 +11,7 @@ import { SavedSearch } from '../../../resources'
 import { SearchResultCountDocument } from '../Search/search-sdk/search-sdk'
 import SavedSearchesCard from './SavedSearchesCard'
 
-jest.mock('../../../resources', () => ({
+jest.mock('../../../resources/userpreference', () => ({
   listResources: jest.fn(() => ({
     promise: Promise.resolve([
       {
@@ -202,7 +202,7 @@ describe('SavedSearchesCard', () => {
     await waitFor(() => expect(getByText('2')).toBeTruthy())
   })
 
-  test('Renders erro correctly when search is disabled', async () => {
+  test('Renders error correctly when search is disabled', async () => {
     nockIgnoreApiPaths()
     const { getByText } = render(
       <RecoilRoot

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DownloadConfigurationDropdown.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DownloadConfigurationDropdown.test.tsx
@@ -6,9 +6,9 @@ import { mockBadRequestStatus, nockGet, nockIgnoreApiPaths } from '../../../../.
 import { DownloadConfigurationDropdown } from './DownloadConfigurationDropdown'
 import { clickByText } from '../../../../../lib/test-util'
 
-jest.mock('../../../../../resources/utils', () => ({
+jest.mock('../../../../../resources/utils/utils', () => ({
   __esModule: true,
-  ...jest.requireActual('../../../../../resources/utils'),
+  ...jest.requireActual('../../../../../resources/utils/utils'),
   createDownloadFile: jest.fn(),
 }))
 

--- a/frontend/src/ui-components/AcmTable/AcmManageColumn.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmManageColumn.tsx
@@ -17,7 +17,6 @@ import {
   DragDrop,
   Droppable,
   Draggable,
-  ToolbarItem,
 } from '@patternfly/react-core'
 import { IAcmTableColumn } from './AcmTable'
 import { useTranslation } from '../../lib/acm-i18next'
@@ -50,7 +49,7 @@ export function AcmManageColumn<T>({
   }
 
   return (
-    <ToolbarItem>
+    <>
       <ManageColumnModal<T>
         {...{
           isModalOpen,
@@ -67,7 +66,7 @@ export function AcmManageColumn<T>({
       <Tooltip content={t('Manage columns')} enableFlip trigger="mouseenter" position="top" exitDelay={50}>
         <Button isInline variant="plain" onClick={toggleModal} icon={<ColumnsIcon />} aria-label="columns-management" />
       </Tooltip>
-    </ToolbarItem>
+    </>
   )
 }
 

--- a/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
@@ -928,4 +928,30 @@ describe('AcmTable', () => {
     expect(container.querySelector('div .pf-c-dropdown__toggle')).toBeInTheDocument()
     userEvent.click(getByTestId('create'))
   })
+
+  test('renders with export button', () => {
+    const { getByTestId, getByText, container } = render(<Table showExportButton />)
+    expect(container.querySelector('#export-search-result')).toBeInTheDocument()
+    userEvent.click(getByTestId('export-search-result'))
+    expect(getByText('Export as CSV')).toBeInTheDocument()
+  })
+
+  test('export button should produce a file for download', () => {
+    window.URL.createObjectURL = jest.fn()
+    window.URL.revokeObjectURL = jest.fn()
+    const { getByTestId, getByText, container } = render(<Table showExportButton />)
+
+    const anchorMocked = { href: '', click: jest.fn(), download: 'table-values', style: { display: '' } } as any
+    const createElementSpyOn = jest.spyOn(document, 'createElement').mockReturnValueOnce(anchorMocked)
+    document.body.appendChild = jest.fn()
+    document.createElement('a').dispatchEvent = jest.fn()
+
+    expect(container.querySelector('#export-search-result')).toBeInTheDocument()
+    userEvent.click(getByTestId('export-search-result'))
+    expect(getByText('Export as CSV')).toBeInTheDocument()
+    userEvent.click(getByText('Export as CSV'))
+
+    expect(createElementSpyOn).toHaveBeenCalledWith('a')
+    expect(anchorMocked.download).toContain('table-values')
+  })
 })


### PR DESCRIPTION
Regarding: https://issues.redhat.com/browse/ACM-12099?filter=-1

PR 1/7

Added exportContent prop to AcmTable, enabling the component to consume a callback that returns the column value's export string. 

When used (see subsequent PR's for the implementation of this feature) the export button appears at the left end of the toolbar after the Manage columns button.

![Screenshot 2024-07-10 at 2 15 24 AM](https://github.com/stolostron/console/assets/21374229/4807e0b7-4f9e-4a1e-a9b4-be752a791b9c)


