### PR TITLE
Do not set BRIDGE_K8S_AUTH_BEARER_TOKEN for OCP 4.16+

### DIFF
--- a/start-ocp-console.sh
+++ b/start-ocp-console.sh
@@ -33,7 +33,9 @@ set +e
 BRIDGE_K8S_MODE_OFF_CLUSTER_THANOS=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.thanosPublicURL}' 2>/dev/null)
 BRIDGE_K8S_MODE_OFF_CLUSTER_ALERTMANAGER=$(oc -n openshift-config-managed get configmap monitoring-shared-config -o jsonpath='{.data.alertmanagerPublicURL}' 2>/dev/null)
 set -e
-BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
+if [ "$CONSOLE_VERSION" "<" "4.16" ]; then
+    BRIDGE_K8S_AUTH_BEARER_TOKEN=$(oc whoami --show-token 2>/dev/null)
+fi
 BRIDGE_USER_SETTINGS_LOCATION="localstorage"
 
 # Don't fail if the cluster doesn't have gitops.


### PR DESCRIPTION
This environment variable only works with 4.15 and earlier.