### PR TITLE
Fix the Policy badge issue when the table is collapsed

### DIFF
--- a/frontend/src/routes/Governance/discovered/ByCluster/common.tsx
+++ b/frontend/src/routes/Governance/discovered/ByCluster/common.tsx
@@ -161,7 +161,8 @@ export function discoveredSourceCell(t: TFunction, source: ISourceType | undefin
             borderRadius: '20px',
             fontSize: '0.75rem',
             marginRight: '10px',
-            minWidth: 18,
+            width: 20,
+            textAlign: 'center',
           }}
         >
           P


### PR DESCRIPTION
When the table is collapsed, the policy badge width is increased
This PR will fix the bug