### PR TITLE
EDM-203: Add Overview tab extension

### DIFF
--- a/frontend/src/plugin-extensions/extensions/OverviewTab.ts
+++ b/frontend/src/plugin-extensions/extensions/OverviewTab.ts
@@ -1,0 +1,12 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { Extension, ExtensionDeclaration } from '@openshift-console/dynamic-plugin-sdk/lib/types'
+import { OverviewTabProps } from '../properties'
+
+/** This extension allows plugins to contribute a tab to Overview page */
+export type OverviewTab = ExtensionDeclaration<'acm.overview/tab', OverviewTabProps>
+
+// Type guards
+
+export const isOverviewTab = (e: Extension): e is OverviewTab => {
+  return e.type === 'acm.overview/tab'
+}

--- a/frontend/src/plugin-extensions/extensions/index.ts
+++ b/frontend/src/plugin-extensions/extensions/index.ts
@@ -1,3 +1,4 @@
 /* Copyright Contributors to the Open Cluster Management project */
 export * from './ApplicationAction'
 export * from './ApplicationListPageColumn'
+export * from './OverviewTab'

--- a/frontend/src/plugin-extensions/handler.ts
+++ b/frontend/src/plugin-extensions/handler.ts
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { useResolvedExtensions } from '@openshift-console/dynamic-plugin-sdk'
-import { isApplicationAction, isApplicationListColumn } from './extensions'
+import { isApplicationAction, isApplicationListColumn, isOverviewTab } from './extensions'
 import { ApplicationActionProps, ApplicationListColumnProps } from './properties'
 import { AcmExtension } from './types'
 
@@ -20,6 +20,12 @@ export function useAcmExtension() {
     acmExtension.applicationListColumn = applicationListColumn.map(
       (column) => column.properties as ApplicationListColumnProps
     )
+  }
+
+  // Resolving overview tab to acm compatible type
+  const [overviewTab, resolvedOverviewTab] = useResolvedExtensions(isOverviewTab)
+  if (resolvedOverviewTab) {
+    acmExtension.overviewTab = overviewTab
   }
 
   // list of all acm supported extensions

--- a/frontend/src/plugin-extensions/properties/index.ts
+++ b/frontend/src/plugin-extensions/properties/index.ts
@@ -1,3 +1,4 @@
 /* Copyright Contributors to the Open Cluster Management project */
 export * from './addActionProps'
 export * from './addListColumnProps'
+export * from './overviewTabProps'

--- a/frontend/src/plugin-extensions/properties/overviewTabProps.ts
+++ b/frontend/src/plugin-extensions/properties/overviewTabProps.ts
@@ -1,0 +1,8 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { CodeRef } from '@openshift-console/dynamic-plugin-sdk/lib/types'
+import * as React from 'react'
+
+export type OverviewTabProps = {
+  tabTitle: string
+  component: CodeRef<React.ComponentType>
+}

--- a/frontend/src/plugin-extensions/types.ts
+++ b/frontend/src/plugin-extensions/types.ts
@@ -1,7 +1,10 @@
 /* Copyright Contributors to the Open Cluster Management project */
+import { ResolvedExtension } from '@openshift-console/dynamic-plugin-sdk'
 import { ApplicationActionProps, ApplicationListColumnProps } from './properties'
+import { OverviewTab } from './extensions'
 
 export type AcmExtension = Partial<{
   applicationAction: ApplicationActionProps[]
   applicationListColumn: ApplicationListColumnProps[]
+  overviewTab: ResolvedExtension<OverviewTab>[]
 }>

