### PR TITLE
ACM-12098: Implement CSV export for credentials page

### DIFF
--- a/frontend/src/routes/Credentials/CredentialsPage.tsx
+++ b/frontend/src/routes/Credentials/CredentialsPage.tsx
@@ -118,10 +118,25 @@ export function CredentialsTable(props: {
     return inUse
   }
 
+  const getAdditionalActionsText = (item: Secret) => {
+    const label = item.metadata.labels?.['cluster.open-cluster-management.io/type']
+    if (label === Provider.redhatcloud) {
+      if (CredentialIsInUseByDiscovery(item)) {
+        return t('Configure cluster discovery')
+      } else {
+        return t('Create cluster discovery')
+      }
+    } else {
+      return '-'
+    }
+  }
+
   return (
     <Fragment>
       <BulkActionModal<Secret> {...modalProps} />
       <AcmTable<Secret>
+        showExportButton
+        exportFilePrefix="credentials"
         emptyState={
           <AcmEmptyState
             title={t(`You don't have any credentials`)}
@@ -164,6 +179,7 @@ export function CredentialsTable(props: {
                 </Link>
               </span>
             ),
+            exportContent: (secret) => secret.metadata.name,
           },
           {
             header: t('Credential type'),
@@ -178,12 +194,18 @@ export function CredentialsTable(props: {
             search: (item: Secret) => {
               return getProviderName(item.metadata?.labels)
             },
+            exportContent: (item: Secret) => {
+              return getProviderName(item.metadata.labels)
+            },
           },
           {
             header: t('Namespace'),
             sort: 'metadata.namespace',
             search: 'metadata.namespace',
             cell: 'metadata.namespace',
+            exportContent: (item: Secret) => {
+              return item.metadata.namespace
+            },
           },
           {
             header: t('Additional actions'),
@@ -202,6 +224,9 @@ export function CredentialsTable(props: {
                 return <span>-</span>
               }
             },
+            exportContent: (item: Secret) => {
+              return getAdditionalActionsText(item)
+            },
             sort: /* istanbul ignore next */ (a: Secret, b: Secret) => {
               return compareStrings(getAdditionalActions(a), getAdditionalActions(b))
             },
@@ -214,6 +239,11 @@ export function CredentialsTable(props: {
                 {resource.metadata.creationTimestamp && moment(new Date(resource.metadata.creationTimestamp)).fromNow()}
               </span>
             ),
+            exportContent: (item: Secret) => {
+              if (item.metadata.creationTimestamp) {
+                return moment(new Date(item.metadata.creationTimestamp)).fromNow()
+              }
+            },
           },
           {
             header: '',


### PR DESCRIPTION
Regarding: [ACM-12098](https://issues.redhat.com/browse/ACM-12098)

Holding PR so #3681 can merge ahead of it.

![Screenshot 2024-07-19 at 5 44 31 PM](https://github.com/user-attachments/assets/0a018940-0cdd-40d1-bd55-87aae878697e)
Example output: 
[credentials-1721436369263.csv](https://github.com/user-attachments/files/16318064/credentials-1721436369263.csv)
