### PR TITLE
ACM-12797 - LaunchLogs uses default path for installer pod logs

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HiveNotification.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HiveNotification.test.tsx
@@ -157,9 +157,7 @@ describe('HiveNotification', () => {
     await waitForNock(podScope)
     await waitFor(() =>
       expect(window.open).toHaveBeenCalledWith(
-        `${
-          mockOpenShiftConsoleConfigMap.data!.consoleURL
-        }/k8s/ns/test-cluster/pods/test-cluster-pod/logs?container=hive`
+        `${mockOpenShiftConsoleConfigMap.data!.consoleURL}/k8s/ns/test-cluster/pods/test-cluster-pod/logs`
       )
     )
   })
@@ -182,9 +180,7 @@ describe('HiveNotification', () => {
     await waitForNock(podScope)
     await waitFor(() =>
       expect(window.open).toHaveBeenCalledWith(
-        `${
-          mockOpenShiftConsoleConfigMap.data!.consoleURL
-        }/k8s/ns/test-cluster/pods/test-cluster-pod/logs?container=hive`
+        `${mockOpenShiftConsoleConfigMap.data!.consoleURL}/k8s/ns/test-cluster/pods/test-cluster-pod/logs`
       )
     )
   })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HiveNotification.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/HiveNotification.tsx
@@ -107,11 +107,7 @@ export function launchLogs(cluster: Cluster, configMaps: ConfigMap[]) {
     const response = getHivePod(cluster.namespace, cluster.name, cluster.status)
     response.then((job) => {
       const podName = job?.metadata.name || ''
-      const containerName = podName.includes('uninstall') ? 'deprovision' : 'hive'
-      podName &&
-        window.open(
-          `${openShiftConsoleUrl}/k8s/ns/${cluster.namespace}/pods/${podName}/logs?container=${containerName}`
-        )
+      podName && window.open(`${openShiftConsoleUrl}/k8s/ns/${cluster.namespace}/pods/${podName}/logs`)
     })
   }
 }


### PR DESCRIPTION
Regarding: [ACM-12899](https://issues.redhat.com/browse/ACM-12899)

https://github.com/user-attachments/assets/ed099cca-aaee-4221-bb4a-de02d57d0c3d