--- a/frontend/src/routes/Home/Overview/ClustersTab.tsx
+++ b/frontend/src/routes/Home/Overview/ClustersTab.tsx
@@ -1,0 +1,48 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import * as React from 'react'
+import { AcmScrollable } from '../../../ui-components'
+import OverviewPageBeta from './OverviewPageBeta'
+import OverviewPage from './OverviewPage'
+import { Card, CardBody, Flex, FlexItem, PageSection, Switch } from '@patternfly/react-core'
+import OverviewClusterLabelSelector from './OverviewClusterLabelSelector'
+import { useTranslation } from '../../../lib/acm-i18next'
+
+const ClustersTab = () => {
+  const { t } = useTranslation()
+  const [selectedClusterLabels, setSelectedClusterLabels] = React.useState<Record<string, string[]>>({})
+  const [isBetaView, setIsBetaView] = React.useState<boolean>(localStorage.getItem('overview-isBeta') === 'true')
+
+  return (
+    <AcmScrollable>
+      <PageSection>
+        <Card>
+          <CardBody>
+            <Flex alignItems={{ default: 'alignItemsBaseline' }} spacer={{ default: 'spacerMd' }}>
+              <FlexItem>
+                <Switch
+                  label={t('Fleet view')}
+                  isChecked={isBetaView}
+                  onChange={() => {
+                    setIsBetaView(!isBetaView)
+                    localStorage.setItem('overview-isBeta', `${!isBetaView}`) // keep selection
+                  }}
+                />
+              </FlexItem>
+              {isBetaView && (
+                <FlexItem>
+                  <OverviewClusterLabelSelector
+                    selectedClusterLabels={selectedClusterLabels}
+                    setSelectedClusterLabels={setSelectedClusterLabels}
+                  />
+                </FlexItem>
+              )}
+            </Flex>
+          </CardBody>
+        </Card>
+      </PageSection>
+      {isBetaView ? <OverviewPageBeta selectedClusterLabels={selectedClusterLabels} /> : <OverviewPage />}
+    </AcmScrollable>
+  )
+}
+
+export default ClustersTab

--- a/frontend/src/routes/Home/Overview/Overview.sharedmocks.tsx
+++ b/frontend/src/routes/Home/Overview/Overview.sharedmocks.tsx
@@ -1,0 +1,77 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { SelfSubjectAccessReview } from '../../../resources'
+
+export const getAddonRequest = {
+  apiVersion: 'view.open-cluster-management.io/v1beta1',
+  kind: 'ManagedClusterView',
+  metadata: {
+    name: '46de65eb9b4a488e6744a0b264a076cc107fd55e',
+    namespace: 'local-cluster',
+    labels: {
+      viewName: '46de65eb9b4a488e6744a0b264a076cc107fd55e',
+    },
+  },
+  spec: {
+    scope: {
+      name: 'observability-controller',
+      resource: 'clustermanagementaddon.v1alpha1.addon.open-cluster-management.io',
+    },
+  },
+}
+
+export const getAddonResponse = {
+  apiVersion: 'view.open-cluster-management.io/v1beta1',
+  kind: 'ManagedClusterView',
+  metadata: {
+    name: '46de65eb9b4a488e6744a0b264a076cc107fd55e',
+    namespace: 'local-cluster',
+    labels: {
+      viewName: '46de65eb9b4a488e6744a0b264a076cc107fd55e',
+    },
+  },
+  spec: {
+    scope: {
+      name: 'observability-controller',
+      resource: 'clustermanagementaddon.v1alpha1.addon.open-cluster-management.io',
+    },
+  },
+  status: {
+    conditions: [
+      {
+        message: 'Watching resources successfully',
+        reason: 'GetResourceProcessing',
+        status: 'True',
+        type: 'Processing',
+      },
+    ],
+  },
+}
+
+export const mockGetSelfSubjectAccessRequest: SelfSubjectAccessReview = {
+  apiVersion: 'authorization.k8s.io/v1',
+  kind: 'SelfSubjectAccessReview',
+  metadata: {},
+  spec: {
+    resourceAttributes: {
+      resource: 'managedclusters',
+      verb: 'create',
+      group: 'cluster.open-cluster-management.io',
+    },
+  },
+}
+
+export const mockGetSelfSubjectAccessResponse: SelfSubjectAccessReview = {
+  apiVersion: 'authorization.k8s.io/v1',
+  kind: 'SelfSubjectAccessReview',
+  metadata: {},
+  spec: {
+    resourceAttributes: {
+      resource: 'managedclusters',
+      verb: 'create',
+      group: 'cluster.open-cluster-management.io',
+    },
+  },
+  status: {
+    allowed: true,
+  },
+}

