### PR TITLE
Fix empty issue in Discovered Policies table

### DIFF
--- a/frontend/src/routes/Governance/discovered/useFetchPolicies.tsx
+++ b/frontend/src/routes/Governance/discovered/useFetchPolicies.tsx
@@ -134,6 +134,7 @@ export function useFetchPolicies(policyName?: string, policyKind?: string, apiGr
     })
 
     if (searchDataItems.length == 0 && !searchErr && !searchLoading) {
+      setData([])
       setIsFetching(false)
     }
 


### PR DESCRIPTION
When fetch is success but the data is empty. It is showing table skeleton