### PR TITLE
Add page count metric for VM page

### DIFF
--- a/backend/test/routes/metrics.test.ts
+++ b/backend/test/routes/metrics.test.ts
@@ -37,9 +37,9 @@ describe('metrics route', function () {
           },
         },
       })
-    nock(process.env.CLUSTER_API_URL).post('/metrics?overview-classic').reply(200)
+    nock(process.env.CLUSTER_API_URL).post('/metrics?overview-fleet').reply(200)
 
-    const res = await request('POST', '/metrics?overview-classic')
+    const res = await request('POST', '/metrics?overview-fleet')
     // POST increases the metric count - no response to validate
     expect(res.statusCode).toEqual(200)
   })

--- a/frontend/src/hooks/console-metrics.ts
+++ b/frontend/src/hooks/console-metrics.ts
@@ -4,11 +4,11 @@ import { useEffect } from 'react'
 import { getBackendUrl, postRequest } from '../resources'
 
 export enum Pages {
-  overview = 'overview-classic',
   overviewFleet = 'overview-fleet',
   search = 'search',
   searchDetails = 'search-details',
   clusters = 'clusters',
+  virtualMachines = 'virtual-machines',
   application = 'application',
   governance = 'governance',
 }

--- a/frontend/src/routes/Home/Overview/Overview.test.tsx
+++ b/frontend/src/routes/Home/Overview/Overview.test.tsx
@@ -1,14 +1,14 @@
 /* Copyright Contributors to the Open Cluster Management project */
+import { MockedProvider } from '@apollo/client/testing'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom-v5-compat'
-import Overview from './Overview'
+import { RecoilRoot } from 'recoil'
+import { nockAggegateRequest, nockCreate, nockGet, nockIgnoreApiPaths } from '../../../lib/nock-util'
 import { PluginContext } from '../../../lib/PluginContext'
 import { PluginDataContext } from '../../../lib/PluginDataContext'
-import { render } from '@testing-library/react'
 import { clickByText, waitForNocks, waitForText } from '../../../lib/test-util'
