### PR TITLE
Stop rerendering discovered policies table when polling updates

### DIFF
--- a/frontend/src/routes/Governance/discovered/useFetchPolicies.tsx
+++ b/frontend/src/routes/Governance/discovered/useFetchPolicies.tsx
@@ -120,8 +120,6 @@ export function useFetchPolicies(policyName?: string, policyKind?: string, apiGr
   })
 
   useEffect(() => {
-    setIsFetching(true)
-
     if (searchErr && !searchLoading) {
       setIsFetching(false)
     }


### PR DESCRIPTION
We only need to display the spinner on the first load. Polling updates should be transparent to the user.