--- a/frontend/src/routes/Home/Overview/Overview.test.tsx
+++ b/frontend/src/routes/Home/Overview/Overview.test.tsx
@@ -1,0 +1,87 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { MemoryRouter } from 'react-router-dom-v5-compat'
+import Overview from './Overview'
+import { PluginContext } from '../../../lib/PluginContext'
+import { PluginDataContext } from '../../../lib/PluginDataContext'
+import { render } from '@testing-library/react'
+import { clickByText, waitForNocks, waitForText } from '../../../lib/test-util'
+import { RecoilRoot } from 'recoil'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MockedProvider } from '@apollo/client/testing'
+import { nockCreate, nockGet, nockIgnoreApiPaths, nockPostRequest, nockSearch } from '../../../lib/nock-util'
+import {
+  getAddonRequest,
+  getAddonResponse,
+  mockGetSelfSubjectAccessRequest,
+  mockGetSelfSubjectAccessResponse,
+} from './Overview.sharedmocks'
+import {
+  mockSearchQueryArgoApps,
+  mockSearchQueryArgoAppsCount,
+  mockSearchQueryOCPApplications,
+  mockSearchQueryOCPApplicationsCount,
+  mockSearchResponseArgoApps,
+  mockSearchResponseArgoAppsCount,
+  mockSearchResponseOCPApplications,
+  mockSearchResponseOCPApplicationsCount,
+} from '../../Applications/Application.sharedmocks'
+
+const queryClient = new QueryClient()
+
+it('should render overview page with extension', async () => {
+  const apiPathNock = nockIgnoreApiPaths()
+  const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
+  const getManageedClusterAccessRequeset = nockCreate(mockGetSelfSubjectAccessRequest, mockGetSelfSubjectAccessResponse)
+  const metricNock = nockPostRequest('/metrics?overview-classic', {})
+  nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
+  nockSearch(mockSearchQueryArgoAppsCount, mockSearchResponseArgoAppsCount)
+  nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
+  nockSearch(mockSearchQueryOCPApplicationsCount, mockSearchResponseOCPApplicationsCount)
+  render(
+    <RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MockedProvider mocks={[]}>
+            <PluginContext.Provider
+              value={{
+                isACMAvailable: false,
+                isOverviewAvailable: true,
+                isSubmarinerAvailable: true,
+                isApplicationsAvailable: true,
+                isGovernanceAvailable: true,
+                isSearchAvailable: true,
+                dataContext: PluginDataContext,
+                acmExtensions: {
+                  overviewTab: [
+                    {
+                      pluginID: 'test-plugin',
+                      pluginName: 'test-plugin',
+                      type: 'acm.overview/tab',
+                      uid: 'test-plugin-tab',
+                      properties: {
+                        tabTitle: 'Test tab',
+                        component: () => <div>Test extension content</div>,
+                      },
+                    },
+                  ],
+                },
+                ocpApi: {
+                  useK8sWatchResource: () => [[] as any, true, undefined],
+                },
+              }}
+            >
+              <Overview />
+            </PluginContext.Provider>
+          </MockedProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </RecoilRoot>
+  )
+
+  await waitForText('Overview')
+  await waitForText('Test tab')
+  await clickByText('Test tab')
+
+  await waitForText('Test extension content')
+  await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
+})

