### PR TITLE
ACM-12098: Helper function for export of SubRows and returning CSV safe strings

### DIFF
--- a/frontend/src/resources/utils/utils.ts
+++ b/frontend/src/resources/utils/utils.ts
@@ -1,6 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import get from 'get-value'
+import { ReactNode } from 'react'
 
 export function getLatest<T>(items: T[], key: string) {
   if (items.length === 0) {
@@ -43,4 +44,15 @@ export function getGroupFromApiVersion(apiVersion: string) {
     return { apiGroup: apiVersion.split('/')[0], version: apiVersion.split('/')[1] }
   }
   return { apiGroup: '', version: apiVersion }
+}
+
+export function exportObjectString(object: Record<string, string>) {
+  const keyValueMap = Object.keys(object).map((key) => {
+    return `'${key}':'${object[key]}'`
+  })
+  return keyValueMap.toString()
+}
+
+export function returnCSVSafeString(exportValue: string | ReactNode) {
+  return `"${exportValue}"`
 }

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -79,7 +79,7 @@ import { AcmManageColumn } from './AcmManageColumn'
 import { useNavigate, useLocation } from 'react-router-dom-v5-compat'
 import { ParsedQuery, parse, stringify } from 'query-string'
 import { IAlertContext } from '../AcmAlert/AcmAlert'
-import { createDownloadFile } from '../../resources/utils'
+import { createDownloadFile, returnCSVSafeString } from '../../resources/utils'
 
 type SortFn<T> = (a: T, b: T) => number
 type CellFn<T> = (item: T) => ReactNode
@@ -119,6 +119,9 @@ export interface IAcmTableColumn<T> {
   // isFirstVisitChecked=true, When users visit at the first time, users can see these columns.
   // unlike isDefualt columns, these columns can be controllable.
   isFirstVisitChecked?: boolean
+
+  // Used to supply export information for Sub Rows. If true, the table will include column item within the CSV export
+  isSubRowExport?: boolean
 }
 
 /* istanbul ignore next */
@@ -201,10 +204,18 @@ export type IAcmTableAction<T> =
   | IAcmTableActionSeperator
   | IAcmTableActionGroup<T>
 
+export interface ExportableIRow extends IRow {
+  // content from subrow to include in export document
+  exportSubRow?: {
+    header: string
+    exportContent: (item: any) => string
+  }[]
+}
+
 interface ITableItem<T> {
   item: T
   key: string
-  subRows?: IRow[]
+  subRows?: ExportableIRow[]
   [key: string]: unknown
 }
 
@@ -842,17 +853,28 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
       selectedSortedCols.forEach(({ header }) => {
         header && headerString.push(header)
       })
+      sorted[0]?.subRows &&
+        sorted[0].subRows[0]?.exportSubRow?.forEach(({ header }) => {
+          header && headerString.push(header)
+        })
       csvExportCellArray.push(headerString.join(','))
 
-      sorted.forEach(({ item }) => {
+      sorted.forEach(({ item, subRows }) => {
         let contentString: string[] = []
         selectedSortedCols.forEach(({ header, exportContent }) => {
           if (header) {
             // if callback and its output exists, add to array, else add "-"
-            exportContent && exportContent(item)
-              ? contentString.push(exportContent(item) as string)
-              : contentString.push('-')
+            const exportvalue = exportContent?.(item)
+            exportvalue ? contentString.push(returnCSVSafeString(exportvalue)) : contentString.push('-')
           }
+        })
+        subRows?.forEach(({ exportSubRow }) => {
+          exportSubRow?.forEach(({ header, exportContent }) => {
+            if (header) {
+              const exportvalue = exportContent?.(item)
+              exportvalue ? contentString.push(returnCSVSafeString(exportvalue)) : contentString.push('-')
+            }
+          })
         })
         contentString = [contentString.join(',')]
         contentString[0] && csvExportCellArray.push(contentString[0])


### PR DESCRIPTION
Related to ACM-12099: Here I'm adding some functionality to the export feature that will make exporting SubRows possible and will make exporting strings with comma's a seamless experience.

**_Merge this commit ahead of the  "Implementation" commits!_**