### PR TITLE
Add advanced config table option to csv export file name prefix

### DIFF
--- a/frontend/src/routes/Applications/components/ToggleSelector.tsx
+++ b/frontend/src/routes/Applications/components/ToggleSelector.tsx
@@ -46,7 +46,7 @@ export function ToggleSelector(props: IToggleSelectorProps) {
       <DeleteResourceModal {...props.modalProps} />
       <AcmTable<IResource>
         showExportButton
-        exportFilePrefix="applicationadvancedconfiguration"
+        exportFilePrefix={`applicationadvancedconfiguration-${selectedId}`}
         columns={selectedResources.columns}
         keyFn={props.keyFn}
         items={selectedResources.items}


### PR DESCRIPTION
Regarding: https://issues.redhat.com/browse/ACM-13595

Adds Application page advanced configuration table tab name to the CSV file prefix.