### PR TITLE
ACM-13209 - Update search parameters when returning to ACMTable with a filter

### DIFF
--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -368,7 +368,7 @@ export function useTableFilterSelections<T>({ id, filters }: { id?: string; filt
     updateFilters({})
   }, [updateFilters])
 
-  return { filterSelections, addFilterValue, removeFilterValue, removeFilter, clearFilters }
+  return { filterSelections, addFilterValue, removeFilterValue, removeFilter, clearFilters, updateFilters }
 }
 
 function setLocalStorage(key: string | undefined, value: any) {
@@ -1389,11 +1389,14 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
 function TableColumnFilters<T>(props: Readonly<{ id?: string; filters: ITableFilter<T>[]; items?: T[] }>) {
   const [isOpen, setIsOpen] = useState(false)
   const { id, filters, items } = props
-  const { filterSelections, addFilterValue, removeFilterValue, removeFilter } = useTableFilterSelections({
-    id,
-    filters,
-  })
+  const { filterSelections, addFilterValue, removeFilterValue, removeFilter, updateFilters } = useTableFilterSelections(
+    {
+      id,
+      filters,
+    }
+  )
   const { t } = useTranslation()
+  const { search: searchString } = useLocation()
 
   const onFilterSelect = useCallback(
     (selection: FilterSelectOptionObject) => {
@@ -1428,6 +1431,13 @@ function TableColumnFilters<T>(props: Readonly<{ id?: string; filters: ITableFil
       []
     )
   }, [filterSelections])
+
+  useEffect(() => {
+    // search parameters need to be re-added (updated) when moving between pages
+    if (selections.length && !searchString) {
+      updateFilters(filterSelections)
+    }
+  }, [updateFilters, filterSelections, searchString, selections])
 
   const filterSelectGroups = useMemo(() => {
     const validFilters: {


### PR DESCRIPTION
Regarding: https://issues.redhat.com/browse/ACM-13209
https://redhat-internal.slack.com/archives/C02684L8JMV/p1723130553096239  


Search parameter is not being added back to URL when user returns to a page with a AcmTable filter being applied to it.
The fix is an attempt at updating the search parameter whenever AcmTable is rendered and the filter content changes.

Before: 

https://github.com/user-attachments/assets/5c3f0f02-ce11-4807-a99c-eb06632db8c6


After:

https://github.com/user-attachments/assets/42ad4a04-79a5-4e4c-a48a-255735e6a589




