### PR TITLE
Add the OperatorPolicy compliance message to policy details page

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetails.tsx
@@ -105,6 +105,19 @@ export function PolicyTemplateDetails() {
       ]
     }
 
+    if (kind === 'OperatorPolicy') {
+      let value = '-'
+
+      for (const condition of template?.status?.conditions ?? []) {
+        if (condition?.type === 'Compliant') {
+          value = condition?.message ?? '-'
+          break
+        }
+      }
+
+      cols.push({ key: t('Message'), value: value })
+    }
+
     return cols
   }, [t, name, kind, apiGroup, template, clusterName])
 

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetailsPage.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetailsPage.test.tsx
@@ -627,6 +627,14 @@ describe('Policy Template Details Page', () => {
     await waitForText('oppol-no-group', true)
     await waitForText('OperatorPolicy')
 
+    await waitForText('Message')
+    await waitForText(
+      'Compliant; the OperatorGroup matches what is required by the policy, the Subscription matches what is ' +
+        'required by the policy, no InstallPlans requiring approval were found, ClusterServiceVersion - install ' +
+        'strategy completed with no errors, all operator Deployments have their minimum availability, CatalogSource ' +
+        'was found'
+    )
+
     await waitForText('View YAML', true)
 
     const row = screen.getByRole('row', {


### PR DESCRIPTION
When there is an error message, the UI wouldn't show it and the user had to look at the YAML to find the error message.

This just shows it as a row in the details card.

![image](https://github.com/user-attachments/assets/55e53c70-6154-4184-84d6-a59ad293353f)
