### PR TITLE
Update PR branch for previous release

### DIFF
--- a/.tekton/console-acm-212-pull-request.yaml
+++ b/.tekton/console-acm-212-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.12"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-212

--- a/.tekton/console-mce-mce-27-pull-request.yaml
+++ b/.tekton/console-mce-mce-27-pull-request.yaml
@@ -7,8 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.12"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-mce-27


### PR DESCRIPTION
PRs against `main` are now fast-forwarded to `release-2.13` / `backplane-2.8`. PRs for ACM 2.12 / MCE 2.7 are now made against `release-2.12`.