### PR TITLE
Allow upgrade and channel select for MOS only when ARO

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -717,11 +717,11 @@ export function getDistributionInfo(
   let ocp: OpenShiftDistributionInfo | undefined
   let displayVersion: string | undefined
 
-  const isManagedOpenShiftUpgradeable = () => {
+  const hasControlPlaneNodes = () => {
     const { nodeList } = getNodes(managedClusterInfo)
     const roleList = nodeList?.map((node: NodeInfo) => getRoles(node))
-    const hasControlPlane = roleList.filter((str) => {
-      return str.indexOf('control-plane') > -1
+    const hasControlPlane = roleList.filter((roles) => {
+      return roles.includes('control-plane') || roles.includes('master')
     })
     return hasControlPlane.length > 0
   }
@@ -738,10 +738,13 @@ export function getDistributionInfo(
       isManagedOpenShift = true
       break
     case 'ROSA':
-      distributionValue = isManagedOpenShiftUpgradeable() ? 'ROSA Classic' : 'ROSA'
+      distributionValue = hasControlPlaneNodes() ? 'ROSA Classic' : 'ROSA'
       isManagedOpenShift = true
       break
     case 'ARO':
+      distributionValue = 'ARO'
+      isManagedOpenShift = true
+      break
     case 'ROKS':
       isManagedOpenShift = true
       break
@@ -910,7 +913,7 @@ export function getDistributionInfo(
       upgradeInfo.availableUpdates &&
       upgradeInfo.availableUpdates.length > 0 &&
       !upgradeInfo.upgradeFailed &&
-      (!isManagedOpenShift || isManagedOpenShiftUpgradeable()) &&
+      (!isManagedOpenShift || productClaim === 'ARO') &&
       !upgradeInfo.isUpgrading &&
       curatorIsIdle
     upgradeInfo.isReadyUpdates = !!isReadyUpdates
@@ -919,7 +922,7 @@ export function getDistributionInfo(
     const isReadySelectChannels =
       upgradeInfo.availableChannels &&
       upgradeInfo.availableChannels.length > 0 &&
-      (!isManagedOpenShift || isManagedOpenShiftUpgradeable()) &&
+      (!isManagedOpenShift || productClaim == 'ARO') &&
       !upgradeInfo.isSelectingChannel &&
       curatorIsIdle
     upgradeInfo.isReadySelectChannels = !!isReadySelectChannels


### PR DESCRIPTION
- Disable upgrade and channel select for OSD and ROSA Classic
- Update distribution version to show "ARO" for ARO

Related to https://issues.redhat.com/browse/ACM-10135

![image](https://github.com/user-attachments/assets/7497d4f3-0997-42e5-a13f-e917cef1d362)
