### PR TITLE
ACM-14531 RHOCM Import credential in Discovered Clusters fix 

### DIFF
--- a/frontend/src/lib/test-metadata.ts
+++ b/frontend/src/lib/test-metadata.ts
@@ -74,11 +74,23 @@ export const multiClusterHub: MultiClusterHub = {
   },
 }
 
-export const mockCRHCredential: Secret = {
+export const mockCRHCredential1: Secret = {
   apiVersion: SecretApiVersion,
   kind: SecretKind,
   metadata: {
     name: 'ocm-api-token',
+    namespace: 'ocm',
+    labels: {
+      'cluster.open-cluster-management.io/type': Provider.redhatcloud,
+    },
+  },
+}
+
+export const mockCRHCredential2: Secret = {
+  apiVersion: SecretApiVersion,
+  kind: SecretKind,
+  metadata: {
+    name: 'ocm-service-account',
     namespace: 'ocm',
     labels: {
       'cluster.open-cluster-management.io/type': Provider.redhatcloud,

--- a/frontend/src/lib/test-metadata.ts
+++ b/frontend/src/lib/test-metadata.ts
@@ -74,6 +74,18 @@ export const multiClusterHub: MultiClusterHub = {
   },
 }
 
+export const mockCRHCredential: Secret = {
+  apiVersion: SecretApiVersion,
+  kind: SecretKind,
+  metadata: {
+    name: 'ocm-api-token',
+    namespace: 'ocm',
+    labels: {
+      'cluster.open-cluster-management.io/type': Provider.redhatcloud,
+    },
+  },
+}
+
 export const mockCRHCredential1: Secret = {
   apiVersion: SecretApiVersion,
   kind: SecretKind,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -1069,7 +1069,7 @@ describe('Import Discovered Cluster with import credentials', () => {
     await waitForNocks([projectNock, managedClusterNock, kacNock, importCommandNock, autoImportSecretNock])
   })
 
-   test('create discovered ROSA cluster with auto import service account', async () => {
+  test('create discovered ROSA cluster with auto import service account', async () => {
     window.sessionStorage.setItem('DiscoveredClusterConsoleURL', 'https://test-cluster-serviceaccount.com')
 
     const Component = () => (
@@ -1101,7 +1101,7 @@ describe('Import Discovered Cluster with import credentials', () => {
     await waitForText('Import from Red Hat OpenShift Cluster Manager', true)
 
     await waitForText('OCM-Access-SA')
-    await waitForText(mockDiscoveredClusters[2].spec.credential!.name) 
+    await waitForText(mockDiscoveredClusters[2].spec.credential!.name)
     await waitForText('Cluster ID')
     getByDisplayValue('39ldt3r51vjjsho1eqntrg3m') // cluster ID field should be set correctly
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -55,6 +55,7 @@ import {
   nockIgnoreRBAC,
 } from '../../../../../lib/nock-util'
 import {
+  mockCRHCredential,
   mockCRHCredential1,
   mockCRHCredential2,
   mockDiscoveryConfig,
@@ -579,6 +580,25 @@ const mockProviderConnectionAnsibleCopied: ProviderConnection = {
   type: 'Opaque',
 }
 
+const mockOCMConnection: Secret = {
+  apiVersion: ProviderConnectionApiVersion,
+  kind: ProviderConnectionKind,
+  metadata: {
+    name: 'OCM-access',
+    namespace: 'foobar',
+    labels: {
+      'cluster.open-cluster-management.io/type': 'rhocm',
+      'cluster.open-cluster-management.io/copiedFromNamespace': 'test-ROSA',
+      'cluster.open-cluster-management.io/copiedFromSecretName': 'OCM-connection',
+      'cluster.open-cluster-management.io/backup': 'cluster',
+    },
+  },
+  stringData: {
+    ocmAPIToken: 'fake_token',
+  },
+  type: 'Opaque',
+}
+
 const mockOCMConnection1: Secret = {
   apiVersion: ProviderConnectionApiVersion,
   kind: ProviderConnectionKind,
@@ -915,7 +935,7 @@ describe('Import Discovered Cluster', () => {
       <RecoilRoot
         initializeState={(snapshot) => {
           snapshot.set(managedClusterSetsState, [mockManagedClusterSet])
-           //snapshot.set(secretsState, [mockCRHCredential, mockOCMConnection1, mockOCMConnection2])
+          snapshot.set(secretsState, [mockCRHCredential, mockOCMConnection])
           snapshot.set(discoveryConfigState, [mockDiscoveryConfig])
           snapshot.set(discoveredClusterState, mockDiscoveredClusters)
           snapshot.set(namespacesState, mockNamepaces)
@@ -980,7 +1000,7 @@ describe('Import Discovered Cluster', () => {
     ).toBeDefined()
     expect(
       container.querySelector(
-        `[data-ouia-component-id=${mockDiscoveredClusters[3].metadata.uid!}] td.pf-c-table__action`
+        `[data-ouia-component-id=${mockDiscoveredClusters[4].metadata.uid!}] td.pf-c-table__action`
       )
     ).toBeEmptyDOMElement()
   })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -33,7 +33,7 @@ import {
   SubscriptionOperatorApiVersion,
   SubscriptionOperatorKind,
 } from '../../../../../resources'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat'
 import { RecoilRoot } from 'recoil'
@@ -55,7 +55,6 @@ import {
   nockIgnoreRBAC,
 } from '../../../../../lib/nock-util'
 import {
-  mockCRHCredential,
   mockCRHCredential1,
   mockCRHCredential2,
   mockDiscoveryConfig,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -306,9 +306,9 @@ const mockROSAAutoTokenSecretServiceAcc: Secret = {
   },
   stringData: {
     autoImportRetry: '2',
-    client_id: 'c437fga6-9035-44ff-8cf7-4dh5b9',
-    client_secret: '3q55tPVVsdgdshfdjgykcdCDOoTBuc',
-    cluster_id: '39ldt3r51vjjsho1eqntrg3m',
+    client_id: 'sldkhfgsdkgksdfkshdkfj',
+    client_secret: 'kdjsfhsdkgfksdg',
+    cluster_id: 'sdkfjsldfhgksjdfhg',
   },
   type: 'auto-import/rosa',
 }
@@ -915,7 +915,7 @@ describe('Import Discovered Cluster', () => {
       <RecoilRoot
         initializeState={(snapshot) => {
           snapshot.set(managedClusterSetsState, [mockManagedClusterSet])
-          //  snapshot.set(secretsState, [mockCRHCredential, mockOCMConnection1, mockOCMConnection2])
+           //snapshot.set(secretsState, [mockCRHCredential, mockOCMConnection1, mockOCMConnection2])
           snapshot.set(discoveryConfigState, [mockDiscoveryConfig])
           snapshot.set(discoveredClusterState, mockDiscoveredClusters)
           snapshot.set(namespacesState, mockNamepaces)
@@ -986,7 +986,7 @@ describe('Import Discovered Cluster', () => {
   })
 })
 
-describe.only('Import Discovered Cluster with import credentials', () => {
+describe('Import Discovered Cluster with import credentials', () => {
   beforeEach(() => {
     localStorage.clear()
     nockIgnoreRBAC()
@@ -1051,14 +1051,14 @@ describe.only('Import Discovered Cluster with import credentials', () => {
   })
 })
 
-describe.only('Import Discovered Cluster with import credentials', () => {
+describe('Import Discovered Cluster with import credentials', () => {
   beforeEach(() => {
     localStorage.clear()
     nockIgnoreRBAC()
     nockIgnoreApiPaths()
     nockIgnoreOperatorCheck()
   })
-  test.only('create discovered ROSA cluster with auto import service account', async () => {
+  test('create discovered ROSA cluster with auto import service account', async () => {
     window.sessionStorage.setItem('DiscoveredClusterConsoleURL', 'https://test-cluster-serviceaccount.com')
 
     const Component = () => (

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -1101,7 +1101,7 @@ describe('Import Discovered Cluster with import credentials', () => {
     await waitForText('Import from Red Hat OpenShift Cluster Manager', true)
 
     await waitForText('OCM-Access-SA')
-    await waitForText(mockDiscoveredClusters[2].spec.credential?.name ?? 'default credential')
+    await waitForText(mockDiscoveredClusters[2].spec.credential!.name) 
     await waitForText('Cluster ID')
     getByDisplayValue('39ldt3r51vjjsho1eqntrg3m') // cluster ID field should be set correctly
 
@@ -1124,66 +1124,3 @@ describe('Import Discovered Cluster with import credentials', () => {
     await waitForNocks([projectNock, managedClusterNock, kacNock, importCommandNock, autoImportSecretNock])
   })
 })
-
-// describe.skip('Import Discovered Cluster with import credentials', () => {
-//   beforeEach(() => {
-//     localStorage.clear()
-//     nockIgnoreRBAC()
-//     nockIgnoreApiPaths()
-//     nockIgnoreOperatorCheck()
-//   })
-//   test('create discovered ROSA cluster with auto import service account', async () => {
-//     window.sessionStorage.setItem('DiscoveredClusterConsoleURL', 'https://test-cluster-serviceaccount.com')
-
-//     const Component = () => (
-//       <RecoilRoot
-//         initializeState={(snapshot) => {
-//           snapshot.set(managedClusterSetsState, [mockManagedClusterSet])
-//           snapshot.set(secretsState, [mockCRHCredential2, mockOCMConnection2])
-//           snapshot.set(discoveryConfigState, [mockDiscoveryConfig])
-//           snapshot.set(discoveredClusterState, mockDiscoveredClusters)
-//           snapshot.set(namespacesState, mockNamepaces)
-//         }}
-//       >
-//         <MemoryRouter>
-//           <Routes>
-//             <Route path="/" element={<DiscoveredClustersPage />} />
-//             <Route path={NavigationPath.importCluster} element={<ImportClusterPage />} />
-//           </Routes>
-//         </MemoryRouter>
-//       </RecoilRoot>
-//     )
-
-//     const { getAllByText, getAllByLabelText, getByDisplayValue } = render(<Component />) // Render the custom component
-
-//     await waitFor(() => {
-//       expect(getAllByText(mockDiscoveredClusters[2].metadata.name!)[0]!).toBeInTheDocument()
-//     })
-//     userEvent.click(getAllByLabelText('Actions')[2]) // Click on Kebab menu
-//     await clickByText('Import cluster')
-//     await waitForText('Import from Red Hat OpenShift Cluster Manager', true)
-
-//     await waitForText('OCM-Access-SA')
-//     await waitForText(mockDiscoveredClusters[2].spec.credential?.name ?? 'Default Credential Name')
-//     await waitForText('Cluster ID')
-//     getByDisplayValue('39ldt3r51vjjsho1eqntrg3m') // cluster ID field should be set correctly
-
-//     const projectNock = nockCreate(mockROSADiscoveryProject, mockROSADiscoveryProjectResponse)
-//     const managedClusterNock = nockCreate(mockManagedROSADiscoveredCluster, mockManagedROSADiscoveredClusterResponse)
-//     const kacNock = nockCreate(mockROSADiscoveryKlusterletAddonConfig, mockROSADiscoveryKlusterletAddonConfigResponse)
-//     const autoImportSecretNock = nockCreate(mockROSAAutoTokenSecretServiceAcc)
-//     const importCommandNock = nockGet(mockROSAAutoTokenSecretServiceAcc)
-
-//     // Add labels
-//     await clickByTestId('label-input-button')
-//     await typeByTestId('additionalLabels', 'foo=bar{enter}')
-
-//     // Advance to Review step and submit the form
-//     await clickByText('Next')
-//     await clickByText('Next')
-//     await waitForText('Import')
-//     await clickByText('Import')
-
-//     await waitForNocks([projectNock, managedClusterNock, kacNock, importCommandNock, autoImportSecretNock])
-//   })
-// })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -307,9 +307,8 @@ const mockROSAAutoTokenSecretServiceAcc: Secret = {
   },
   stringData: {
     autoImportRetry: '2',
-    client_id: 'sldkhfgsdkgksdfkshdkfj',
-    client_secret: 'kdjsfhsdkgfksdg',
-    cluster_id: 'sdkfjsldfhgksjdfhg',
+    api_token: '',
+    cluster_id: '39ldt3r51vjjsho1eqntrg3m',
   },
   type: 'auto-import/rosa',
 }
@@ -1013,7 +1012,7 @@ describe('Import Discovered Cluster with import credentials', () => {
     nockIgnoreApiPaths()
     nockIgnoreOperatorCheck()
   })
-  test('create discovered ROSA cluster with auto import apitoken', async () => {
+  test('create discovered ROSA cluster with auto import api token', async () => {
     // Set the sessionStorage item specifically for this test
     window.sessionStorage.setItem('DiscoveredClusterConsoleURL', 'https://test-cluster.com')
 
@@ -1069,16 +1068,8 @@ describe('Import Discovered Cluster with import credentials', () => {
 
     await waitForNocks([projectNock, managedClusterNock, kacNock, importCommandNock, autoImportSecretNock])
   })
-})
 
-describe('Import Discovered Cluster with import credentials', () => {
-  beforeEach(() => {
-    localStorage.clear()
-    nockIgnoreRBAC()
-    nockIgnoreApiPaths()
-    nockIgnoreOperatorCheck()
-  })
-  test('create discovered ROSA cluster with auto import service account', async () => {
+   test('create discovered ROSA cluster with auto import service account', async () => {
     window.sessionStorage.setItem('DiscoveredClusterConsoleURL', 'https://test-cluster-serviceaccount.com')
 
     const Component = () => (
@@ -1105,18 +1096,12 @@ describe('Import Discovered Cluster with import credentials', () => {
     await waitFor(() => {
       expect(getAllByText(mockDiscoveredClusters[2].metadata.name!)[0]!).toBeInTheDocument()
     })
-    userEvent.click(getAllByLabelText('Actions')[1]) // Click on Kebab menu
+    userEvent.click(getAllByLabelText('Actions')[2]) // Click on Kebab menu
     await clickByText('Import cluster')
     await waitForText('Import from Red Hat OpenShift Cluster Manager', true)
 
-    // await waitFor(() => {
-    //   const dropdownToggles = screen.getAllByLabelText('Options menu')
-    //   expect(dropdownToggles[3]).toBeInTheDocument()
-    //   fireEvent.click(dropdownToggles[3])
-    // })
-
     await waitForText('OCM-Access-SA')
-    await waitForText(mockDiscoveredClusters[2].spec.credential?.name)
+    await waitForText(mockDiscoveredClusters[2].spec.credential?.name ?? 'default credential')
     await waitForText('Cluster ID')
     getByDisplayValue('39ldt3r51vjjsho1eqntrg3m') // cluster ID field should be set correctly
 
@@ -1139,3 +1124,66 @@ describe('Import Discovered Cluster with import credentials', () => {
     await waitForNocks([projectNock, managedClusterNock, kacNock, importCommandNock, autoImportSecretNock])
   })
 })
+
+// describe.skip('Import Discovered Cluster with import credentials', () => {
+//   beforeEach(() => {
+//     localStorage.clear()
+//     nockIgnoreRBAC()
+//     nockIgnoreApiPaths()
+//     nockIgnoreOperatorCheck()
+//   })
+//   test('create discovered ROSA cluster with auto import service account', async () => {
+//     window.sessionStorage.setItem('DiscoveredClusterConsoleURL', 'https://test-cluster-serviceaccount.com')
+
+//     const Component = () => (
+//       <RecoilRoot
+//         initializeState={(snapshot) => {
+//           snapshot.set(managedClusterSetsState, [mockManagedClusterSet])
+//           snapshot.set(secretsState, [mockCRHCredential2, mockOCMConnection2])
+//           snapshot.set(discoveryConfigState, [mockDiscoveryConfig])
+//           snapshot.set(discoveredClusterState, mockDiscoveredClusters)
+//           snapshot.set(namespacesState, mockNamepaces)
+//         }}
+//       >
+//         <MemoryRouter>
+//           <Routes>
+//             <Route path="/" element={<DiscoveredClustersPage />} />
+//             <Route path={NavigationPath.importCluster} element={<ImportClusterPage />} />
+//           </Routes>
+//         </MemoryRouter>
+//       </RecoilRoot>
+//     )
+
+//     const { getAllByText, getAllByLabelText, getByDisplayValue } = render(<Component />) // Render the custom component
+
+//     await waitFor(() => {
+//       expect(getAllByText(mockDiscoveredClusters[2].metadata.name!)[0]!).toBeInTheDocument()
+//     })
+//     userEvent.click(getAllByLabelText('Actions')[2]) // Click on Kebab menu
+//     await clickByText('Import cluster')
+//     await waitForText('Import from Red Hat OpenShift Cluster Manager', true)
+
+//     await waitForText('OCM-Access-SA')
+//     await waitForText(mockDiscoveredClusters[2].spec.credential?.name ?? 'Default Credential Name')
+//     await waitForText('Cluster ID')
+//     getByDisplayValue('39ldt3r51vjjsho1eqntrg3m') // cluster ID field should be set correctly
+
+//     const projectNock = nockCreate(mockROSADiscoveryProject, mockROSADiscoveryProjectResponse)
+//     const managedClusterNock = nockCreate(mockManagedROSADiscoveredCluster, mockManagedROSADiscoveredClusterResponse)
+//     const kacNock = nockCreate(mockROSADiscoveryKlusterletAddonConfig, mockROSADiscoveryKlusterletAddonConfigResponse)
+//     const autoImportSecretNock = nockCreate(mockROSAAutoTokenSecretServiceAcc)
+//     const importCommandNock = nockGet(mockROSAAutoTokenSecretServiceAcc)
+
+//     // Add labels
+//     await clickByTestId('label-input-button')
+//     await typeByTestId('additionalLabels', 'foo=bar{enter}')
+
+//     // Advance to Review step and submit the form
+//     await clickByText('Next')
+//     await clickByText('Next')
+//     await waitForText('Import')
+//     await clickByText('Import')
+
+//     await waitForNocks([projectNock, managedClusterNock, kacNock, importCommandNock, autoImportSecretNock])
+//   })
+// })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -812,7 +812,7 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
   const updateROSAImportSecret = useCallback(
     (credentialName: string) => {
       const selectedCredential = ocmCredentials.find((credential) => credential.metadata.name === credentialName)
-      const authMethod = selectedCredential?.stringData?.auth_method ?? ''
+      const authMethod = selectedCredential?.stringData?.auth_method || 'offline-token'
       const discoverySecret = cloneDeep(autoImportSecret)
       // Updating the discovery secret based on the auth_method
       if (authMethod === 'service-account') {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -449,7 +449,12 @@ export default function ImportClusterPage() {
         id="code-content"
         schema={isACMAvailable ? acmSchema : schema}
         resources={resources}
-        secrets={['Secret.*.stringData.token', 'Secret.*.stringData.kubeconfig', 'Secret.*.stringData.api_token']}
+        secrets={[
+          'Secret.*.stringData.token',
+          'Secret.*.stringData.kubeconfig',
+          'Secret.*.stringData.api_token',
+          'Secret.*.stringData.client_secret',
+        ]}
         syncs={syncs}
         onEditorChange={(changes: { resources: any[] }): void => {
           update(changes?.resources)
@@ -806,13 +811,25 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
 
   const updateROSAImportSecret = useCallback(
     (credentialName: string) => {
-      const newToken =
-        ocmCredentials.find((credential) => credential.metadata.name === credentialName)?.stringData?.ocmAPIToken ?? ''
+      const selectedCredential = ocmCredentials.find((credential) => credential.metadata.name === credentialName)
+      const authMethod = selectedCredential?.stringData?.auth_method ?? ''
       const discoverySecret = cloneDeep(autoImportSecret)
-      discoverySecret.stringData = {
-        ...discoverySecret.stringData,
-        api_token: newToken,
-        cluster_id: clusterID,
+      // Updating the discovery secret based on the auth_method
+      if (authMethod === 'service-account') {
+        discoverySecret.stringData = {
+          ...discoverySecret.stringData,
+          auth_method: 'service-account',
+          client_id: selectedCredential?.stringData?.client_id ?? '',
+          client_secret: selectedCredential?.stringData?.client_secret ?? '',
+          cluster_id: clusterID,
+        }
+      } else if (authMethod === 'offline-token') {
+        discoverySecret.stringData = {
+          ...discoverySecret.stringData,
+          auth_method: 'offline-token',
+          api_token: selectedCredential?.stringData?.ocmAPIToken ?? '',
+          cluster_id: clusterID,
+        }
       }
       discoverySecret.type = 'auto-import/rosa'
       return discoverySecret

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/schema.json
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/schema.json
@@ -57,13 +57,18 @@
             "host": { "type": "string" },
             "kubeconfig": { "type": "string" },
             "server": { "type": "string" },
-            "token": { "type": "string" }
+            "token": { "type": "string" },
+            "api_token": { "type": "string" },
+            "cluster_id": { "type": "string" },
+            "client_id": { "type": "string" },
+            "client_secret": { "type": "string" }
           },
           "oneOf": [
             { "required": ["host", "token"] },
             { "required": ["autoImportRetry", "token", "server"] },
             { "required": ["autoImportRetry", "kubeconfig"] },
-            { "required": ["api_token", "cluster_id"] }
+            { "required": ["api_token", "cluster_id"] },
+            { "required": ["client_id", "client_secret", "cluster_id"] }
           ]
         }
       },


### PR DESCRIPTION
Updates the updateROSAImportSecret to copy the correct OCM credential either `api-token` or `service-account`