### PR TITLE
Store fleet view section toggle states

### DIFF
--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.test.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.test.tsx
@@ -3,6 +3,7 @@
 import { MockedProvider } from '@apollo/client/testing'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom-v5-compat'
 import { RecoilRoot } from 'recoil'
 import {
@@ -232,4 +233,117 @@ it('should render overview page with expected data', async () => {
   await waitFor(() => expect(getByText('All pods')).toBeTruthy())
   await waitFor(() => expect(getByText('testSavedQueryDesc1')).toBeTruthy())
   await waitFor(() => expect(getByText('10')).toBeTruthy())
+})
+
+it('should toggle card sections correctly', async () => {
+  nockIgnoreApiPaths()
+  nockSearch(mockSearchQueryArgoApps, mockSearchResponseArgoApps)
+  nockSearch(mockSearchQueryArgoAppsCount, mockSearchResponseArgoAppsCount)
+  nockSearch(mockSearchQueryOCPApplications, mockSearchResponseOCPApplications)
+  nockSearch(mockSearchQueryOCPApplicationsCount, mockSearchResponseOCPApplicationsCount)
+  const metricNock = nockPostRequest('/metrics?overview-fleet', {})
+  const mockAlertMetricsNock = nockRequest('/observability/query?query=ALERTS', mockAlertMetrics)
+  const mockOperatorMetricsNock = nockRequest(
+    '/observability/query?query=cluster_operator_conditions',
+    mockOperatorMetrics
+  )
+  const mockWorkerCoreCountMetricsNock = nockRequest(
+    '/prometheus/query?query=acm_managed_cluster_worker_cores',
+    mockWorkerCoreCountMetrics
+  )
+  const getUserPreferenceNock = nockRequest('/userpreference', mockUserPreference)
+  const getUpgradeRisksPredictionsNock = nockUpgradeRiskRequest(
+    '/upgrade-risks-prediction',
+    { clusterIds: ['1234-abcd'] },
+    mockUpgradeRisksPredictions
+  )
+
+  const { container } = render(
+    <RecoilRoot
+      initializeState={(snapshot) => {
+        snapshot.set(applicationsState, mockApplications)
+        snapshot.set(applicationSetsState, appSets)
+        snapshot.set(argoApplicationsState, mockArgoApplications)
+        snapshot.set(managedClustersState, managedClusters)
+        snapshot.set(managedClusterInfosState, [
+          ...managedClusterInfos,
+          {
+            apiVersion: 'internal.open-cluster-management.io/v1beta1',
+            kind: 'ManagedClusterInfo',
+            metadata: {
+              labels: {
+                cloud: 'Amazon',
+                env: 'dev',
+                name: 'managed-2',
+                vendor: 'OpenShift',
+                clusterID: '1234-abcd',
+              },
+              name: 'managed-2',
+              namespace: 'managed-2',
+            },
+            status: {
+              cloudVendor: 'Amazon',
+              kubeVendor: 'OpenShift',
+              loggingPort: { name: 'https', port: 443, protocol: 'TCP' },
+              version: 'v1.26.5+7d22122',
+            },
+          } as ManagedClusterInfo,
+        ])
+        snapshot.set(policiesState, policies)
+        snapshot.set(policyreportState, policyReports)
+        snapshot.set(managedClusterAddonsState, mockManagedClusterAddons)
+        snapshot.set(clusterManagementAddonsState, mockClusterManagementAddons)
+        snapshot.set(placementDecisionsState, placementDecisions)
+        snapshot.set(argoApplicationsState, [])
+        snapshot.set(helmReleaseState, [])
+        snapshot.set(subscriptionsState, [])
+        snapshot.set(settingsState, mockSettings)
+      }}
+    >
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MockedProvider mocks={savedSearchesMock}>
+            <OverviewPageBeta selectedClusterLabels={{}} />
+          </MockedProvider>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </RecoilRoot>
+  )
+
+  // Wait for prometheus nocks to finish
+  await waitForNocks([
+    metricNock,
+    mockAlertMetricsNock,
+    mockOperatorMetricsNock,
+    mockWorkerCoreCountMetricsNock,
+    getUserPreferenceNock,
+    getUpgradeRisksPredictionsNock,
+  ])
+
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: jest.fn(),
+      setItem: jest.fn(),
+    },
+    writable: true,
+  })
+
+  // toggle insights section
+  const insightsToggle = container.querySelector('#insights-section-toggle')
+  expect(insightsToggle).toBeTruthy()
+  userEvent.click(insightsToggle as Element)
+
+  // toggle cluster health section
+  const clusterToggle = container.querySelector('#cluster-section-toggle')
+  expect(clusterToggle).toBeTruthy()
+  userEvent.click(clusterToggle as Element)
+
+  // toggle your view section
+  const savedSearchToggle = container.querySelector('#saved-search-section-toggle')
+  expect(savedSearchToggle).toBeTruthy()
+  userEvent.click(savedSearchToggle as Element)
+
+  expect(window.localStorage.setItem).toHaveBeenCalledWith('insights-section-toggle', 'false')
+  expect(window.localStorage.setItem).toHaveBeenCalledWith('cluster-section-toggle', 'false')
+  expect(window.localStorage.setItem).toHaveBeenCalledWith('saved-search-section-toggle', 'false')
 })

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -197,25 +197,16 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   }, [upgradeRiskPredictions])
 
   const clusterStatusData = useMemo(() => {
-    if (isClusterSectionOpen) {
-      return getClusterStatus(filteredClusters, clusterLabelsSearchFilter, t)
-    }
-    return []
-  }, [isClusterSectionOpen, filteredClusters, clusterLabelsSearchFilter, t])
+    return getClusterStatus(filteredClusters, clusterLabelsSearchFilter, t)
+  }, [filteredClusters, clusterLabelsSearchFilter, t])
 
   const complianceData: any = useMemo(() => {
-    if (isClusterSectionOpen) {
-      return getComplianceData(allClusters, filteredClusterNames, policies, t)
-    }
-    return []
-  }, [isClusterSectionOpen, allClusters, filteredClusterNames, policies, t])
+    return getComplianceData(allClusters, filteredClusterNames, policies, t)
+  }, [allClusters, filteredClusterNames, policies, t])
 
   const clusterAddonData = useMemo(() => {
-    if (isClusterSectionOpen) {
-      return getAddonHealth(allAddons, filteredClusterNames, t)
-    }
-    return []
-  }, [isClusterSectionOpen, allAddons, filteredClusterNames, t])
+    return getAddonHealth(allAddons, filteredClusterNames, t)
+  }, [allAddons, filteredClusterNames, t])
 
   const grafanaLinkClusterLabelCondition = useMemo(() => {
     const filteredSelectedClusterLabels = { ...selectedClusterLabels }

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -443,6 +443,7 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
                 </div>
 
                 <Button
+                  id={'insights-section-toggle'}
                   onClick={() => {
                     localStorage.setItem('insights-section-toggle', `${!isInsightsSectionOpen}`)
                     setIsInsightsSectionOpen(!isInsightsSectionOpen)
@@ -647,6 +648,7 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
               {t('Cluster health')}
               <Button
+                id={'cluster-section-toggle'}
                 onClick={() => {
                   localStorage.setItem('cluster-section-toggle', `${!isClusterSectionOpen}`)
                   setIsClusterSectionOpen(!isClusterSectionOpen)
@@ -694,6 +696,7 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
               {t('Your view')}
               <Button
+                id={'saved-search-section-toggle'}
                 onClick={() => {
                   localStorage.setItem('saved-search-section-toggle', `${!isCustomizationSectionOpen}`)
                   setIsCustomizationSectionOpen(!isCustomizationSectionOpen)

--- a/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPageBeta.tsx
@@ -82,9 +82,17 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   const policyReports = useRecoilValue(policyreportState)
   const subscriptions = useRecoilValue(subscriptionsState)
   const clusterManagementAddons = useRecoilValue(clusterManagementAddonsState)
-  const [isClusterSectionOpen, setIsClusterSectionOpen] = useState<boolean>(true)
-  const [isInsightsSectionOpen, setIsInsightsSectionOpen] = useState<boolean>(true)
-  const [isCustomizationSectionOpen, setIsCustomizationSectionOpen] = useState<boolean>(true)
+  const [isInsightsSectionOpen, setIsInsightsSectionOpen] = useState<boolean>(
+    localStorage.getItem('insights-section-toggle') ? localStorage.getItem('insights-section-toggle') === 'true' : true
+  )
+  const [isClusterSectionOpen, setIsClusterSectionOpen] = useState<boolean>(
+    localStorage.getItem('cluster-section-toggle') ? localStorage.getItem('cluster-section-toggle') === 'true' : true
+  )
+  const [isCustomizationSectionOpen, setIsCustomizationSectionOpen] = useState<boolean>(
+    localStorage.getItem('saved-search-section-toggle')
+      ? localStorage.getItem('saved-search-section-toggle') === 'true'
+      : true
+  )
   const [isObservabilityInstalled, setIsObservabilityInstalled] = useState<boolean>(false)
   const [argoApplicationsHashSet, setArgoApplicationsHashSet] = useState<Set<string>>(new Set<string>())
   const [upgradeRiskPredictions, setUpgradeRiskPredictions] = useState<any[]>([])
@@ -150,8 +158,17 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
     policyReportLowCount,
     clustersWithIssuesCount,
   } = useMemo(() => {
-    return getPolicyReport(policyReports, filteredClusters)
-  }, [filteredClusters, policyReports])
+    if (isInsightsSectionOpen) {
+      return getPolicyReport(policyReports, filteredClusters)
+    }
+    return {
+      policyReportCriticalCount: 0,
+      policyReportImportantCount: 0,
+      policyReportModerateCount: 0,
+      policyReportLowCount: 0,
+      clustersWithIssuesCount: 0,
+    }
+  }, [isInsightsSectionOpen, filteredClusters, policyReports])
 
   const managedClusterIds = useMemo(() => {
     const ids: string[] = []
@@ -164,10 +181,10 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   }, [allClusters])
 
   useEffect(() => {
-    if (managedClusterIds.length > 0) {
+    if (isInsightsSectionOpen && managedClusterIds.length > 0) {
       getUpgradeRiskPredictions(managedClusterIds).then((res) => setUpgradeRiskPredictions(res))
     }
-  }, [managedClusterIds])
+  }, [isInsightsSectionOpen, managedClusterIds])
 
   const { criticalUpdateCount, warningUpdateCount, infoUpdateCount, clustersWithRiskPredictors } = useMemo(() => {
     const reducedUpgradeRiskPredictions = upgradeRiskPredictions.reduce((acc: any[], curr: any) => {
@@ -180,16 +197,25 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   }, [upgradeRiskPredictions])
 
   const clusterStatusData = useMemo(() => {
-    return getClusterStatus(filteredClusters, clusterLabelsSearchFilter, t)
-  }, [filteredClusters, clusterLabelsSearchFilter, t])
+    if (isClusterSectionOpen) {
+      return getClusterStatus(filteredClusters, clusterLabelsSearchFilter, t)
+    }
+    return []
+  }, [isClusterSectionOpen, filteredClusters, clusterLabelsSearchFilter, t])
 
   const complianceData: any = useMemo(() => {
-    return getComplianceData(allClusters, filteredClusterNames, policies, t)
-  }, [allClusters, filteredClusterNames, policies, t])
+    if (isClusterSectionOpen) {
+      return getComplianceData(allClusters, filteredClusterNames, policies, t)
+    }
+    return []
+  }, [isClusterSectionOpen, allClusters, filteredClusterNames, policies, t])
 
   const clusterAddonData = useMemo(() => {
-    return getAddonHealth(allAddons, filteredClusterNames, t)
-  }, [allAddons, filteredClusterNames, t])
+    if (isClusterSectionOpen) {
+      return getAddonHealth(allAddons, filteredClusterNames, t)
+    }
+    return []
+  }, [isClusterSectionOpen, allAddons, filteredClusterNames, t])
 
   const grafanaLinkClusterLabelCondition = useMemo(() => {
     const filteredSelectedClusterLabels = { ...selectedClusterLabels }
@@ -215,7 +241,7 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   const [clusterOperators, operatorError, operatorLoading] = useMetricsPoll({
     endpoint: ObservabilityEndpoint.QUERY,
     query: 'cluster_operator_conditions',
-    skip: !isObservabilityInstalled,
+    skip: !isInsightsSectionOpen || !isObservabilityInstalled,
   })
   const {
     clustersAffectedOperator,
@@ -230,7 +256,7 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   const [alertsResult, alertsError, alertsLoading] = useMetricsPoll({
     endpoint: ObservabilityEndpoint.QUERY,
     query: 'ALERTS',
-    skip: !isObservabilityInstalled,
+    skip: !isInsightsSectionOpen || !isObservabilityInstalled,
   })
   const {
     clustersAffectedAlerts,
@@ -251,11 +277,13 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
   }, [alertsResult, filteredClusterNames, t])
 
   useEffect(() => {
-    getUserPreference().then((resp) => {
-      setIsUserPreferenceLoading(false)
-      setUserPreference(resp)
-    })
-  }, [])
+    if (isCustomizationSectionOpen) {
+      getUserPreference().then((resp) => {
+        setIsUserPreferenceLoading(false)
+        setUserPreference(resp)
+      })
+    }
+  }, [isCustomizationSectionOpen])
 
   const userSavedSearches = useMemo(() => {
     return userPreference?.spec?.savedSearches ?? []
@@ -424,7 +452,10 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
                 </div>
 
                 <Button
-                  onClick={() => setIsInsightsSectionOpen(!isInsightsSectionOpen)}
+                  onClick={() => {
+                    localStorage.setItem('insights-section-toggle', `${!isInsightsSectionOpen}`)
+                    setIsInsightsSectionOpen(!isInsightsSectionOpen)
+                  }}
                   icon={isInsightsSectionOpen ? <AngleDownIcon /> : <AngleUpIcon />}
                   variant={'plain'}
                 />
@@ -625,7 +656,10 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
               {t('Cluster health')}
               <Button
-                onClick={() => setIsClusterSectionOpen(!isClusterSectionOpen)}
+                onClick={() => {
+                  localStorage.setItem('cluster-section-toggle', `${!isClusterSectionOpen}`)
+                  setIsClusterSectionOpen(!isClusterSectionOpen)
+                }}
                 icon={isClusterSectionOpen ? <AngleDownIcon /> : <AngleUpIcon />}
                 variant={'plain'}
               />
@@ -669,7 +703,10 @@ export default function OverviewPageBeta(props: { selectedClusterLabels: Record<
             <div style={{ display: 'flex', justifyContent: 'space-between' }}>
               {t('Your view')}
               <Button
-                onClick={() => setIsCustomizationSectionOpen(!isCustomizationSectionOpen)}
+                onClick={() => {
+                  localStorage.setItem('saved-search-section-toggle', `${!isCustomizationSectionOpen}`)
+                  setIsCustomizationSectionOpen(!isCustomizationSectionOpen)
+                }}
                 icon={isCustomizationSectionOpen ? <AngleDownIcon /> : <AngleUpIcon />}
                 variant={'plain'}
               />


### PR DESCRIPTION
Store toggle state of the three card sections (insights, cluster health, and your view) in local storage.