### PR TITLE
Run MCE Konflux on PRs against ACM branch [release-2.9]

### DIFF
--- a/.tekton/console-mce-pull-request.yaml
+++ b/.tekton/console-mce-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: '[pull_request]'
-    pipelinesascode.tekton.dev/on-target-branch: '[backplane-2.4]'
+    pipelinesascode.tekton.dev/on-target-branch: '[release-2.9]'
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: mce-24


### PR DESCRIPTION
Since we fast-forward from our `release-*` branches to our corresponding `backplane-*` branch, the MCE PR configuration should be run on PRs against the `release-*` branch.