### PR TITLE
Run MCE Konflux on PRs against ACM branch [release-2.11]

### DIFF
--- a/.tekton/console-mce-mce-26-pull-request.yaml
+++ b/.tekton/console-mce-mce-26-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "backplane-2.6"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.11"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-mce-26


### PR DESCRIPTION
Since we fast-forward from our `release-*` branches to our corresponding `backplane-*` branch, the MCE PR configuration should be run on PRs against the `release-*` branch.