### PR TITLE
ACM-12099: CSV export clusters

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.test.tsx
@@ -545,6 +545,38 @@ describe('ClusterPools page', () => {
   })
 })
 
+describe('Export from clusterpool table', () => {
+  test('export button should produce a file for download', async () => {
+    nockIgnoreRBAC()
+    nockIgnoreApiPaths()
+    render(
+      <RecoilRoot>
+        <MemoryRouter>
+          <ClusterPoolsTable clusterPools={[mockClusterPool]} clusters={[mockCluster]} emptyState={''} />
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+    window.URL.createObjectURL = jest.fn()
+    window.URL.revokeObjectURL = jest.fn()
+    const documentBody = document.body.appendChild
+    const documentCreate = document.createElement('a').dispatchEvent
+
+    const anchorMocked = { href: '', click: jest.fn(), download: 'table-values', style: { display: '' } } as any
+    const createElementSpyOn = jest.spyOn(document, 'createElement').mockReturnValueOnce(anchorMocked)
+    document.body.appendChild = jest.fn()
+    document.createElement('a').dispatchEvent = jest.fn()
+
+    await clickByLabel('export-search-result')
+    await clickByText('Export as CSV')
+
+    expect(createElementSpyOn).toHaveBeenCalledWith('a')
+    expect(anchorMocked.download).toContain('table-values')
+
+    document.body.appendChild = documentBody
+    document.createElement('a').dispatchEvent = documentCreate
+  })
+})
+
 describe('Destroy ClusterPool with claimed clusters', () => {
   beforeEach(async () => {
     nockIgnoreRBAC()

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/ClusterStatuses.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/ClusterStatuses.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { ClusterPool, getClusterStatusType, ManagedClusterSet } from '../../../../../resources'
+import { Cluster, ClusterPool, getClusterStatusType, ManagedClusterSet } from '../../../../../resources'
 import { AcmInlineStatusGroup, StatusType } from '../../../../../ui-components'
 import { useClusters } from './useClusters'
 
@@ -10,6 +10,34 @@ export function ClusterStatuses(props: {
   isGlobalClusterSet?: boolean
 }) {
   const clusters = useClusters(props.managedClusterSet, props.clusterPool, props.isGlobalClusterSet)
+  const { healthy, running, warning, progress, danger, pending, sleep, unknown, detached } = getClusterStatusCount(
+    clusters,
+    props.managedClusterSet,
+    props.clusterPool
+  )
+
+  return clusters.length === 0 ? (
+    <>-</>
+  ) : (
+    <AcmInlineStatusGroup
+      healthy={healthy}
+      running={running}
+      warning={warning}
+      progress={progress}
+      danger={danger}
+      pending={pending}
+      sleep={sleep}
+      unknown={unknown}
+      detached={detached}
+    />
+  )
+}
+
+export function getClusterStatusCount(
+  clusters: Cluster[],
+  managedClusterSet?: ManagedClusterSet,
+  clusterPool?: ClusterPool
+) {
   let healthy = 0
   let running = 0
   let warning = 0
@@ -53,20 +81,17 @@ export function ClusterStatuses(props: {
         break
     }
   })
-
-  return clusters.length === 0 ? (
-    <>-</>
-  ) : (
-    <AcmInlineStatusGroup
-      healthy={healthy}
-      running={running}
-      warning={warning}
-      progress={progress}
-      danger={danger}
-      pending={pending}
-      sleep={sleep}
-      unknown={unknown}
-      detached={detached}
-    />
-  )
+  return {
+    healthy,
+    running,
+    warning,
+    progress,
+    danger,
+    pending,
+    sleep,
+    unknown,
+    detached,
+    managedClustername: managedClusterSet?.metadata.name,
+    clusterPoolName: clusterPool?.metadata.name,
+  }
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/useClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/useClusters.tsx
@@ -1,10 +1,20 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import {
-  Cluster,
+  AgentClusterInstallK8sResource,
+  HostedClusterK8sResource,
+  NodePoolK8sResource,
+} from '@openshift-assisted/ui-lib/cim'
+import {
+  CertificateSigningRequest,
+  ClusterClaim,
+  ClusterCurator,
   ClusterDeployment,
+  ClusterManagementAddOn,
   ClusterPool,
   ManagedCluster,
+  ManagedClusterAddOn,
+  ManagedClusterInfo,
   ManagedClusterSet,
   managedClusterSetLabel,
   mapClusters,
@@ -43,6 +53,41 @@ export function useClusters(
   const hostedClusters = useRecoilValue(hostedClustersState)
   const nodePools = useRecoilValue(nodePoolsState)
 
+  return getMappedClusterPoolClusterSetClusters(
+    managedClusters,
+    clusterDeployments,
+    managedClusterInfos,
+    certificateSigningRequests,
+    managedClusterAddons,
+    clusterManagementAddons,
+    clusterClaims,
+    clusterCurators,
+    agentClusterInstalls,
+    hostedClusters,
+    nodePools,
+    managedClusterSet,
+    clusterPool,
+    isGlobalClusterSet
+  )
+}
+
+// returns the clusters assigned to a ManagedClusterSet without invoking a react hook
+export function getMappedClusterPoolClusterSetClusters(
+  managedClusters: ManagedCluster[],
+  clusterDeployments: ClusterDeployment[],
+  managedClusterInfos: ManagedClusterInfo[],
+  certificateSigningRequests: CertificateSigningRequest[],
+  managedClusterAddons: ManagedClusterAddOn[],
+  clusterManagementAddons: ClusterManagementAddOn[],
+  clusterClaims: ClusterClaim[],
+  clusterCurators: ClusterCurator[],
+  agentClusterInstalls: AgentClusterInstallK8sResource[],
+  hostedClusters: HostedClusterK8sResource[],
+  nodePools: NodePoolK8sResource[],
+  managedClusterSet: ManagedClusterSet | undefined,
+  clusterPool: ClusterPool | undefined,
+  isGlobalClusterSet: boolean | undefined
+) {
   let groupManagedClusters: ManagedCluster[] = []
   let groupClusterDeployments: ClusterDeployment[] = []
 
@@ -91,7 +136,7 @@ export function useClusters(
 
   const groupHostedClusters = hostedClusters.filter((hc) => clusterNames.includes(hc.metadata?.name))
 
-  const clusters: Cluster[] = mapClusters(
+  return mapClusters(
     groupClusterDeployments,
     groupManagedClusterInfos,
     certificateSigningRequests,
@@ -104,6 +149,4 @@ export function useClusters(
     groupHostedClusters,
     nodePools
   )
-
-  return clusters
 }

--- a/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/DiscoveredClusters/DiscoveredClusters.tsx
@@ -216,6 +216,7 @@ export function DiscoveredClustersTable(props: {
           </a>
         </span>
       ),
+      exportContent: (discoveredCluster) => discoveredCluster.spec.displayName,
     },
     {
       header: t('dcTbl.lastActive'),
@@ -229,6 +230,12 @@ export function DiscoveredClustersTable(props: {
                 .humanize()}
         </span>
       ),
+      exportContent: (discoveredCluster) =>
+        discoveredCluster.spec.activityTimestamp === undefined
+          ? 'N/A'
+          : moment
+              .duration(Math.abs(new Date().getTime() - new Date(discoveredCluster.spec.activityTimestamp).getTime()))
+              .humanize(),
     },
     {
       header: t('dcTbl.namespace'),
@@ -236,6 +243,7 @@ export function DiscoveredClustersTable(props: {
         compareStrings(a?.metadata.namespace, b?.metadata.namespace),
       search: (discoveredCluster) => discoveredCluster?.metadata.namespace ?? '-',
       cell: (discoveredCluster) => discoveredCluster?.metadata.namespace ?? '-',
+      exportContent: (discoveredCluster) => discoveredCluster?.metadata.namespace ?? '-',
     },
     {
       header: t('dcTbl.type'),
@@ -250,6 +258,8 @@ export function DiscoveredClustersTable(props: {
       },
       cell: (discoveredCluster) =>
         discoveredCluster?.spec.type ? getFullTypeByAcronym(discoveredCluster?.spec.type) : '-',
+      exportContent: (discoveredCluster) =>
+        discoveredCluster?.spec.type ? getFullTypeByAcronym(discoveredCluster?.spec.type) : '-',
     },
     {
       header: t('dcTbl.openShiftVersion'),
@@ -262,6 +272,7 @@ export function DiscoveredClustersTable(props: {
         }
       },
       cell: (discoveredCluster) => discoveredCluster.spec.openshiftVersion ?? '-',
+      exportContent: (discoveredCluster) => discoveredCluster.spec.openshiftVersion ?? '-',
     },
     {
       header: t('dcTbl.infrastructureProvider'),
@@ -274,6 +285,7 @@ export function DiscoveredClustersTable(props: {
         ) : (
           '-'
         ),
+      exportContent: (discoveredCluster) => getProvider(discoveredCluster?.spec.cloudProvider) || '-',
     },
     {
       header: t('dcTbl.created'),
@@ -287,6 +299,13 @@ export function DiscoveredClustersTable(props: {
                 .humanize()}
         </span>
       ),
+      exportContent: (discoveredCluster) => {
+        return discoveredCluster.spec.creationTimestamp === undefined
+          ? ['N/A']
+          : moment
+              .duration(Math.abs(new Date().getTime() - new Date(discoveredCluster.spec.creationTimestamp).getTime()))
+              .humanize()
+      },
     },
     {
       header: t('dcTbl.discovered'),
@@ -304,6 +323,15 @@ export function DiscoveredClustersTable(props: {
                 .humanize()}
         </span>
       ),
+      exportContent: (discoveredCluster) => {
+        return discoveredCluster.spec.creationTimestamp === undefined
+          ? ['N/A']
+          : moment
+              .duration(
+                Math.abs(new Date().getTime() - new Date(discoveredCluster.metadata.creationTimestamp ?? '').getTime())
+              )
+              .humanize()
+      },
     },
   ]
 
@@ -361,6 +389,8 @@ export function DiscoveredClustersTable(props: {
         columns={discoveredClusterCols}
         keyFn={dckeyFn}
         key="tbl-discoveredclusters"
+        showExportButton
+        exportFilePrefix="discoveredclusters"
         tableActionButtons={[
           {
             id: 'configureDiscovery',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { HostedClusterK8sResource } from '@openshift-assisted/ui-lib/cim'
+import { getVersionFromReleaseImage, HostedClusterK8sResource } from '@openshift-assisted/ui-lib/cim'
 import {
   Alert,
   ButtonVariant,
@@ -31,6 +31,7 @@ import {
   ClusterDeployment,
   ClusterDeploymentDefinition,
   ClusterStatus,
+  exportObjectString,
   getAddonStatusLabel,
   getClusterStatusLabel,
   getRoles,
@@ -72,6 +73,7 @@ import { StatusField } from './components/StatusField'
 import { UpdateAutomationModal } from './components/UpdateAutomationModal'
 import { useAllClusters } from './components/useAllClusters'
 import { ClusterAction, clusterDestroyable, clusterSupportsAction } from './utils/cluster-actions'
+import { TFunction } from 'react-i18next'
 
 const onToggle = (acmCardID: string, setOpen: (open: boolean) => void) => {
   setOpen(false)
@@ -592,6 +594,8 @@ export function ClustersTable(props: {
         emptyState={props.emptyState}
         filters={filters}
         id="managedClusters"
+        showExportButton
+        exportFilePrefix="managedclusters"
       />
     </Fragment>
   )
@@ -616,6 +620,7 @@ export function useClusterNameColumn(): IAcmTableColumn<Cluster> {
         )}
       </>
     ),
+    exportContent: (cluster) => cluster.displayName,
   }
 }
 
@@ -669,6 +674,7 @@ export function useClusterNamespaceColumn(): IAcmTableColumn<Cluster> {
     ),
     sort: 'namespace',
     cell: (cluster) => cluster.namespace || '-',
+    exportContent: (cluster) => cluster.namespace,
   }
 }
 
@@ -683,6 +689,9 @@ export function useClusterStatusColumn(): IAcmTableColumn<Cluster> {
         <StatusField cluster={cluster} />
       </span>
     ),
+    exportContent: (cluster) => {
+      return getClusterStatusLabel(cluster.status, t)
+    },
   }
 }
 
@@ -693,6 +702,39 @@ export function useClusterProviderColumn(): IAcmTableColumn<Cluster> {
     sort: 'provider',
     search: 'provider',
     cell: (cluster) => (cluster?.provider ? <AcmInlineProvider provider={cluster?.provider} /> : '-'),
+    exportContent: (cluster) => {
+      return ProviderLongTextMap[cluster?.provider!]
+    },
+  }
+}
+
+const getControlPlaneString = (cluster: Cluster, t: TFunction<string, undefined>) => {
+  const clusterHasControlPlane = () => {
+    const nodeList = cluster.nodes?.nodeList
+    const roleList = nodeList?.map((node: NodeInfo) => getRoles(node))
+    const hasControlPlane = roleList?.filter((str) => {
+      return str.indexOf('control-plane') > -1
+    })
+    return hasControlPlane ? hasControlPlane.length > 0 : false
+  }
+
+  if (cluster.name === 'local-cluster') {
+    return t('Hub')
+  }
+  if (cluster.isRegionalHubCluster) {
+    if (cluster.isHostedCluster || cluster.isHypershift) {
+      return t('Hub, Hosted')
+    }
+    return t('Hub')
+  }
+  if (
+    cluster.isHostedCluster ||
+    cluster.isHypershift ||
+    (cluster.distribution?.displayVersion?.includes('ROSA') && !clusterHasControlPlane())
+  ) {
+    return t('Hosted')
+  } else {
+    return t('Standalone')
   }
 }
 
@@ -701,33 +743,10 @@ export function useClusterControlPlaneColumn(): IAcmTableColumn<Cluster> {
   return {
     header: t('table.controlplane'),
     cell: (cluster) => {
-      const clusterHasControlPlane = () => {
-        const nodeList = cluster.nodes?.nodeList
-        const roleList = nodeList?.map((node: NodeInfo) => getRoles(node))
-        const hasControlPlane = roleList?.filter((str) => {
-          return str.indexOf('control-plane') > -1
-        })
-        return hasControlPlane ? hasControlPlane.length > 0 : false
-      }
-
-      if (cluster.name === 'local-cluster') {
-        return t('Hub')
-      }
-      if (cluster.isRegionalHubCluster) {
-        if (cluster.isHostedCluster || cluster.isHypershift) {
-          return t('Hub, Hosted')
-        }
-        return t('Hub')
-      }
-      if (
-        cluster.isHostedCluster ||
-        cluster.isHypershift ||
-        (cluster.distribution?.displayVersion?.includes('ROSA') && !clusterHasControlPlane())
-      ) {
-        return t('Hosted')
-      } else {
-        return t('Standalone')
-      }
+      return getControlPlaneString(cluster, t)
+    },
+    exportContent: (cluster) => {
+      return getControlPlaneString(cluster, t)
     },
   }
 }
@@ -737,6 +756,25 @@ export function useClusterDistributionColumn(
   hostedClusters: HostedClusterK8sResource[]
 ): IAcmTableColumn<Cluster> {
   const { t } = useTranslation()
+  const { agentClusterInstallsState, clusterImageSetsState } = useSharedAtoms()
+  const clusterImageSets = useRecoilValue(clusterImageSetsState)
+  const agentClusterInstalls = useRecoilValue(agentClusterInstallsState)
+  const clusters = useAllClusters()
+  const agentClusterObject: Record<string, string> = {}
+
+  clusters.forEach((cluster) => {
+    const agentClusterInstall = agentClusterInstalls.find((aci) => {
+      return aci.metadata?.name === cluster?.name && aci.metadata?.namespace === cluster.namespace
+    })
+    const clusterImage = clusterImageSets.find(
+      (clusterImageSet) => clusterImageSet.metadata?.name === agentClusterInstall?.spec?.imageSetRef?.name
+    )
+    const version = getVersionFromReleaseImage(clusterImage?.spec?.releaseImage)
+    if (version) {
+      agentClusterObject[cluster?.name] = version
+    }
+  })
+
   return {
     header: t('table.distribution'),
     sort: 'distribution.displayVersion',
@@ -749,6 +787,23 @@ export function useClusterDistributionColumn(
         resource={'managedclusterpage'}
       />
     ),
+    exportContent: (cluster) => {
+      let version
+      const openshiftText = 'OpenShift'
+      const microshiftText = 'MicroShift'
+
+      if (cluster?.provider === Provider.microshift) {
+        version = cluster?.microshiftDistribution?.version
+        return version ?? `${microshiftText} ${version}`
+      }
+      // use version from cluster image
+      const clusterImageVersion = agentClusterObject[cluster.name]
+      if (clusterImageVersion) {
+        return `${openshiftText} ${clusterImageVersion}`
+      }
+      // else use displayVersion
+      return cluster?.distribution?.displayVersion
+    },
   }
 }
 
@@ -793,6 +848,11 @@ export function useClusterLabelsColumn(): IAcmTableColumn<Cluster> {
         return '-'
       }
     },
+    exportContent: (cluster) => {
+      if (cluster.labels) {
+        return exportObjectString(cluster.labels)
+      }
+    },
   }
 }
 
@@ -811,6 +871,9 @@ export function useClusterNodesColumn(): IAcmTableColumn<Cluster> {
       ) : (
         '-'
       )
+    },
+    exportContent: (cluster) => {
+      return `healthy: ${cluster.nodes!.ready}, danger: ${cluster.nodes!.unhealthy}, unknown: ${cluster.nodes!.unknown}`
     },
   }
 }
@@ -833,7 +896,15 @@ export function useClusterAddonColumn(): IAcmTableColumn<Cluster> {
         '-'
       )
     },
+    exportContent: (cluster) => {
+      return `healthy: ${cluster.addons!.available}, danger: ${cluster.addons!.degraded}, in progress: ${cluster.addons!.progressing},  unknown: ${cluster.addons!.unknown}`
+    },
   }
+}
+
+const getCreationTimestampString = (cluster: Cluster) => {
+  const dateTimeCell = getDateTimeCell(cluster.creationTimestamp ? new Date(cluster.creationTimestamp).toString() : '-')
+  return dateTimeCell.title === 'Invalid Date' ? '-' : dateTimeCell.title
 }
 
 export function useClusterCreatedDateColumn(): IAcmTableColumn<Cluster> {
@@ -851,10 +922,10 @@ export function useClusterCreatedDateColumn(): IAcmTableColumn<Cluster> {
     search: 'creationDate',
     cellTransforms: [nowrap],
     cell: (cluster) => {
-      const dateTimeCell = getDateTimeCell(
-        cluster.creationTimestamp ? new Date(cluster.creationTimestamp).toString() : '-'
-      )
-      return dateTimeCell.title === 'Invalid Date' ? '-' : dateTimeCell.title
+      return getCreationTimestampString(cluster)
+    },
+    exportContent: (cluster) => {
+      return getCreationTimestampString(cluster)
     },
   }
 }


### PR DESCRIPTION
Regarding: [ACM-12098](https://issues.redhat.com/browse/ACM-12098)

**Holding PR so #3681 can merge ahead of it.**

Implement CSV export for Cluster list, Cluster sets, Cluster pools, Discovered clusters tabs.
![Screenshot 2024-07-19 at 5 29 27 PM](https://github.com/user-attachments/assets/e19a6127-ab55-4fdc-a6d2-2ce4aa9ba29c)

Example output: 
[managedclusters-1721435333872.csv](https://github.com/user-attachments/files/16318015/managedclusters-1721435333872.csv)
[clustersets-1721435787818.csv](https://github.com/user-attachments/files/16318020/clustersets-1721435787818.csv)
[clusterpool-1721435799153.csv](https://github.com/user-attachments/files/16318022/clusterpool-1721435799153.csv)
[discoveredclusters-1721435808274.csv](https://github.com/user-attachments/files/16318023/discoveredclusters-1721435808274.csv)
