### PR TITLE
ACM-13728: Missing s390x arch option in Cpu architecture in InfraEnv

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/ai-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/ai-template.hbs
@@ -58,6 +58,7 @@ spec:
       hostPrefix: 23
     serviceNetwork:
     - 172.30.0.0/16
+    userManagedNetworking: {{{ai.userManagedNetworking}}}
   sshPublicKey: '{{{ai.sshPublicKey}}}'
 
 ---


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-13728