### PR TITLE
ACM-14557-Implement inferred ranges for cluster list advanced search

### DIFF
--- a/frontend/src/lib/search-utils.test.ts
+++ b/frontend/src/lib/search-utils.test.ts
@@ -17,6 +17,14 @@ const versionData = {
   versionIncomplete: '1.',
 }
 
+const incompleteVersionData = {
+  versionOneIncomplete: '1.',
+  versionTwoIncomplete: '1.5',
+  versionThreeIncomplete: '2',
+  versionFourIncomplete: '2.5',
+  versionFiveIncomplete: '2.5.',
+}
+
 describe('search-utils basic string operator', () => {
   const { stringOne, stringTwo, stringThree, stringFour, stringFive } = stringData
   it('can determine equals', () => {
@@ -43,10 +51,18 @@ describe('search-utils basic string operator', () => {
 
 describe('search-utils sermver operator', () => {
   const { versionOne, versionTwo, versionThree, versionFour, versionIncomplete } = versionData
-  it('can determine greater semver', () => {
+  const {
+    versionOneIncomplete,
+    versionTwoIncomplete,
+    versionThreeIncomplete,
+    versionFourIncomplete,
+    versionFiveIncomplete,
+  } = incompleteVersionData
+
+  it('can determine greater than semver', () => {
     expect(handleSemverOperatorComparison(versionFour, versionThree, SearchOperator.GreaterThan)).toBeTruthy()
   })
-  it('can determine less semver', () => {
+  it('can determine less than semver', () => {
     expect(handleSemverOperatorComparison(versionOne, versionTwo, SearchOperator.LessThan)).toBeTruthy()
   })
   it('can determine equals semver', () => {
@@ -65,5 +81,35 @@ describe('search-utils sermver operator', () => {
   })
   it('can coerce incomplete semver strings', () => {
     expect(handleSemverOperatorComparison(versionIncomplete, versionOne, SearchOperator.Equals)).toBeTruthy()
+  })
+  it('can infer on incomplete semver equals', () => {
+    expect(handleSemverOperatorComparison(versionOne, versionOneIncomplete, SearchOperator.Equals)).toBeTruthy()
+  })
+  it('can infer on incomplete semver greater than', () => {
+    expect(handleSemverOperatorComparison(versionTwo, versionOneIncomplete, SearchOperator.GreaterThan)).toBeTruthy()
+  })
+  it('can infer on incomplete semver greater than or equal to', () => {
+    expect(
+      handleSemverOperatorComparison(versionTwo, versionOneIncomplete, SearchOperator.GreaterThanOrEqualTo)
+    ).toBeTruthy()
+  })
+  it('can infer on incomplete semver less than', () => {
+    expect(handleSemverOperatorComparison(versionOne, versionTwoIncomplete, SearchOperator.LessThan)).toBeTruthy()
+  })
+  it('can infer on incomplete semver less than or equal to', () => {
+    expect(
+      handleSemverOperatorComparison(versionOne, versionThreeIncomplete, SearchOperator.LessThanOrEqualTo)
+    ).toBeTruthy()
+  })
+  it('can infer on incomplete semver not equals', () => {
+    expect(handleSemverOperatorComparison(versionOne, versionFourIncomplete, SearchOperator.NotEquals)).toBeTruthy()
+  })
+  it('can infer with incomplete semver form x.', () => {
+    expect(
+      handleSemverOperatorComparison(versionOneIncomplete, versionFiveIncomplete, SearchOperator.LessThan)
+    ).toBeTruthy()
+  })
+  it('can infer with incomplete semver form x.y.', () => {
+    expect(handleSemverOperatorComparison(versionFour, versionFiveIncomplete, SearchOperator.Equals)).toBeTruthy()
   })
 })

--- a/frontend/src/lib/search-utils.test.ts
+++ b/frontend/src/lib/search-utils.test.ts
@@ -2,114 +2,75 @@
 import { SearchOperator } from '../ui-components/AcmSearchInput'
 import { handleStandardComparison, handleSemverOperatorComparison } from './search-utils'
 
-const stringData = {
-  stringOne: 'Adam',
-  stringTwo: 'Becky',
-  stringThree: 'Charlie',
-  stringFour: 'David',
-  stringFive: 'Eve',
-}
-const versionData = {
-  versionOne: '1.0.0',
-  versionTwo: '1.5.0',
-  versionThree: '2.0.0',
-  versionFour: '2.5.0',
-  versionIncomplete: '1.',
-}
-
-const incompleteVersionData = {
-  versionOneIncomplete: '1.',
-  versionTwoIncomplete: '1.5',
-  versionThreeIncomplete: '2',
-  versionFourIncomplete: '2.5',
-  versionFiveIncomplete: '2.5.',
-}
-
 describe('search-utils basic string operator', () => {
-  const { stringOne, stringTwo, stringThree, stringFour, stringFive } = stringData
   it('can determine equals', () => {
-    expect(handleStandardComparison(stringOne, stringOne, SearchOperator.Equals)).toBeTruthy()
+    expect(handleStandardComparison('Adam', 'Adam', SearchOperator.Equals)).toBeTruthy()
   })
   it('can determine greater', () => {
-    expect(handleStandardComparison(stringOne, stringTwo, SearchOperator.GreaterThan)).toBeTruthy()
+    expect(handleStandardComparison('Adam', 'Becky', SearchOperator.GreaterThan)).toBeTruthy()
   })
   it('can determine less', () => {
-    expect(handleStandardComparison(stringFour, stringThree, SearchOperator.LessThan)).toBeTruthy()
+    expect(handleStandardComparison('David', 'Charlie', SearchOperator.LessThan)).toBeTruthy()
   })
   it('can determine greater than or equal to', () => {
-    expect(handleStandardComparison(stringOne, stringOne, SearchOperator.GreaterThanOrEqualTo)).toBeTruthy()
-    expect(handleStandardComparison(stringOne, stringTwo, SearchOperator.GreaterThanOrEqualTo)).toBeTruthy()
+    expect(handleStandardComparison('Adam', 'Adam', SearchOperator.GreaterThanOrEqualTo)).toBeTruthy()
+    expect(handleStandardComparison('Adam', 'Becky', SearchOperator.GreaterThanOrEqualTo)).toBeTruthy()
   })
   it('can determine less than or equal to', () => {
-    expect(handleStandardComparison(stringOne, stringOne, SearchOperator.LessThanOrEqualTo)).toBeTruthy()
-    expect(handleStandardComparison(stringFive, stringOne, SearchOperator.LessThanOrEqualTo)).toBeTruthy()
+    expect(handleStandardComparison('Adam', 'Adam', SearchOperator.LessThanOrEqualTo)).toBeTruthy()
+    expect(handleStandardComparison('Eve', 'Adam', SearchOperator.LessThanOrEqualTo)).toBeTruthy()
   })
   it('can determine non-equals', () => {
-    expect(handleStandardComparison(stringOne, stringFive, SearchOperator.Equals)).toBeFalsy()
+    expect(handleStandardComparison('Adam', 'Eve', SearchOperator.Equals)).toBeFalsy()
   })
 })
 
 describe('search-utils sermver operator', () => {
-  const { versionOne, versionTwo, versionThree, versionFour, versionIncomplete } = versionData
-  const {
-    versionOneIncomplete,
-    versionTwoIncomplete,
-    versionThreeIncomplete,
-    versionFourIncomplete,
-    versionFiveIncomplete,
-  } = incompleteVersionData
-
   it('can determine greater than semver', () => {
-    expect(handleSemverOperatorComparison(versionFour, versionThree, SearchOperator.GreaterThan)).toBeTruthy()
+    expect(handleSemverOperatorComparison('2.5.0', '2.0.0', SearchOperator.GreaterThan)).toBeTruthy()
   })
   it('can determine less than semver', () => {
-    expect(handleSemverOperatorComparison(versionOne, versionTwo, SearchOperator.LessThan)).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.0.0', '1.5.0', SearchOperator.LessThan)).toBeTruthy()
   })
   it('can determine equals semver', () => {
-    expect(handleSemverOperatorComparison(versionOne, versionOne, SearchOperator.Equals)).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.0.0', '1.0.0', SearchOperator.Equals)).toBeTruthy()
   })
   it('can determine greater than or equal to semver', () => {
-    expect(handleSemverOperatorComparison(versionThree, versionThree, SearchOperator.GreaterThanOrEqualTo)).toBeTruthy()
-    expect(handleSemverOperatorComparison(versionFour, versionThree, SearchOperator.GreaterThanOrEqualTo)).toBeTruthy()
+    expect(handleSemverOperatorComparison('2.0.0', '2.0.0', SearchOperator.GreaterThanOrEqualTo)).toBeTruthy()
+    expect(handleSemverOperatorComparison('2.5.0', '2.0.0', SearchOperator.GreaterThanOrEqualTo)).toBeTruthy()
   })
   it('can determine less than or equal to semver', () => {
-    expect(handleSemverOperatorComparison(versionTwo, versionTwo, SearchOperator.LessThanOrEqualTo)).toBeTruthy()
-    expect(handleSemverOperatorComparison(versionOne, versionTwo, SearchOperator.LessThanOrEqualTo)).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.5.0', '1.5.0', SearchOperator.LessThanOrEqualTo)).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.0.0', '1.5.0', SearchOperator.LessThanOrEqualTo)).toBeTruthy()
   })
   it('can determine non-equal semver', () => {
-    expect(handleSemverOperatorComparison(versionOne, versionTwo, SearchOperator.NotEquals)).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.0.0', '1.5.0', SearchOperator.NotEquals)).toBeTruthy()
   })
   it('can coerce incomplete semver strings', () => {
-    expect(handleSemverOperatorComparison(versionIncomplete, versionOne, SearchOperator.Equals)).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.', '1.0.0', SearchOperator.Equals)).toBeTruthy()
   })
   it('can infer on incomplete semver equals', () => {
-    expect(handleSemverOperatorComparison(versionOne, versionOneIncomplete, SearchOperator.Equals)).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.0.0', '1.', SearchOperator.Equals)).toBeTruthy()
   })
   it('can infer on incomplete semver greater than', () => {
-    expect(handleSemverOperatorComparison(versionTwo, versionOneIncomplete, SearchOperator.GreaterThan)).toBeTruthy()
+    expect(handleSemverOperatorComparison('2.5.0', '1.', SearchOperator.GreaterThan)).toBeTruthy()
   })
   it('can infer on incomplete semver greater than or equal to', () => {
-    expect(
-      handleSemverOperatorComparison(versionTwo, versionOneIncomplete, SearchOperator.GreaterThanOrEqualTo)
-    ).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.5.0', '1.', SearchOperator.GreaterThanOrEqualTo)).toBeTruthy()
   })
   it('can infer on incomplete semver less than', () => {
-    expect(handleSemverOperatorComparison(versionOne, versionTwoIncomplete, SearchOperator.LessThan)).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.0.0', '1.5', SearchOperator.LessThan)).toBeTruthy()
   })
   it('can infer on incomplete semver less than or equal to', () => {
-    expect(
-      handleSemverOperatorComparison(versionOne, versionThreeIncomplete, SearchOperator.LessThanOrEqualTo)
-    ).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.0.0', '2', SearchOperator.LessThanOrEqualTo)).toBeTruthy()
   })
   it('can infer on incomplete semver not equals', () => {
-    expect(handleSemverOperatorComparison(versionOne, versionFourIncomplete, SearchOperator.NotEquals)).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.0.0', '2.5', SearchOperator.NotEquals)).toBeTruthy()
   })
   it('can infer with incomplete semver form x.', () => {
-    expect(
-      handleSemverOperatorComparison(versionOneIncomplete, versionFiveIncomplete, SearchOperator.LessThan)
-    ).toBeTruthy()
+    expect(handleSemverOperatorComparison('1.', '2.5.', SearchOperator.LessThan)).toBeTruthy()
   })
   it('can infer with incomplete semver form x.y.', () => {
-    expect(handleSemverOperatorComparison(versionFour, versionFiveIncomplete, SearchOperator.Equals)).toBeTruthy()
+    expect(handleSemverOperatorComparison('2.5.0', '2.5.', SearchOperator.Equals)).toBeTruthy()
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -524,7 +524,7 @@ export function ClustersTable(props: {
             clusterImageSets,
             agentClusterInstalls,
             props.clusters
-          )?.split(' ')[1]
+          )
           return handleSemverOperatorComparison(clusterVersion ?? '', value, operator)
         },
       },


### PR DESCRIPTION
Regarding: [ACM-14557](https://issues.redhat.com/browse/ACM-14557)

When input in the Advanced Search Field is incomplete the intuitive behavior (what is being implemented here) is that an assumed range of values could appear in the search results.

For example: "Distribution version = 4.", Here the table should display all values **greater than or equal** to 4.0.0 **but less than** 5.0.0

Before: 
![Screenshot 2024-09-27 at 10 19 28 PM](https://github.com/user-attachments/assets/796ec70b-b7b6-4079-912d-0aa546eaaa0e)

After: 
![Screenshot 2024-09-27 at 10 25 19 PM](https://github.com/user-attachments/assets/e70660a9-f050-4f2b-b862-e1fb0d2c320d)

