### PR TITLE
Add link to template in PolicyDetailResult page

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.test.tsx
@@ -39,6 +39,7 @@ describe('Policy Details Results', () => {
     await waitForText('local-cluster')
     await waitForText('No violations')
     await waitForText('policy-set-with-1-placement-policy-1', true)
+    expect(screen.getByTestId('template-name-link-disabled')).toBeInTheDocument()
     await waitForText(
       'notification - namespaces [test] found as specified, therefore this Object template is compliant'
     )


### PR DESCRIPTION
making the Template > “”Template name” in the column clickable and take the user to the same page as “Message” column > “View details” to increase association that this details is for the template 

Ref: https://issues.redhat.com/browse/ACM-13714