### PR TITLE
EDM-312: Add AcmErrorBoundary to Overview tabs

### DIFF
--- a/frontend/src/routes/Home/Overview/Overview.test.tsx
+++ b/frontend/src/routes/Home/Overview/Overview.test.tsx
@@ -145,4 +145,3 @@ it('should render overview page layout when extension tab crashes', async () => 
   await waitForText('Overview')
   await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
 })
-

--- a/frontend/src/routes/Home/Overview/Overview.test.tsx
+++ b/frontend/src/routes/Home/Overview/Overview.test.tsx
@@ -85,3 +85,64 @@ it('should render overview page with extension', async () => {
   await waitForText('Test extension content')
   await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
 })
+
+it('should render overview page layout when extension tab crashes', async () => {
+  const apiPathNock = nockIgnoreApiPaths()
+  const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
+  const getManageedClusterAccessRequeset = nockCreate(mockGetSelfSubjectAccessRequest, mockGetSelfSubjectAccessResponse)
+  const metricNock = nockPostRequest('/metrics?overview-classic', {})
+  nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
+  nockSearch(mockSearchQueryArgoAppsCount, mockSearchResponseArgoAppsCount)
+  nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
+  nockSearch(mockSearchQueryOCPApplicationsCount, mockSearchResponseOCPApplicationsCount)
+  render(
+    <RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MockedProvider mocks={[]}>
+            <PluginContext.Provider
+              value={{
+                isACMAvailable: false,
+                isOverviewAvailable: true,
+                isSubmarinerAvailable: true,
+                isApplicationsAvailable: true,
+                isGovernanceAvailable: true,
+                isSearchAvailable: true,
+                dataContext: PluginDataContext,
+                acmExtensions: {
+                  overviewTab: [
+                    {
+                      pluginID: 'test-plugin',
+                      pluginName: 'test-plugin',
+                      type: 'acm.overview/tab',
+                      uid: 'test-plugin-tab',
+                      properties: {
+                        tabTitle: 'Test tab',
+                        component: () => {
+                          throw new Error('Uncaught error from a bad extension')
+                        },
+                      },
+                    },
+                  ],
+                },
+                ocpApi: {
+                  useK8sWatchResource: () => [[] as any, true, undefined],
+                },
+              }}
+            >
+              <Overview />
+            </PluginContext.Provider>
+          </MockedProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </RecoilRoot>
+  )
+
+  await waitForText('Overview')
+  await waitForText('Test tab')
+  await clickByText('Test tab')
+
+  await waitForText('Overview')
+  await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
+})
+

--- a/frontend/src/routes/Home/Overview/Overview.tsx
+++ b/frontend/src/routes/Home/Overview/Overview.tsx
@@ -3,7 +3,7 @@ import { Label, Switch } from '@patternfly/react-core'
 import { useContext, useState } from 'react'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { PluginContext } from '../../../lib/PluginContext'
-import { AcmPage, AcmPageHeader, AcmSecondaryNav, AcmSecondaryNavItem } from '../../../ui-components'
+import { AcmErrorBoundary, AcmPage, AcmPageHeader, AcmSecondaryNav, AcmSecondaryNavItem } from '../../../ui-components'
 import ReuseableSearchbar from '../../Search/components/ReuseableSearchbar'
 import ClustersTab from './ClustersTab'
 import OverviewClusterLabelSelector from './OverviewClusterLabelSelector'
@@ -21,7 +21,11 @@ export default function Overview() {
   if (selectedTab) {
     const Component = acmExtensions?.overviewTab?.find((o) => o.uid === selectedTab)?.properties.component
     if (Component) {
-      content = <Component />
+      content = (
+        <AcmErrorBoundary>
+          <Component />
+        </AcmErrorBoundary>
+      )
     }
   }
 


### PR DESCRIPTION
In the Overview page, a possible error in the selected extension tab shouldn't break the ACM UI.

I added an `AcmErrorBoundary` component to the tab content to prevent this. (Just a pre-emptively change as we are reviewing the last bits of the integration of Flight Control into ACM).

After the change:
![captured-tab-crash](https://github.com/user-attachments/assets/5ab6cdfd-a634-4221-92eb-e49fbc0ea476)