--- a/frontend/src/routes/Home/Overview/OverviewClusterLabelSelector.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewClusterLabelSelector.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { Button, Chip, ChipGroup, PageSection, Select, SelectOption, SelectVariant } from '@patternfly/react-core'
+import { Button, Chip, ChipGroup, Select, SelectOption, SelectVariant } from '@patternfly/react-core'
 import { FilterIcon } from '@patternfly/react-icons'
 import { Dispatch, SetStateAction, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from '../../../lib/acm-i18next'
@@ -89,82 +89,80 @@ export default function OverviewClusterLabelSelector(props: {
   }
 
   return (
-    <PageSection style={{ paddingTop: 0 }} variant={'light'}>
-      <div>
-        <Select
-          id="cluster-label-key"
-          key="cluster-label-key"
-          aria-label="cluster-label-key"
-          toggleIcon={<FilterIcon />}
-          width={'auto'}
-          maxHeight={'400px'}
-          variant={SelectVariant.single}
-          onToggle={(isExpanded) => setLabelSelectIsOpen(isExpanded)}
-          hasInlineFilter
-          onSelect={(_, selection) => {
-            if (selectedClusterLabel === selection) {
-              setSelectedClusterLabel('')
-            } else {
-              setSelectedClusterLabel(selection as string)
-            }
-            setLabelSelectIsOpen(false)
-          }}
-          selections={selectedClusterLabel}
-          isOpen={labelSelectIsOpen}
-          placeholderText={t('Select cluster label')}
-          aria-labelledby={'cluster-label-key'}
-        >
-          {Object.keys(allClusterLabels).map((labelKey: string) => (
-            <SelectOption key={`cluster-label-key-${labelKey}`} value={labelKey} />
-          ))}
-        </Select>
-        <Select
-          id="cluster-label-value"
-          aria-label="cluster-label-value"
-          width={'auto'}
-          maxHeight={'400px'}
-          variant={SelectVariant.checkbox}
-          onToggle={(isExpanded) => setValuesSelectIsOpen(isExpanded)}
-          onFilter={onFilter}
-          hasInlineFilter
-          onSelect={(_, selection) => {
-            const tempLabels = { ...selectedClusterLabels }
-            const tempValues = tempLabels[selectedClusterLabel ?? ''] ?? []
-            if (tempValues?.includes(selection as string)) {
-              deleteChip(selectedClusterLabel, selection as string)
-            } else {
-              tempLabels[selectedClusterLabel ?? ''] = [...tempValues, selection as string]
-              setSelectedClusterLabels(tempLabels)
-            }
-          }}
-          selections={selectedClusterLabels[selectedClusterLabel ?? '']}
-          isOpen={valuesSelectIsOpen}
-          placeholderText={t('Select label value')}
-          aria-labelledby={'cluster-label-value'}
-        >
-          {allClusterLabels[selectedClusterLabel ?? '']?.map((label) => <SelectOption key={label} value={label} />)}
-        </Select>
-        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-          {Object.keys(selectedClusterLabels).map((label) => {
-            return (
-              <div key={label} style={{ marginTop: '0.5rem', marginRight: '.5rem' }}>
-                <ChipGroup key={label} categoryName={label} isClosable onClick={() => deleteChipGroup(label)}>
-                  {selectedClusterLabels[label].map((value) => (
-                    <Chip key={value} onClick={() => deleteChip(label, value)}>
-                      {value}
-                    </Chip>
-                  ))}
-                </ChipGroup>
-              </div>
-            )
-          })}
-          {Object.values(selectedClusterLabels).length > 0 && (
-            <Button variant={'link'} onClick={() => deleteAllChips()} style={{ marginTop: '0.5rem' }}>
-              {t('Clear all labels')}
-            </Button>
-          )}
-        </div>
+    <div>
+      <Select
+        id="cluster-label-key"
+        key="cluster-label-key"
+        aria-label="cluster-label-key"
+        toggleIcon={<FilterIcon />}
+        width={'auto'}
+        maxHeight={'400px'}
+        variant={SelectVariant.single}
+        onToggle={(isExpanded) => setLabelSelectIsOpen(isExpanded)}
+        hasInlineFilter
+        onSelect={(_, selection) => {
+          if (selectedClusterLabel === selection) {
+            setSelectedClusterLabel('')
+          } else {
+            setSelectedClusterLabel(selection as string)
+          }
+          setLabelSelectIsOpen(false)
+        }}
+        selections={selectedClusterLabel}
+        isOpen={labelSelectIsOpen}
+        placeholderText={t('Select cluster label')}
+        aria-labelledby={'cluster-label-key'}
+      >
+        {Object.keys(allClusterLabels).map((labelKey: string) => (
+          <SelectOption key={`cluster-label-key-${labelKey}`} value={labelKey} />
+        ))}
+      </Select>
+      <Select
+        id="cluster-label-value"
+        aria-label="cluster-label-value"
+        width={'auto'}
+        maxHeight={'400px'}
+        variant={SelectVariant.checkbox}
+        onToggle={(isExpanded) => setValuesSelectIsOpen(isExpanded)}
+        onFilter={onFilter}
+        hasInlineFilter
+        onSelect={(_, selection) => {
+          const tempLabels = { ...selectedClusterLabels }
+          const tempValues = tempLabels[selectedClusterLabel ?? ''] ?? []
+          if (tempValues?.includes(selection as string)) {
+            deleteChip(selectedClusterLabel, selection as string)
+          } else {
+            tempLabels[selectedClusterLabel ?? ''] = [...tempValues, selection as string]
+            setSelectedClusterLabels(tempLabels)
+          }
+        }}
+        selections={selectedClusterLabels[selectedClusterLabel ?? '']}
+        isOpen={valuesSelectIsOpen}
+        placeholderText={t('Select label value')}
+        aria-labelledby={'cluster-label-value'}
+      >
+        {allClusterLabels[selectedClusterLabel ?? '']?.map((label) => <SelectOption key={label} value={label} />)}
+      </Select>
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+        {Object.keys(selectedClusterLabels).map((label) => {
+          return (
+            <div key={label} style={{ marginTop: '0.5rem', marginRight: '.5rem' }}>
+              <ChipGroup key={label} categoryName={label} isClosable onClick={() => deleteChipGroup(label)}>
+                {selectedClusterLabels[label].map((value) => (
+                  <Chip key={value} onClick={() => deleteChip(label, value)}>
+                    {value}
+                  </Chip>
+                ))}
+              </ChipGroup>
+            </div>
+          )
+        })}
+        {Object.values(selectedClusterLabels).length > 0 && (
+          <Button variant={'link'} onClick={() => deleteAllChips()} style={{ marginTop: '0.5rem' }}>
+            {t('Clear all labels')}
+          </Button>
+        )}
       </div>
-    </PageSection>
+    </div>
   )
 }

--- a/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
@@ -30,7 +30,6 @@ import {
   ManagedClusterKind,
   Policy,
   PolicyReport,
-  SelfSubjectAccessReview,
 } from '../../../resources'
 import {
   mockApplications,
@@ -47,83 +46,14 @@ import {
 } from '../../Applications/Application.sharedmocks'
 import { SearchResultCountDocument } from '../../Search/search-sdk/search-sdk'
 import OverviewPage from './OverviewPage'
+import {
+  getAddonRequest,
+  getAddonResponse,
+  mockGetSelfSubjectAccessRequest,
+  mockGetSelfSubjectAccessResponse,
+} from './Overview.sharedmocks'
 
 const queryClient = new QueryClient()
-
-const getAddonRequest = {
-  apiVersion: 'view.open-cluster-management.io/v1beta1',
-  kind: 'ManagedClusterView',
-  metadata: {
-    name: '46de65eb9b4a488e6744a0b264a076cc107fd55e',
-    namespace: 'local-cluster',
-    labels: {
-      viewName: '46de65eb9b4a488e6744a0b264a076cc107fd55e',
-    },
-  },
-  spec: {
-    scope: {
-      name: 'observability-controller',
-      resource: 'clustermanagementaddon.v1alpha1.addon.open-cluster-management.io',
-    },
-  },
-}
-
-const getAddonResponse = {
-  apiVersion: 'view.open-cluster-management.io/v1beta1',
-  kind: 'ManagedClusterView',
-  metadata: {
-    name: '46de65eb9b4a488e6744a0b264a076cc107fd55e',
-    namespace: 'local-cluster',
-    labels: {
-      viewName: '46de65eb9b4a488e6744a0b264a076cc107fd55e',
-    },
-  },
-  spec: {
-    scope: {
-      name: 'observability-controller',
-      resource: 'clustermanagementaddon.v1alpha1.addon.open-cluster-management.io',
-    },
-  },
-  status: {
-    conditions: [
-      {
-        message: 'Watching resources successfully',
-        reason: 'GetResourceProcessing',
-        status: 'True',
-        type: 'Processing',
-      },
-    ],
-  },
-}
-
-const mockGetSelfSubjectAccessRequest: SelfSubjectAccessReview = {
-  apiVersion: 'authorization.k8s.io/v1',
-  kind: 'SelfSubjectAccessReview',
-  metadata: {},
-  spec: {
-    resourceAttributes: {
-      resource: 'managedclusters',
-      verb: 'create',
-      group: 'cluster.open-cluster-management.io',
-    },
-  },
-}
-
-const mockGetSelfSubjectAccessResponse: SelfSubjectAccessReview = {
-  apiVersion: 'authorization.k8s.io/v1',
-  kind: 'SelfSubjectAccessReview',
-  metadata: {},
-  spec: {
-    resourceAttributes: {
-      resource: 'managedclusters',
-      verb: 'create',
-      group: 'cluster.open-cluster-management.io',
-    },
-  },
-  status: {
-    allowed: true,
-  },
-}
 
 const managedClusterInfos: ManagedClusterInfo[] = [
   {

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -25,7 +25,6 @@ import {
   AcmDonutChart,
   AcmLoadingPage,
   AcmOverviewProviders,
-  AcmScrollable,
   AcmSummaryList,
   colorThemes,
   Provider,
@@ -584,7 +583,7 @@ export default function OverviewPage() {
   }, [policyReportCriticalCount, policyReportImportantCount, policyReportLowCount, policyReportModerateCount, t])
 
   return (
-    <AcmScrollable>
+    <>
       {searchError && (
         <PageSection>
           <AcmAlert
@@ -603,7 +602,7 @@ export default function OverviewPage() {
           />
         </PageSection>
       )}
-      <PageSection>
+      <PageSection style={{ paddingTop: 0 }}>
         <Stack hasGutter>
           {!clusters ? <AcmLoadingPage /> : <AcmOverviewProviders providers={providers} />}
 
@@ -657,6 +656,6 @@ export default function OverviewPage() {
           </Stack>
         </Stack>
       </PageSection>
-    </AcmScrollable>
+    </>
   )
 }

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -25,7 +25,7 @@ import { ObservabilityEndpoint, useObservabilityPoll } from '../../../lib/useObs
 import { NavigationPath } from '../../../NavigationPath'
 import { ArgoApplication, Cluster, getUserPreference, UserPreference } from '../../../resources'
 import { useRecoilValue, useSharedAtoms } from '../../../shared-recoil'
-import { AcmButton, AcmDonutChart, AcmScrollable, colorThemes } from '../../../ui-components'
+import { AcmButton, AcmDonutChart, colorThemes } from '../../../ui-components'
 import { parseArgoApplications, parseDiscoveredApplications, parseOcpAppResources } from '../../Applications/Overview'
 import { useClusterAddons } from '../../Infrastructure/Clusters/ClusterSets/components/useClusterAddons'
 import {
@@ -309,8 +309,8 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   }, [userPreference])
 
   return (
-    <AcmScrollable>
-      <PageSection>
+    <>
+      <PageSection style={{ paddingTop: 0 }}>
         <Gallery hasGutter style={{ display: 'flex', flexWrap: 'wrap' }}>
           {clustersSummary
             ? clustersSummary.map(
@@ -656,6 +656,6 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
           )}
         </Card>
       </PageSection>
-    </AcmScrollable>
+    </>
   )
 }


### PR DESCRIPTION
This extension enables adding new tabs to the overview page - such as this edge management overview

![acm_tab](https://github.com/user-attachments/assets/b821c210-1665-4e4f-b5c8-aaeeafcf2e6f)


Some elements (the Fleet view switcher and filtering dropdowns) were moved to a more natural place (as they have effect only on the Clusters tab)
before


![overview_before](https://github.com/user-attachments/assets/a830ed80-c29a-481f-8c63-a509e83c389d)

after

![overview_after](https://github.com/user-attachments/assets/6e4903d8-d8dd-404b-82b9-09542733eb5a)