-import { RecoilRoot } from 'recoil'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { MockedProvider } from '@apollo/client/testing'
-import { nockAggegateRequest, nockCreate, nockGet, nockIgnoreApiPaths, nockPostRequest } from '../../../lib/nock-util'
+import Overview from './Overview'
 import {
   getAddonRequest,
   getAddonResponse,
@@ -29,7 +29,6 @@ it('should render overview page with extension', async () => {
   const apiPathNock = nockIgnoreApiPaths()
   const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
   const getManageedClusterAccessRequeset = nockCreate(mockGetSelfSubjectAccessRequest, mockGetSelfSubjectAccessResponse)
-  const metricNock = nockPostRequest('/metrics?overview-classic', {})
   nockAggegateRequest('statuses', statusAggregate.req, statusAggregate.res)
   render(
     <RecoilRoot>
@@ -77,14 +76,13 @@ it('should render overview page with extension', async () => {
   await clickByText('Test tab')
 
   await waitForText('Test extension content')
-  await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
+  await waitForNocks([getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
 })
 
 it('should render overview page layout when extension tab crashes', async () => {
   const apiPathNock = nockIgnoreApiPaths()
   const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
   const getManageedClusterAccessRequeset = nockCreate(mockGetSelfSubjectAccessRequest, mockGetSelfSubjectAccessResponse)
-  const metricNock = nockPostRequest('/metrics?overview-classic', {})
   nockAggegateRequest('statuses', statusAggregate.req, statusAggregate.res)
   render(
     <RecoilRoot>
@@ -134,5 +132,5 @@ it('should render overview page layout when extension tab crashes', async () => 
   await clickByText('Test tab')
 
   await waitForText('Overview')
-  await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
+  await waitForNocks([getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
 })

--- a/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.test.tsx
@@ -19,7 +19,7 @@ import {
   policiesState,
   policyreportState,
 } from '../../../atoms'
-import { nockAggegateRequest, nockCreate, nockGet, nockIgnoreApiPaths, nockPostRequest } from '../../../lib/nock-util'
+import { nockAggegateRequest, nockCreate, nockGet, nockIgnoreApiPaths } from '../../../lib/nock-util'
 import { clickByText, wait, waitForNocks } from '../../../lib/test-util'
 import {
   ClusterManagementAddOn,
@@ -33,13 +33,13 @@ import {
 } from '../../../resources'
 import { mockApplications, mockApplicationSets, mockArgoApplications } from '../../Applications/Application.sharedmocks'
 import { SearchResultCountDocument } from '../../Search/search-sdk/search-sdk'
-import OverviewPage from './OverviewPage'
 import {
   getAddonRequest,
   getAddonResponse,
   mockGetSelfSubjectAccessRequest,
   mockGetSelfSubjectAccessResponse,
 } from './Overview.sharedmocks'
+import OverviewPage from './OverviewPage'
 
 const queryClient = new QueryClient()
 
@@ -920,7 +920,6 @@ it('should render overview page in empty state', async () => {
   const apiPathNock = nockIgnoreApiPaths()
   const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
   const getManageedClusterAccessRequeset = nockCreate(mockGetSelfSubjectAccessRequest, mockGetSelfSubjectAccessResponse)
-  const metricNock = nockPostRequest('/metrics?overview-classic', {})
   nockAggegateRequest('statuses', statusAggregate.req, statusAggregate.res)
 
   render(
@@ -939,13 +938,12 @@ it('should render overview page in empty state', async () => {
   await waitFor(() => expect(screen.getByText(`You don't have any clusters`)).toBeInTheDocument())
 
   // Wait for delete resource requests to finish
-  await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
+  await waitForNocks([getAddonNock, getManageedClusterAccessRequeset, apiPathNock])
 })
 
 it('should render overview page in error state', async () => {
   nockIgnoreApiPaths()
   nockAggegateRequest('statuses', statusAggregate.req, statusAggregate.res)
-  const metricNock = nockPostRequest('/metrics?overview-classic', {})
   const getAddonNock = nockGet(getAddonRequest, getAddonResponse)
   const getManageedClusterAccessRequeset = nockCreate(mockGetSelfSubjectAccessRequest, mockGetSelfSubjectAccessResponse)
   const mocks = [
@@ -975,14 +973,13 @@ it('should render overview page in error state', async () => {
   await wait()
 
   // Wait for delete resource requests to finish
-  await waitForNocks([metricNock, getAddonNock, getManageedClusterAccessRequeset])
+  await waitForNocks([getAddonNock, getManageedClusterAccessRequeset])
 
   // Test that the component has rendered correctly with an error
   await waitFor(() => expect(screen.queryByText('An unexpected error occurred.')).toBeTruthy())
 })
 
 it('should render overview page with expected data', async () => {
-  const metricNock = nockPostRequest('/metrics?overview-classic', {})
   nockAggegateRequest('statuses', statusAggregate.req, statusAggregate.res)
 
   nockIgnoreApiPaths()
@@ -1094,7 +1091,7 @@ it('should render overview page with expected data', async () => {
   )
 
   // Wait for delete resource requests to finish
-  await waitForNocks([metricNock, getAddonNock])
+  await waitForNocks([getAddonNock])
 
   // This wait pauses till apollo query is returning data
   await wait()

--- a/frontend/src/routes/Home/Overview/OverviewPage.tsx
+++ b/frontend/src/routes/Home/Overview/OverviewPage.tsx
@@ -4,8 +4,8 @@ import { PageSection, Stack } from '@patternfly/react-core'
 import { isEqual } from 'lodash'
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useState } from 'react'
 import { AcmMasonry } from '../../../components/AcmMasonry'
-import { Pages, usePageVisitMetricHandler } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
+import { SupportedAggregate, useAggregate } from '../../../lib/useAggregates'
 import { NavigationPath } from '../../../NavigationPath'
 import {
   Addon,
@@ -31,7 +31,6 @@ import { useClusterAddons } from '../../Infrastructure/Clusters/ClusterSets/comp
 import { useAllClusters } from '../../Infrastructure/Clusters/ManagedClusters/components/useAllClusters'
 import { searchClient } from '../../Search/search-sdk/search-client'
 import { useSearchResultCountLazyQuery } from '../../Search/search-sdk/search-sdk'
-import { SupportedAggregate, useAggregate } from '../../../lib/useAggregates'
 
 function getClusterSummary(
   clusters: Cluster[],
@@ -177,7 +176,6 @@ const searchQueries = (selectedClusters: Array<string>, clusters: Cluster[]): Ar
 }
 
 export default function OverviewPage() {
-  usePageVisitMetricHandler(Pages.overview)
   const { t } = useTranslation()
   const { managedClusterInfosState, policyreportState, usePolicies } = useSharedAtoms()
 

--- a/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.test.tsx
+++ b/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.test.tsx
@@ -6,12 +6,14 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { GraphQLError } from 'graphql'
 import { MemoryRouter } from 'react-router-dom-v5-compat'
 import { RecoilRoot } from 'recoil'
-import { wait } from '../../../lib/test-util'
+import { nockPostRequest } from '../../../lib/nock-util'
+import { wait, waitForNocks } from '../../../lib/test-util'
 import { SearchResultItemsDocument } from '../../Search/search-sdk/search-sdk'
 import VirtualMachinesPage from './VirtualMachinesPage'
 
 describe('VirtualMachinesPage Page', () => {
   it('should render page with correct vm data', async () => {
+    const metricNock = nockPostRequest('/metrics?virtual-machines', {})
     const mocks = [
       {
         request: {
@@ -92,6 +94,7 @@ describe('VirtualMachinesPage Page', () => {
         </MemoryRouter>
       </RecoilRoot>
     )
+    await waitForNocks([metricNock])
     // This wait pauses till apollo query is returning data
     await wait()
     // Test that the table has rendered with virtual machine 1 data
@@ -108,6 +111,7 @@ describe('VirtualMachinesPage Page', () => {
   })
 
   it('should render page with errors', async () => {
+    const metricNock = nockPostRequest('/metrics?virtual-machines', {})
     const mocks = [
       {
         request: {
@@ -142,6 +146,7 @@ describe('VirtualMachinesPage Page', () => {
         </MemoryRouter>
       </RecoilRoot>
     )
+    await waitForNocks([metricNock])
     // This wait pauses till apollo query is returning data
     await wait()
     // Test that the component has rendered errors correctly

--- a/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
+++ b/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core'
 import { ExclamationCircleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons'
 import { Fragment, useMemo, useState } from 'react'
+import { Pages, usePageVisitMetricHandler } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { useRecoilValue, useSharedAtoms } from '../../../shared-recoil'
 import {
@@ -176,6 +177,7 @@ function VirtualMachineTable() {
 
 export default function VirtualMachinesPage() {
   const { t } = useTranslation()
+  usePageVisitMetricHandler(Pages.virtualMachines)
 
   return (
     <AcmPage hasDrawer header={<AcmPageHeader title={t('Virtual machines')} />}>


### PR DESCRIPTION
add `virtual-machines` label to`acm_console_page_count` metric
remove deprecated `overview-classic` label