### PR TITLE
Make the PolicySet donut chart consistent

### DIFF
--- a/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
+++ b/frontend/src/routes/Governance/policy-sets/components/PolicySetDetailSidebar.tsx
@@ -67,14 +67,6 @@ function renderDonutChart(
     name: `${d.value} ${d.key}`,
   }))
 
-  const donutTitle =
-    clusterCompliantCount + clusterNonCompliantCount + clusterPendingCount === 0
-      ? '0%'
-      : `${(
-          (clusterCompliantCount / (clusterCompliantCount + clusterNonCompliantCount + clusterPendingCount)) *
-          100
-        ).toFixed(0)}%`
-
   return (
     <div style={{ height: 230, marginTop: -16, marginBottom: -16 }}>
       <ChartDonut
@@ -91,7 +83,8 @@ function renderDonutChart(
         padding={{
           right: 300,
         }}
-        title={donutTitle}
+        title={clusterNonCompliantCount.toString()}
+        subTitle={t('Violation', { count: clusterNonCompliantCount })}
         width={450}
         colorScale={colorThemes.criticalLowSuccess}
       />


### PR DESCRIPTION
Use a number like other policy related donut charts rather than a percentage.

Relates:
https://issues.redhat.com/browse/ACM-14661

![image](https://github.com/user-attachments/assets/a8bd0fb8-e681-4465-a227-c8e1acd6de94)