### PR TITLE
ACM-12807 Fix form match expressions required fields [release-2.11]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@octokit/types": "6.40.0",
         "@openshift-assisted/locales": "2.11.3-cim",
         "@openshift-assisted/ui-lib": "2.11.3-cim",
-        "@patternfly-labs/react-form-wizard": "^1.29.0",
+        "@patternfly-labs/react-form-wizard": "^1.29.2",
         "@patternfly/patternfly": "4.196.7",
         "@patternfly/react-charts": "^6.74.3",
         "@patternfly/react-code-editor": "4.65.1",
@@ -5169,9 +5169,9 @@
       }
     },
     "node_modules/@patternfly-labs/react-form-wizard": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.29.0.tgz",
-      "integrity": "sha512-PsqKIT6dkhj2yIng8TgFQtP0Q/kfBPfVaa0ZVfBV2V4J+hGa7FOqTpSFeOYwZA33IDJos5XoXllfVHJSh5eLPg==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.29.2.tgz",
+      "integrity": "sha512-Ewyl7fi405SDm3u4NEhaZhfRlfMigNnL+ImPUSK4yOuprmYJvXdqZolOuYxXfagjZLGGmFJluQRDWo5gbmcqAQ==",
       "dependencies": {
         "get-value": "3.0.1",
         "klona": "2.0.6",
@@ -36072,9 +36072,9 @@
       }
     },
     "@patternfly-labs/react-form-wizard": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.29.0.tgz",
-      "integrity": "sha512-PsqKIT6dkhj2yIng8TgFQtP0Q/kfBPfVaa0ZVfBV2V4J+hGa7FOqTpSFeOYwZA33IDJos5XoXllfVHJSh5eLPg==",
+      "version": "1.29.2",
+      "resolved": "https://registry.npmjs.org/@patternfly-labs/react-form-wizard/-/react-form-wizard-1.29.2.tgz",
+      "integrity": "sha512-Ewyl7fi405SDm3u4NEhaZhfRlfMigNnL+ImPUSK4yOuprmYJvXdqZolOuYxXfagjZLGGmFJluQRDWo5gbmcqAQ==",
       "requires": {
         "get-value": "3.0.1",
         "klona": "2.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,7 @@
     "@octokit/types": "6.40.0",
     "@openshift-assisted/locales": "2.11.3-cim",
     "@openshift-assisted/ui-lib": "2.11.3-cim",
-    "@patternfly-labs/react-form-wizard": "^1.29.0",
+    "@patternfly-labs/react-form-wizard": "^1.29.2",
     "@patternfly/patternfly": "4.196.7",
     "@patternfly/react-charts": "^6.74.3",
     "@patternfly/react-code-editor": "4.65.1",

--- a/frontend/src/wizards/Placement/MatchExpression.tsx
+++ b/frontend/src/wizards/Placement/MatchExpression.tsx
@@ -28,12 +28,14 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
           path="key"
           options={Object.keys(labelValuesMap)}
           isCreatable
+          required
           onValueChange={(_value, item) => set(item as object, 'values', [])}
         />
       ) : (
         <WizTextInput
           label={t('Label')}
           path="key"
+          required
           onValueChange={(_value, item) => set(item as object, 'values', [])}
         />
       )}
@@ -46,6 +48,7 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
           { label: t('exists'), value: 'Exists' },
           { label: t('does not exist'), value: 'DoesNotExist' },
         ]}
+        required
         onValueChange={(value, item) => {
           switch (value) {
             case 'Exists':
@@ -66,6 +69,7 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
                 placeholder={t('Select the values')}
                 path="values"
                 isCreatable
+                required
                 hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector?.operator)}
                 options={values}
               />
@@ -76,6 +80,7 @@ export function MatchExpression(props: { labelValuesMap?: Record<string, string[
         <WizStringsInput
           label={t('Values')}
           path="values"
+          required
           hidden={(labelSelector) => !['In', 'NotIn'].includes(labelSelector?.operator)}
         />
       )}


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12807

Makes match expression fields required again, after fixing @patternfly-labs/react-form-wizard to treat empty array as no value for multi-value input controls.