### PR TITLE
ACM-12100 Add kubevirt detection for imported hosted clusters

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterPools/ClusterPools.tsx
@@ -53,7 +53,7 @@ import { useAllClusters } from '../ManagedClusters/components/useAllClusters'
 import { ClusterClaimModal, ClusterClaimModalProps } from './components/ClusterClaimModal'
 import { ScaleClusterPoolModal, ScaleClusterPoolModalProps } from './components/ScaleClusterPoolModal'
 import { UpdateReleaseImageModal, UpdateReleaseImageModalProps } from './components/UpdateReleaseImageModal'
-import { getMappedClusterPoolClusterSetClusters } from '../ClusterSets/components/useClusters'
+import { getMappedClusterPoolClusters } from '../ClusterSets/components/useClusters'
 
 export default function ClusterPoolsPage() {
   const alertContext = useContext(AcmAlertContext)
@@ -188,6 +188,7 @@ export function ClusterPoolsTable(props: {
     clusterCuratorsState,
     hostedClustersState,
     nodePoolsState,
+    discoveredClusterState,
   } = useSharedAtoms()
   const clusterImageSets = useRecoilValue(clusterImageSetsState)
   const clusterClaims = useRecoilValue(clusterClaimsState)
@@ -201,6 +202,7 @@ export function ClusterPoolsTable(props: {
   const agentClusterInstalls = useRecoilValue(agentClusterInstallsState)
   const hostedClusters = useRecoilValue(hostedClustersState)
   const nodePools = useRecoilValue(nodePoolsState)
+  const discoveredClusters = useRecoilValue(discoveredClusterState)
 
   const { clusterPools } = props
   const { t } = useTranslation()
@@ -217,22 +219,21 @@ export function ClusterPoolsTable(props: {
   props.clusterPools &&
     props.clusterPools.forEach((clusterPool) => {
       if (clusterPool.metadata.name) {
-        const clusters = getMappedClusterPoolClusterSetClusters(
+        const clusters = getMappedClusterPoolClusters({
           managedClusters,
           clusterDeployments,
           managedClusterInfos,
           certificateSigningRequests,
-          managedClusterAddons,
-          clusterManagementAddons,
+          managedClusterAddOns: managedClusterAddons,
+          clusterManagementAddOns: clusterManagementAddons,
           clusterClaims,
           clusterCurators,
           agentClusterInstalls,
           hostedClusters,
           nodePools,
-          undefined,
+          discoveredClusters,
           clusterPool,
-          undefined
-        )
+        })
         clusterPoolClusters[clusterPool.metadata.name] = clusters
       }
     })

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.tsx
@@ -52,7 +52,7 @@ export default function ClusterSetDetails() {
   const clusterSet = managedClusterSets.find((mcs) => mcs.metadata.name === match.params.id)
   const prevClusterSet = usePrevious(clusterSet)
 
-  const clusters = useClusters(clusterSet)
+  const clusters = useClusters({ managedClusterSet: clusterSet })
   const clusterPools = useRecoilValue(clusterPoolsState)
   const clusterSetClusterPools = clusterPools.filter(
     (cp) => cp.metadata.labels?.[managedClusterSetLabel] === clusterSet?.metadata.name

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetManageResources/ClusterSetManageResources.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetManageResources/ClusterSetManageResources.test.tsx
@@ -14,7 +14,7 @@ import {
   ManagedClusterSetApiVersion,
   ManagedClusterSetKind,
   managedClusterSetLabel,
-  mapClusters,
+  testMapClusters,
 } from '../../../../../../resources'
 import { render } from '@testing-library/react'
 import { MemoryRouter, Outlet, Route, Routes, generatePath } from 'react-router-dom-v5-compat'
@@ -244,7 +244,9 @@ function nockPatchClusterDeployment(clusterName: string, op: 'replace' | 'add' |
 const Component = () => {
   const context: Partial<ClusterSetDetailsContext> = {
     clusterSet: mockManagedClusterSet,
-    clusters: mapClusters([], [], [], [mockManagedClusterRemove, mockManagedClusterUnchanged], {}),
+    clusters: testMapClusters({
+      managedClusters: [mockManagedClusterRemove, mockManagedClusterUnchanged],
+    }),
     clusterPools: [],
     clusterDeployments: [mockClusterDeploymentClaimed],
     clusterRoleBindings: [],

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSets.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSets.tsx
@@ -42,7 +42,7 @@ import { GlobalClusterSetPopover } from './components/GlobalClusterSetPopover'
 import { CreateClusterSetModal } from './CreateClusterSet/CreateClusterSetModal'
 import { PluginContext } from '../../../../lib/PluginContext'
 import { useSharedAtoms, useRecoilValue } from '../../../../shared-recoil'
-import { getMappedClusterPoolClusterSetClusters } from './components/useClusters'
+import { getMappedClusterSetClusters } from './components/useClusters'
 
 export default function ClusterSetsPage() {
   const { t } = useTranslation()
@@ -139,41 +139,42 @@ export function ClusterSetsTable(props: { managedClusterSets?: ManagedClusterSet
     clusterCuratorsState,
     hostedClustersState,
     nodePoolsState,
+    discoveredClusterState,
   } = useSharedAtoms()
   const managedClusterSetBindings = useRecoilValue(managedClusterSetBindingsState)
   const managedClusters = useRecoilValue(managedClustersState)
   const clusterDeployments = useRecoilValue(clusterDeploymentsState)
   const managedClusterInfos = useRecoilValue(managedClusterInfosState)
   const certificateSigningRequests = useRecoilValue(certificateSigningRequestsState)
-  const managedClusterAddons = useRecoilValue(managedClusterAddonsState)
-  const clusterManagementAddons = useRecoilValue(clusterManagementAddonsState)
+  const managedClusterAddOns = useRecoilValue(managedClusterAddonsState)
+  const clusterManagementAddOns = useRecoilValue(clusterManagementAddonsState)
   const clusterClaims = useRecoilValue(clusterClaimsState)
   const clusterCurators = useRecoilValue(clusterCuratorsState)
   const agentClusterInstalls = useRecoilValue(agentClusterInstallsState)
   const hostedClusters = useRecoilValue(hostedClustersState)
   const nodePools = useRecoilValue(nodePoolsState)
+  const discoveredClusters = useRecoilValue(discoveredClusterState)
 
   const managedClusterSetClusters: Record<string, Cluster[]> = {}
 
   props.managedClusterSets &&
     props.managedClusterSets.forEach((managedClusterSet) => {
       if (managedClusterSet.metadata.name) {
-        const clusters = getMappedClusterPoolClusterSetClusters(
+        const clusters = getMappedClusterSetClusters({
           managedClusters,
           clusterDeployments,
           managedClusterInfos,
           certificateSigningRequests,
-          managedClusterAddons,
-          clusterManagementAddons,
+          managedClusterAddOns,
+          clusterManagementAddOns,
           clusterClaims,
           clusterCurators,
           agentClusterInstalls,
           hostedClusters,
           nodePools,
+          discoveredClusters,
           managedClusterSet,
-          undefined,
-          isGlobalClusterSet(managedClusterSet)
-        )
+        })
         managedClusterSetClusters[managedClusterSet.metadata.name] = clusters
       }
     })
@@ -241,13 +242,7 @@ export function ClusterSetsTable(props: { managedClusterSets?: ManagedClusterSet
           },
           {
             header: t('table.cluster.statuses'),
-            cell: (managedClusterSet: ManagedClusterSet) => {
-              return isGlobalClusterSet(managedClusterSet) ? (
-                <ClusterStatuses isGlobalClusterSet={true} />
-              ) : (
-                <ClusterStatuses managedClusterSet={managedClusterSet} />
-              )
-            },
+            cell: (managedClusterSet: ManagedClusterSet) => <ClusterStatuses managedClusterSet={managedClusterSet} />,
             exportContent: (managedClusterSet: ManagedClusterSet) => {
               const status = getClusterStatusCount(managedClusterSetClusters[managedClusterSet.metadata.name!])
               const clusterStatusAvailable =

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/ClusterStatuses.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/ClusterStatuses.tsx
@@ -4,12 +4,8 @@ import { Cluster, ClusterPool, getClusterStatusType, ManagedClusterSet } from '.
 import { AcmInlineStatusGroup, StatusType } from '../../../../../ui-components'
 import { useClusters } from './useClusters'
 
-export function ClusterStatuses(props: {
-  managedClusterSet?: ManagedClusterSet
-  clusterPool?: ClusterPool
-  isGlobalClusterSet?: boolean
-}) {
-  const clusters = useClusters(props.managedClusterSet, props.clusterPool, props.isGlobalClusterSet)
+export function ClusterStatuses(props: { managedClusterSet?: ManagedClusterSet; clusterPool?: ClusterPool }) {
+  const clusters = useClusters({ managedClusterSet: props.managedClusterSet, clusterPool: props.clusterPool })
   const { healthy, running, warning, progress, danger, pending, sleep, unknown, detached } = getClusterStatusCount(
     clusters,
     props.managedClusterSet,

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/MultiClusterNetworkStatus.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/components/MultiClusterNetworkStatus.tsx
@@ -17,7 +17,7 @@ export function MultiClusterNetworkStatus(props: { clusterSet: ManagedClusterSet
   const { managedClusterAddonsState } = useSharedAtoms()
   const managedClusterAddons = useRecoilValue(managedClusterAddonsState)
 
-  const clusters = useClusters(clusterSet)
+  const clusters = useClusters({ managedClusterSet: clusterSet })
   // instead of searching through clusters for each ManagedClusterAddon (12*3800)
   // loop through clusters once and use a managedClusterAddons map to get the addons for each cluster
   const submarinerAddons = useMemo(() => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
@@ -72,15 +72,8 @@ function getAIClusterProperties(
 }
 
 export function ClusterOverviewPageContent() {
-  const {
-    canGetSecret,
-    cluster,
-    clusterCurator,
-    clusterDeployment,
-    agentClusterInstall,
-    hostedCluster,
-    selectedHostedCluster,
-  } = useClusterDetailsContext()
+  const { canGetSecret, cluster, clusterCurator, clusterDeployment, agentClusterInstall, hostedCluster } =
+    useClusterDetailsContext()
   const { t } = useTranslation()
   const [showEditLabels, setShowEditLabels] = useState<boolean>(false)
   const [showChannelSelectModal, setShowChannelSelectModal] = useState<boolean>(false)
@@ -446,8 +439,8 @@ export function ClusterOverviewPageContent() {
         )}
         <ClusterStatusMessageAlert cluster={cluster} padBottom />
         <HiveNotification />
-        {cluster?.isHypershift && !cluster?.isHostedCluster && selectedHostedCluster ? (
-          <HypershiftImportCommand selectedHostedClusterResource={selectedHostedCluster} />
+        {cluster?.isHypershift && !cluster?.isHostedCluster && hostedCluster ? (
+          <HypershiftImportCommand selectedHostedClusterResource={hostedCluster} />
         ) : (
           <ImportCommandContainer />
         )}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/useAllClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/useAllClusters.tsx
@@ -21,35 +21,38 @@ export function useAllClusters(excludeUnclaimed?: boolean) {
     agentClusterInstallsState,
     hostedClustersState,
     nodePoolsState,
+    discoveredClusterState,
   } = useSharedAtoms()
 
   const managedClusters = useRecoilValue(managedClustersState)
   const clusterDeployments = useRecoilValue(clusterDeploymentsState)
   const managedClusterInfos = useRecoilValue(managedClusterInfosState)
   const certificateSigningRequests = useRecoilValue(certificateSigningRequestsState)
-  const managedClusterAddons = useRecoilValue(managedClusterAddonsState)
+  const managedClusterAddOns = useRecoilValue(managedClusterAddonsState)
   const clusterManagementAddOns = useRecoilValue(clusterManagementAddonsState)
   const clusterClaims = useRecoilValue(clusterClaimsState)
   const clusterCurators = useRecoilValue(clusterCuratorsState)
   const agentClusterInstalls = useRecoilValue(agentClusterInstallsState)
   const hostedClusters = useRecoilValue(hostedClustersState)
   const nodePools = useRecoilValue(nodePoolsState)
+  const discoveredClusters = useRecoilValue(discoveredClusterState)
 
   const clusters = useMemo(
     () =>
-      mapClusters(
+      mapClusters({
         clusterDeployments,
         managedClusterInfos,
         certificateSigningRequests,
         managedClusters,
-        managedClusterAddons,
+        managedClusterAddOns,
         clusterManagementAddOns,
         clusterClaims,
         clusterCurators,
         agentClusterInstalls,
         hostedClusters,
-        nodePools
-      ).filter((cluster) => {
+        nodePools,
+        discoveredClusters,
+      }).filter((cluster) => {
         if (excludeUnclaimed) {
           if (cluster.hive.clusterPool) {
             return cluster.hive.clusterClaimName !== undefined
@@ -62,13 +65,14 @@ export function useAllClusters(excludeUnclaimed?: boolean) {
       managedClusterInfos,
       certificateSigningRequests,
       managedClusters,
-      managedClusterAddons,
+      managedClusterAddOns,
       clusterManagementAddOns,
       clusterClaims,
       clusterCurators,
       agentClusterInstalls,
       hostedClusters,
       nodePools,
+      discoveredClusters,
       excludeUnclaimed,
     ]
   )


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-12100

- Improve efficiency by removing unnecessary use of useAllClusters
- Refactor cluster mapping code functions to mostly use destructured object params

## Before
![image](https://github.com/user-attachments/assets/d09c585f-aa92-4ee3-8923-8d1416efe143)


## After
![image](https://github.com/user-attachments/assets/65d3ec57-755f-4321-a1bc-431023cce354)
