### PR TITLE
Add a tab for the YAML editor on the template details page

### DIFF
--- a/frontend/src/NavigationPath.tsx
+++ b/frontend/src/NavigationPath.tsx
@@ -154,6 +154,7 @@ export enum NavigationPath {
   policyDetailsResults = '/multicloud/governance/policies/details/:namespace/:name/results',
   policyDetailsHistory = '/multicloud/governance/policies/details/:namespace/:name/status/:clusterName/templates/:templateName/history',
   policyTemplateDetails = '/multicloud/governance/policies/details/:namespace/:name/template/:clusterName/:apiGroup?/:apiVersion/:kind/:templateName',
+  policyTemplateYaml = '/multicloud/governance/policies/details/:namespace/:name/template/:clusterName/:apiGroup?/:apiVersion/:kind/:templateName/yaml',
   createPolicySet = '/multicloud/governance/policy-sets/create',
   editPolicySet = '/multicloud/governance/policy-sets/edit/:namespace/:name',
 

--- a/frontend/src/routes/Governance/Governance.tsx
+++ b/frontend/src/routes/Governance/Governance.tsx
@@ -16,6 +16,8 @@ import PolicyDetailsResults from './policies/policy-details/PolicyDetailsResults
 import GovernanceOverview from './overview/Overview'
 import PolicySetsPage from './policy-sets/PolicySets'
 import PoliciesPage from './policies/Policies'
+import { PolicyTemplateDetails } from './policies/policy-details/PolicyTemplateDetails'
+import PolicyTemplateYaml from './policies/policy-details/PolicyTemplateYaml'
 
 const governanceChildPath = createRoutePathFunction(NavigationPath.governance)
 
@@ -26,8 +28,11 @@ export default function Governance() {
       <Route path={governanceChildPath(NavigationPath.editPolicy)} element={<EditPolicy />} />
       <Route path={governanceChildPath(NavigationPath.createPolicyAutomation)} element={<CreatePolicyAutomation />} />
       <Route path={governanceChildPath(NavigationPath.editPolicyAutomation)} element={<EditPolicyAutomation />} />
-      <Route path={governanceChildPath(NavigationPath.policyTemplateDetails)} element={<PolicyTemplateDetailsPage />} />
       <Route path={governanceChildPath(NavigationPath.policyDetailsHistory)} element={<PolicyDetailsHistoryPage />} />
+      <Route element={<PolicyTemplateDetailsPage />}>
+        <Route path={governanceChildPath(NavigationPath.policyTemplateDetails)} element={<PolicyTemplateDetails />} />
+        <Route path={governanceChildPath(NavigationPath.policyTemplateYaml)} element={<PolicyTemplateYaml />} />
+      </Route>
       <Route element={<PolicyDetailsPage />}>
         <Route path={governanceChildPath(NavigationPath.policyDetails)} element={<PolicyDetailsOverview />} />
         <Route path={governanceChildPath(NavigationPath.policyDetailsResults)} element={<PolicyDetailsResults />} />

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
@@ -1,19 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
-
-import {
-  Card,
-  CardExpandableContent,
-  CardHeader,
-  CardTitle,
-  Grid,
-  GridItem,
-  PageSection,
-  Title,
-} from '@patternfly/react-core'
+import { Grid, GridItem, PageSection, Title } from '@patternfly/react-core'
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
-import jsYaml from 'js-yaml'
 import { useEffect, useMemo, useState } from 'react'
-import YamlEditor from '../../../../components/YamlEditor'
 import { useTranslation } from '../../../../lib/acm-i18next'
 import { NavigationPath } from '../../../../NavigationPath'
 
@@ -25,21 +13,16 @@ import {
   compareStrings,
 } from '../../../../ui-components'
 import { DiffModal } from '../../components/DiffModal'
+import { useTemplateDetailsContext } from './PolicyTemplateDetailsPage'
+import { useParams } from 'react-router-dom-v5-compat'
 
-export function PolicyTemplateDetails(
-  props: Readonly<{
-    clusterName: string
-    template: any
-  }>
-) {
+export function PolicyTemplateDetails() {
   const { t } = useTranslation()
-  const { clusterName, template } = props
-  const isCertPolicy = template?.kind === 'CertificatePolicy'
+  const urlParams = useParams()
+  const kind = urlParams.kind ?? ''
+  const { clusterName, template } = useTemplateDetailsContext()
+  const isCertPolicy = kind === 'CertificatePolicy'
   const [relatedObjects, setRelatedObjects] = useState<any>()
-  const [isExpanded, setIsExpanded] = useState<boolean>(isCertPolicy)
-  const [editorHeight, setEditorHeight] = useState<number>(250)
-
-  const kind = template?.kind
 
   useEffect(() => {
     if (template?.status?.relatedObjects?.length) {
@@ -82,15 +65,6 @@ export function PolicyTemplateDetails(
     setRelatedObjects([])
   }, [clusterName, template])
 
-  // Hook to get the height of the template details section so both details and editor sections are the same height
-  /* istanbul ignore next */
-  useEffect(() => {
-    const detailsElementHeight = document.getElementById('template-details-section')?.offsetHeight
-    if (detailsElementHeight && detailsElementHeight > 250) {
-      setEditorHeight(detailsElementHeight)
-    }
-  }, [])
-
   const descriptionItems = [
     {
       key: t('Name'),
@@ -102,7 +76,7 @@ export function PolicyTemplateDetails(
     },
     {
       key: t('Kind'),
-      value: template?.kind ?? '-',
+      value: kind ?? '-',
     },
     {
       key: t('API groups'),
@@ -252,23 +226,13 @@ export function PolicyTemplateDetails(
     <div>
       <PageSection style={{ paddingBottom: '0' }}>
         <Grid hasGutter>
-          <GridItem span={6}>
+          <GridItem span={12}>
             <AcmDescriptionList
               id={'template-details-section'}
               title={kind + ' ' + t('details')}
               leftItems={descriptionItems}
               defaultOpen={isCertPolicy}
             />
-          </GridItem>
-          <GridItem span={6}>
-            <Card isExpanded={isExpanded}>
-              <CardHeader id={'template-yaml-section'} onExpand={() => setIsExpanded(!isExpanded)}>
-                <CardTitle id="titleId">{kind + ' ' + t('YAML')}</CardTitle>
-              </CardHeader>
-              <CardExpandableContent>
-                <YamlEditor resourceYAML={jsYaml.dump(template, { indent: 2 })} readOnly={true} height={editorHeight} />
-              </CardExpandableContent>
-            </Card>
           </GridItem>
         </Grid>
       </PageSection>

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetailsPage.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetailsPage.test.tsx
@@ -9,11 +9,13 @@ import { waitForNocks, waitForNotText, waitForText } from '../../../../lib/test-
 import { NavigationPath } from '../../../../NavigationPath'
 import { ManagedClusterAddOn } from '../../../../resources'
 import { PolicyTemplateDetailsPage } from './PolicyTemplateDetailsPage'
+import { PolicyTemplateDetails } from './PolicyTemplateDetails'
+import PolicyTemplateYaml from './PolicyTemplateYaml'
 
 jest.mock('../../../../components/YamlEditor', () => {
   // TODO replace with actual YAML Page when Monaco editor is imported correctly
   return function YamlEditor() {
-    return <div />
+    return <div>Yaml Editor Open</div>
   }
 })
 
@@ -326,12 +328,14 @@ describe('Policy Template Details Page', () => {
       >
         <MemoryRouter initialEntries={[path]}>
           <Routes>
-            <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetailsPage />} />
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.policyTemplateYaml} element={<PolicyTemplateYaml />} />
+            </Route>
           </Routes>
         </MemoryRouter>
       </RecoilRoot>
     )
-
     // Wait for delete resource requests to finish
     await waitForNocks([getResourceNock])
 
@@ -346,18 +350,21 @@ describe('Policy Template Details Page', () => {
     await waitForText('test-cluster')
     await waitForText('ConfigurationPolicy')
 
-    // wait for template yaml to load correctly
-    await waitForText('ConfigurationPolicy YAML')
-    const yamlButton = container.querySelector('#template-yaml-section > div:nth-child(1) > button')
-    expect(yamlButton).not.toBeNull()
-    userEvent.click(yamlButton as Element)
-
     // wait for related resources table to load correctly
     await waitForText('Related resources')
     await waitForText('test')
     await waitForText('v1')
     await waitForText('No violations', true)
     await waitForText('Resource found as expected')
+
+    // wait for template yaml to load correctly
+    await waitForText('YAML')
+    const yamlButton = container.querySelectorAll('.pf-c-nav__link')
+    expect(yamlButton).not.toBeNull()
+
+    userEvent.click(yamlButton[1])
+
+    await waitForText('Yaml Editor Open')
   })
 
   test('Should render Policy Template Details Page content correctly in hosted mode', async () => {
@@ -420,7 +427,10 @@ describe('Policy Template Details Page', () => {
       >
         <MemoryRouter initialEntries={[path]}>
           <Routes>
-            <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetailsPage />} />
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.policyTemplateYaml} element={<PolicyTemplateYaml />} />
+            </Route>
           </Routes>
         </MemoryRouter>
       </RecoilRoot>
@@ -430,8 +440,7 @@ describe('Policy Template Details Page', () => {
     await waitForNocks([getResourceNock])
 
     await waitForText('ConfigurationPolicy details')
-    const configDetail = screen.getAllByRole('button')[0]
-    userEvent.click(configDetail)
+    screen.getByRole('button', { name: /toggle details/i }).click()
 
     // Verify the template description section
     // Ensure the hosting cluster name isn't shown as the cluster name
@@ -550,7 +559,10 @@ describe('Policy Template Details Page', () => {
       >
         <MemoryRouter initialEntries={[path]}>
           <Routes>
-            <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetailsPage />} />
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.policyTemplateYaml} element={<PolicyTemplateYaml />} />
+            </Route>
           </Routes>
         </MemoryRouter>
       </RecoilRoot>
@@ -566,11 +578,13 @@ describe('Policy Template Details Page', () => {
     await waitForText('ns-must-have-gk', true)
     await waitForText('K8sRequiredLabels')
 
-    const row = screen.getByRole('row', {
-      name: /default-broker - namespace v1 violations you must provide labels: \{"gatekeeper"\} view yaml/i,
-    })
-    const viewYamlLink = within(row).getByRole('link', { name: /view yaml/i })
-    expect(viewYamlLink.getAttribute('href')).toEqual(
+    await waitForText('View YAML', true)
+
+    const viewYamlLinks = screen.getAllByText('View YAML')
+    expect(viewYamlLinks[0].getAttribute('href')).toEqual(
+      `/multicloud/search/resources/yaml?cluster=test-cluster&kind=Namespace&apiversion=v1&name=default`
+    )
+    expect(viewYamlLinks[1].getAttribute('href')).toEqual(
       `/multicloud/search/resources/yaml?cluster=test-cluster&kind=Namespace&apiversion=v1&name=default-broker`
     )
   })
@@ -590,7 +604,10 @@ describe('Policy Template Details Page', () => {
       >
         <MemoryRouter initialEntries={[path]}>
           <Routes>
-            <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetailsPage />} />
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.policyTemplateYaml} element={<PolicyTemplateYaml />} />
+            </Route>
           </Routes>
         </MemoryRouter>
       </RecoilRoot>
@@ -605,6 +622,8 @@ describe('Policy Template Details Page', () => {
     // Verify the template description section
     await waitForText('oppol-no-group', true)
     await waitForText('OperatorPolicy')
+
+    await waitForText('View YAML', true)
 
     const row = screen.getByRole('row', {
       name: /Deployment Available/i,
@@ -739,7 +758,10 @@ describe('Policy Template Details Page', () => {
       >
         <MemoryRouter initialEntries={[path]}>
           <Routes>
-            <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetailsPage />} />
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.policyTemplateYaml} element={<PolicyTemplateYaml />} />
+            </Route>
           </Routes>
         </MemoryRouter>
       </RecoilRoot>
@@ -786,7 +808,10 @@ describe('Policy Template Details Page', () => {
       >
         <MemoryRouter initialEntries={[path]}>
           <Routes>
-            <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetailsPage />} />
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.policyTemplateYaml} element={<PolicyTemplateYaml />} />
+            </Route>
           </Routes>
         </MemoryRouter>
       </RecoilRoot>
@@ -829,7 +854,10 @@ describe('Policy Template Details Page', () => {
       >
         <MemoryRouter initialEntries={[path]}>
           <Routes>
-            <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetailsPage />} />
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.policyTemplateYaml} element={<PolicyTemplateYaml />} />
+            </Route>
           </Routes>
         </MemoryRouter>
       </RecoilRoot>
@@ -861,7 +889,10 @@ describe('Policy Template Details Page', () => {
       >
         <MemoryRouter initialEntries={[path]}>
           <Routes>
-            <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetailsPage />} />
+            <Route element={<PolicyTemplateDetailsPage />}>
+              <Route path={NavigationPath.policyTemplateDetails} element={<PolicyTemplateDetails />} />
+              <Route path={NavigationPath.policyTemplateYaml} element={<PolicyTemplateYaml />} />
+            </Route>
           </Routes>
         </MemoryRouter>
       </RecoilRoot>

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateYaml.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateYaml.tsx
@@ -1,0 +1,36 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { PageSection } from '@patternfly/react-core'
+import YamlEditor from '../../../../components/YamlEditor'
+import jsYaml from 'js-yaml'
+import { useTemplateDetailsContext } from './PolicyTemplateDetailsPage'
+import { useEffect, useState } from 'react'
+
+export default function PolicyTemplateYaml() {
+  const { template } = useTemplateDetailsContext()
+  const [editorHeight, setEditorHeight] = useState<number>(500)
+
+  useEffect(() => {
+    function handleResize() {
+      let editorHeight = window.innerHeight - 260
+      const globalHeader = document.getElementsByClassName('co-global-notification')
+      /* istanbul ignore if */
+      if (globalHeader.length > 0) {
+        editorHeight = editorHeight - globalHeader.length * 33
+      }
+
+      setEditorHeight(editorHeight)
+    }
+    // init
+    handleResize()
+
+    window.addEventListener('resize', handleResize)
+
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
+  return (
+    <PageSection>
+      <YamlEditor resourceYAML={jsYaml.dump(template, { indent: 2 })} readOnly={true} height={editorHeight} />
+    </PageSection>
+  )
+}


### PR DESCRIPTION
Add a new 'YAML' tab to the TemplateDetail page and relocate the YAML editor from the small card to the new tab. Ref: https://issues.redhat.com/browse/ACM-13327
Signed-off-by: yiraeChristineKim <yikim@redhat.com>