### PR TITLE
ACM-13295-Not-able-to-undo-in-YAML-editor

### DIFF
--- a/frontend/__mocks__/react-monaco-editor.tsx
+++ b/frontend/__mocks__/react-monaco-editor.tsx
@@ -117,7 +117,10 @@ const MonacoEditor = (props: {
         past: ['past'],
       },
       forceTokenization: () => {},
-      getLineCount: () => {},
+      getLineCount: () => {
+        const text = editorMockRef.current.editorContent
+        return text.trim().split('\n').length
+      },
       getFullModelRange: () => {},
       canUndo: () => true,
       canRedo: () => true,

--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -204,13 +204,11 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
           const text = `${lead}${lines.map((line: string) => line.trim()).join(joint)}\r\n`
           editorRef.current.executeEdits('my-source', [{ range: selection, text: text, forceMoveMarkers: true }])
         }
-        const selections = editorRef.current.getSelections()
         // when user is pasting in a complete yaml, do we need to make sure the resource has a namespace
         if (
           autoCreateNs && // make sure resource has namespace
-          selections.length === 1 &&
-          selections[0].startColumn === 1 &&
-          selections[0].endLineNumber === model.getLineCount()
+          selection.startColumn === 1 &&
+          selection.endLineNumber === model.getLineCount()
         ) {
           let nameInx
           let hasMetadata = false

--- a/frontend/src/components/SyncEditor/process.ts
+++ b/frontend/src/components/SyncEditor/process.ts
@@ -5,7 +5,6 @@ import { getErrors, validate } from './validation'
 import { getMatchingValues, getUidSiblings, crossReference, getPathArray } from './synchronize'
 import { reconcile } from './reconcile'
 import { ChangeType } from './changes'
-import { Pair } from 'yaml/types'
 
 export interface ProcessedType {
   parsed: {
@@ -119,34 +118,10 @@ export const processUser = (
   readonly: boolean,
   validators: any,
   currentEditorValue: string,
-  editableUidSiblings: boolean | undefined,
-  autoCreateNs?: boolean
+  editableUidSiblings: boolean | undefined
 ) => {
   // get yaml, documents, resource, mapped
-  let documents: any[] = YAML.parseAllDocuments(yaml, { prettyErrors: true, keepCstNodes: true })
-  let createNs = false
-  if (autoCreateNs) {
-    const newDocs = documents.map((doc: YAML.Document) => {
-      if (doc.has('metadata') && !doc.hasIn(['metadata', 'namespace'])) {
-        createNs = true
-        const pair = new Pair('namespace', '')
-
-        doc.addIn(['metadata'], pair)
-
-        return doc
-      }
-      return doc
-    })
-
-    const yamlArr = newDocs.map((doc) => {
-      return YAML.stringify(doc)
-    })
-
-    yaml = yamlArr.join('\n---\n')
-
-    documents = YAML.parseAllDocuments(yaml, { prettyErrors: true, keepCstNodes: true })
-  }
-
+  const documents: any[] = YAML.parseAllDocuments(yaml, { prettyErrors: true, keepCstNodes: true })
   const syntaxErrors = getErrors(documents)
   const { parsed } = getMappings(documents)
 
@@ -171,8 +146,7 @@ export const processUser = (
       validators,
       currentEditorValue,
       true,
-      editableUidSiblings,
-      createNs
+      editableUidSiblings
     ),
   }
 }
@@ -192,8 +166,7 @@ const process = (
   validators: any,
   currentEditorValue: string,
   editorHasFocus: boolean,
-  editableUidSiblings: boolean | undefined,
-  createNs?: boolean
+  editableUidSiblings: boolean | undefined
 ) => {
   // restore hidden secret values
   let { mappings, parsed, resources, paths } = getMappings(documents)
@@ -253,7 +226,7 @@ const process = (
     }
 
     // create redacted yaml, etc
-    yaml = editorHasFocus && !createNs ? currentEditorValue : stringify(resources)
+    yaml = editorHasFocus ? currentEditorValue : stringify(resources)
     documents = YAML.parseAllDocuments(yaml, { keepCstNodes: true })
     ;({ mappings, parsed, resources, paths } = getMappings(documents))
   }


### PR DESCRIPTION
unfortunately using setYaml on the monaco editor has the unfortunate side effect of messing up the undo stack

to avoid that, monaco prefers adding text with an executeEdits()

we don't want to do that everytime the user types a character because it would mess up the stack even more

but since the bug is only that it doesn't do it with a full paste

so when a paste occurs, this change now looks at the pasted yaml and if it's missing the namespace it will add it

if we want to make this more generic, instead of a boolean (autoAddNs) we could make that a function that's called when a paste occurs which then fixes up the pasted yaml

Signed-off-by: John Swanke <jswanke@redhat.com>