### PR TITLE
ACM-13698 HostedCluster spec.configuration.items is deprecated

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
@@ -31,13 +31,10 @@ spec:
     networkType: {{{hypershift-network.networkType}}}
   {{#if hypershift-network.enableProxy}}
   configuration:
-    items:
-    - apiVersion: config.openshift.io/v1
-      kind: Proxy
-      spec:
-        httpProxy: '{{{hypershift-network.httpProxy}}}'
-        httpsProxy: '{{{hypershift-network.httpsProxy}}}'
-        noProxy: '{{{hypershift-network.noProxy}}}'
+    proxy:
+      httpProxy: '{{{hypershift-network.httpProxy}}}'
+      httpsProxy: '{{{hypershift-network.httpsProxy}}}'
+      noProxy: '{{{hypershift-network.noProxy}}}'
   {{/if}}
   {{#if hypershift-hosts.controllerAvailabilityPolicy}}
   controllerAvailabilityPolicy: {{{hypershift-hosts.controllerAvailabilityPolicy}}}


### PR DESCRIPTION
For [ACM-13698](https://issues.redhat.com/browse/ACM-13698)

Update hypershift HCP template to use spec.configuration.proxy

## Before

<img width="1626" alt="image" src="https://github.com/user-attachments/assets/c0187d01-af1d-40a7-99d5-31a2bf23cbfd">

## After

<img width="1625" alt="image" src="https://github.com/user-attachments/assets/77fe4a86-77e7-4a91-8170-ac22238ffd8c">
