### PR TITLE
Submariner: include hosted clusters in list of available clusters

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetInstallSubmariner/InstallSubmarinerForm.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetInstallSubmariner/InstallSubmarinerForm.tsx
@@ -62,8 +62,9 @@ export function InstallSubmarinerFormPage() {
   const [availableClusters] = useState<Cluster[]>(
     clusters.filter(
       (cluster) =>
-        !submarinerAddons.find((addon) => addon.metadata.namespace === cluster.namespace) &&
-        cluster.distribution?.ocp?.version // OpenShift clusters only
+        (!submarinerAddons.find((addon) => ((addon.metadata.namespace === cluster.namespace) || cluster.isHostedCluster ) &&
+        cluster.distribution?.ocp?.version) // OpenShift clusters only
+        )
     )
   )
   const { isSubmarinerAvailable } = useContext(PluginContext)


### PR DESCRIPTION
For hosted clusters Cluster.namespace [1] is equal to the hostedCluster CR namespace and not managedClusterInfo CR namespace.

This PR updates available Submariner clusters to include hosted clusters as well.

[1]
https://github.com/stolostron/console/blob/main/frontend/src/resources/utils/get-cluster.ts#L470