### PR TITLE
ACM-12772 Fix form match expressions required fields

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@octokit/types": "6.40.0",
         "@openshift-assisted/locales": "2.11.2-cim",
         "@openshift-assisted/ui-lib": "2.11.2-cim",
-        "@patternfly-labs/react-form-wizard": "^1.30.0",
+        "@patternfly-labs/react-form-wizard": "^1.32.0",
         "@patternfly/patternfly": "4.196.7",
         "@patternfly/react-charts": "^6.74.3",
         "@patternfly/react-code-editor": "4.65.1",
@@ -5107,9 +5107,9 @@
       }
     },
     "node_modules/@patternfly-labs/react-form-wizard": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.30.0.tgz",
-      "integrity": "sha512-p7GiD6kSEI2elDDitO2TAfFepz1co6nzZDcRWs+U901T4+rYI2vYva17aa9LgLiQfkV+gkV6Q0piYG8EGiCcBg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.32.0.tgz",
+      "integrity": "sha512-ay5CePoONlJH0eQcv5m+I+szFke4py7RjzsIi/nCXorYt0j+EapiCjDsTEPykLYwKwY1rX4ShS9VvwLDQMPTJA==",
       "dependencies": {
         "get-value": "3.0.1",
         "klona": "2.0.6",
@@ -35485,9 +35485,9 @@
       }
     },
     "@patternfly-labs/react-form-wizard": {
-      "version": "1.30.0",
-      "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.30.0.tgz",
-      "integrity": "sha512-p7GiD6kSEI2elDDitO2TAfFepz1co6nzZDcRWs+U901T4+rYI2vYva17aa9LgLiQfkV+gkV6Q0piYG8EGiCcBg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.32.0.tgz",
+      "integrity": "sha512-ay5CePoONlJH0eQcv5m+I+szFke4py7RjzsIi/nCXorYt0j+EapiCjDsTEPykLYwKwY1rX4ShS9VvwLDQMPTJA==",
       "requires": {
         "get-value": "3.0.1",
         "klona": "2.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "@octokit/types": "6.40.0",
     "@openshift-assisted/locales": "2.11.2-cim",
     "@openshift-assisted/ui-lib": "2.11.2-cim",
-    "@patternfly-labs/react-form-wizard": "^1.30.0",
+    "@patternfly-labs/react-form-wizard": "^1.32.0",
     "@patternfly/patternfly": "4.196.7",
     "@patternfly/react-charts": "^6.74.3",
     "@patternfly/react-code-editor": "4.65.1",

--- a/frontend/src/wizards/Placement/MatchExpression.tsx
+++ b/frontend/src/wizards/Placement/MatchExpression.tsx
@@ -28,12 +28,14 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
           path="key"
           options={Object.keys(labelValuesMap)}
           isCreatable
+          required
           onValueChange={(_value, item) => set(item as object, 'values', [])}
         />
       ) : (
         <WizTextInput
           label={t('Label')}
           path="key"
+          required
           onValueChange={(_value, item) => set(item as object, 'values', [])}
         />
       )}
@@ -46,6 +48,7 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
           { label: t('exists'), value: 'Exists' },
           { label: t('does not exist'), value: 'DoesNotExist' },
         ]}
+        required
         onValueChange={(value, item) => {
           switch (value) {
             case 'Exists':
@@ -66,6 +69,7 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
                 placeholder={t('Select the values')}
                 path="values"
                 isCreatable
+                required
                 hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector?.operator)}
                 options={values}
               />
@@ -76,6 +80,7 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
         <WizStringsInput
           label={t('Values')}
           path="values"
+          required
           hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector?.operator)}
         />
       )}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12772

Makes match expression fields required again, after fixing @patternfly-labs/react-form-wizard to treat empty array as no value for multi-value input controls.