### PR TITLE
Standardize Cluster violations string

### DIFF
--- a/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.test.tsx
+++ b/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.test.tsx
@@ -345,7 +345,7 @@ describe('PolicySets Page', () => {
     await clickByText('Policies')
 
     // Find remediation
-    await waitForText('Cluster violation')
+    await waitForText('Cluster violations')
     await waitForText(REMEDIATION_ACTION.ENFORCE_OVERRIDDEN)
 
     // find the policy names in table

--- a/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
+++ b/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
@@ -266,7 +266,7 @@ export function PolicySetDetailSidebar(props: { policySet: PolicySet }) {
         },
       },
       {
-        header: t('Cluster violation'),
+        header: t('Cluster violations'),
         sort: (policyA: Policy, policyB: Policy) => {
           // Find the clusters in context of the PolicySet
           const policySetClusterContextA = getClusterContext(policyA)


### PR DESCRIPTION
 The UI should be using the exact same string keys where applicable to mitigate chances of inconsistent text and increasing work on doc and costs for translation.
Ref: https://issues.redhat.com/browse/ACM-12604
Signed-off-by: yiraeChristineKim <yikim@redhat.com>