### PR TITLE
Submariner: add support for multiple GWs for managed clusters as well

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.test.tsx
@@ -843,7 +843,7 @@ const mockManagedClusterRosaSubmarinerConfig: SubmarinerConfig = {
     namespace: mockManagedClusterRosa.metadata.name,
   },
   spec: {
-    gatewayConfig: {},
+    gatewayConfig: { gateways: submarinerConfigDefault.gateways },
     IPSecNATTPort: submarinerConfigDefault.nattPort,
     airGappedDeployment: submarinerConfigDefault.airGappedDeployment,
     NATTEnable: submarinerConfigDefault.nattEnable,
@@ -861,7 +861,7 @@ const mockManagedClusterAroSubmarinerConfig: SubmarinerConfig = {
     namespace: mockManagedClusterAro.metadata.name,
   },
   spec: {
-    gatewayConfig: {},
+    gatewayConfig: { gateways: submarinerConfigDefault.gateways },
     IPSecNATTPort: submarinerConfigDefault.nattPort,
     airGappedDeployment: submarinerConfigDefault.airGappedDeployment,
     NATTEnable: submarinerConfigDefault.nattEnable,
@@ -879,7 +879,7 @@ const mockManagedClusterRoksSubmarinerConfig: SubmarinerConfig = {
     namespace: mockManagedClusterRoks.metadata.name,
   },
   spec: {
-    gatewayConfig: {},
+    gatewayConfig: { gateways: submarinerConfigDefault.gateways },
     IPSecNATTPort: submarinerConfigDefault.nattPort,
     airGappedDeployment: submarinerConfigDefault.airGappedDeployment,
     NATTEnable: submarinerConfigDefault.nattEnable,
@@ -897,7 +897,7 @@ const mockManagedClusterRoksSateliteSubmarinerConfig: SubmarinerConfig = {
     namespace: mockManagedClusterRoksSatelite.metadata.name,
   },
   spec: {
-    gatewayConfig: {},
+    gatewayConfig: { gateways: submarinerConfigDefault.gateways },
     IPSecNATTPort: submarinerConfigDefault.nattPort,
     airGappedDeployment: submarinerConfigDefault.airGappedDeployment,
     NATTEnable: submarinerConfigDefault.nattEnable,

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetInstallSubmariner/InstallSubmarinerForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetInstallSubmariner/InstallSubmarinerForm.tsx
@@ -416,7 +416,6 @@ export function InstallSubmarinerForm(props: { availableClusters: Cluster[] }) {
             }
           }
         } else {
-          submarinerConfig.spec.gatewayConfig = {}
           submarinerConfig.spec.loadBalancerEnable = true
           // for ROKS IBM managed openshift on IBM Satelite we shouldn't use loadbalancer
           // ROKS on Satelite is identified by nodes label 'node.kubernetes.io/instance-type' equals to 'upi'
@@ -1056,7 +1055,6 @@ export function InstallSubmarinerForm(props: { availableClusters: Cluster[] }) {
                   placeholder: t('submariner.install.form.gateways.placeholder'),
                   labelHelp: t('submariner.install.form.gateways.labelHelp'),
                   value: gateways[clusterName] ?? submarinerConfigDefault.gateways,
-                  isHidden: cluster.distribution?.isManagedOpenShift,
                   onChange: (value: number) => {
                     const copy = { ...gateways }
                     copy[clusterName] = value


### PR DESCRIPTION
Now that there is no need to create dedicated machinepool for GW node on
ROSA cluster, we can treat managed clusters like other providers and let
the user control number of GWs.