### PR TITLE
ACM-14860 Edge case ROSA import bug

### DIFF
--- a/frontend/src/lib/test-metadata.ts
+++ b/frontend/src/lib/test-metadata.ts
@@ -110,6 +110,18 @@ export const mockCRHCredential2: Secret = {
   },
 }
 
+export const mockCRHCredential3: Secret = {
+  apiVersion: SecretApiVersion,
+  kind: SecretKind,
+  metadata: {
+    name: 'test-credential',
+    namespace: 'ocm',
+    labels: {
+      'cluster.open-cluster-management.io/type': Provider.redhatcloud,
+    },
+  },
+}
+
 export const mockDiscoveryConfig: DiscoveryConfig = {
   apiVersion: DiscoveryConfigApiVersion,
   kind: DiscoveryConfigKind,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -1197,7 +1197,6 @@ describe('Import cluster RHOCM mode', () => {
     // Assert the removed credential does not exist
     expect(screen.queryByText(mockCRHCredential1.metadata.name!)).not.toBeInTheDocument()
     expect(screen.queryByText(mockCRHCredential3.metadata.name!)).toBeInTheDocument()
-    screen.logTestingPlaygroundURL()
     // Remove the 2nd credential (now the 1st in the list)
     setSetSecrets.mock.calls.slice(-1)[0][0]([mockCRHCredential3])
 
@@ -1211,98 +1210,5 @@ describe('Import cluster RHOCM mode', () => {
       })
     )
     expect(screen.queryByText(mockCRHCredential3.metadata.name!)).toBeInTheDocument()
-  })
-})
-describe('Credential Edge Cases 1', () => {
-  const initializeCredentialComponent = (secrets: Secret[]) => (
-    <RecoilRoot
-      initializeState={(snapshot) => {
-        snapshot.set(managedClusterSetsState, [mockManagedClusterSet])
-        snapshot.set(secretsState, secrets)
-        snapshot.set(discoveryConfigState, [mockDiscoveryConfig])
-        snapshot.set(discoveredClusterState, mockDiscoveredClusters)
-        snapshot.set(namespacesState, mockNamepaces)
-      }}
-    >
-      <MemoryRouter>
-        <Routes>
-          <Route path="/" element={<DiscoveredClustersPage />} />
-          <Route path={NavigationPath.importCluster} element={<ImportClusterPage />} />
-        </Routes>
-      </MemoryRouter>
-    </RecoilRoot>
-  )
-
-  test('should set credential to empty string when no credentials exist in namespace', async () => {
-    const secrets: Secret[] = []
-    const { getByDisplayValue } = render(initializeCredentialComponent(secrets))
-
-    await waitFor(() => {
-      expect(getByDisplayValue('')).toBeInTheDocument()
-    })
-  })
-
-  test('should set credential to empty string when metadata.name is undefined', async () => {
-    const secrets: Secret[] = [
-      {
-        apiVersion: 'v1',
-        kind: 'Secret',
-        metadata: { name: '', namespace: 'default' },
-        data: {},
-      },
-    ]
-    const { getByDisplayValue } = render(initializeCredentialComponent(secrets))
-
-    await waitFor(() => {
-      expect(getByDisplayValue('')).toBeInTheDocument()
-    })
-  })
-})
-
-describe('Credential Edge Cases 2', () => {
-  const initializeCredentialComponent = (secrets: Secret[]) => (
-    <RecoilRoot
-      initializeState={(snapshot) => {
-        snapshot.set(managedClusterSetsState, [mockManagedClusterSet])
-        snapshot.set(secretsState, secrets)
-        snapshot.set(discoveryConfigState, [mockDiscoveryConfig])
-        snapshot.set(discoveredClusterState, mockDiscoveredClusters)
-        snapshot.set(namespacesState, mockNamepaces)
-      }}
-    >
-      <MemoryRouter>
-        <Routes>
-          <Route path="/" element={<DiscoveredClustersPage />} />
-          <Route path={NavigationPath.importCluster} element={<ImportClusterPage />} />
-        </Routes>
-      </MemoryRouter>
-    </RecoilRoot>
-  )
-
-  test('should set credential to the first filtered credential name when it exists', async () => {
-    const validSecrets: Secret[] = [
-      {
-        apiVersion: 'v1',
-        kind: 'Secret',
-        metadata: { name: 'validCredential', namespace: 'open-cluster-management' },
-        data: {
-          someKey: 'someValue',
-        },
-      },
-      {
-        apiVersion: 'v1',
-        kind: 'Secret',
-        metadata: { name: 'otherCredential', namespace: 'open-cluster-management' },
-        data: {
-          anotherKey: 'anotherValue',
-        },
-      },
-    ]
-
-    const { getAllByText } = render(initializeCredentialComponent(validSecrets))
-
-    await waitFor(() => {
-      expect(getAllByText(mockDiscoveredClusters[1].metadata.name!)[0]!).toBeInTheDocument()
-    })
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -1159,7 +1159,6 @@ describe('Import cluster RHOCM mode', () => {
   it('responds to changes in available RHOCM credentials', async () => {
     const setSetSecrets = jest.fn()
     render(<Component secrets={[mockCRHCredential1, mockCRHCredential2]} setSetSecrets={setSetSecrets} />)
-    await clickByText('Run import commands manually')
     await clickByText('Import from Red Hat OpenShift Cluster Manager')
     await clickByText('Select a namespace')
     await clickByText(mockCRHCredential1.metadata.namespace!)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -330,35 +330,6 @@ export default function ImportClusterPage() {
           return state.importMode === ImportMode.discoveryOCM ? { ...state, credential: action.credential } : state
         case 'setKubeconfig':
           return state.importMode === ImportMode.kubeconfig ? { ...state, kubeconfig: action.kubeconfig } : state
-        // case 'updateCredentials': {
-        //   const namespaceExists = doesNamespaceExist(ocmCredentials, state.namespace)
-
-        //   if (!namespaceExists) {
-        //     return {
-        //       ...state,
-        //       namespace: '',
-        //       credential: '',
-        //     }
-        //   }
-
-        //   const filteredCredentials = getFilteredCredentials(ocmCredentials, state.namespace)
-        //   const credentialExists = doesCredentialExist(filteredCredentials, state.credential)
-
-        //   if (!credentialExists) {
-        //     return {
-        //       ...state,
-        //       credential:
-        //         filteredCredentials.length > 0 && filteredCredentials[0].metadata.name
-        //           ? filteredCredentials[0].metadata.name
-        //           : '',
-        //       credentials: filteredCredentials,
-        //     }
-        //   }
-        //   return {
-        //     ...state,
-        //     credentials: filteredCredentials,
-        //   }
-        // }
         case 'updateCredentials': {
           const namespaceExists = doesNamespaceExist(ocmCredentials, state.namespace)
           const filteredCredentials = namespaceExists ? getFilteredCredentials(ocmCredentials, state.namespace) : []

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -132,6 +132,7 @@ type Action =
   | ({ type: 'setClusterID' } & Pick<State, 'clusterID'>)
   | ({ type: 'setNamespace' } & Pick<State, 'namespace'>)
   | ({ type: 'setCredential' } & Pick<State, 'credential'>)
+  | { type: 'updateCredentials' }
 
 const getImportMode = (presetDiscoveredCluster: boolean, discoveryClusterType?: string) => {
   if (presetDiscoveredCluster) {
@@ -239,6 +240,21 @@ export default function ImportClusterPage() {
     client_secret: initialClientSecret,
   } = initialStringData
 
+  // Helper function to check if the namespace exists
+  function doesNamespaceExist(ocmCredentials: ProviderConnection[], namespace: string): boolean {
+    return ocmCredentials.some((credential) => credential.metadata.namespace === namespace)
+  }
+
+  // Helper function to filter credentials based on namespace
+  function getFilteredCredentials(ocmCredentials: ProviderConnection[], namespace: string): ProviderConnection[] {
+    return ocmCredentials.filter((credential) => credential.metadata.namespace === namespace)
+  }
+
+  // Helper function to check if a credential exists within the filtered credentials
+  function doesCredentialExist(filteredCredentials: ProviderConnection[], credentialName: string): boolean {
+    return filteredCredentials.some((credential) => credential.metadata.name === credentialName)
+  }
+
   const reducer = useCallback(
     (state: State, action: Action): State => {
       switch (action.type) {
@@ -314,6 +330,31 @@ export default function ImportClusterPage() {
           return state.importMode === ImportMode.discoveryOCM ? { ...state, credential: action.credential } : state
         case 'setKubeconfig':
           return state.importMode === ImportMode.kubeconfig ? { ...state, kubeconfig: action.kubeconfig } : state
+        case 'updateCredentials': {
+          const namespaceExists = doesNamespaceExist(ocmCredentials, state.namespace)
+
+          if (!namespaceExists) {
+            return {
+              ...state,
+              namespace: '',
+              credential: '',
+            }
+          }
+
+          const filteredCredentials = getFilteredCredentials(ocmCredentials, state.namespace)
+          const credentialExists = doesCredentialExist(filteredCredentials, state.credential)
+
+          if (!credentialExists) {
+            return {
+              ...state,
+              credential:
+                filteredCredentials.length > 0 && filteredCredentials[0].metadata.name
+                  ? filteredCredentials[0].metadata.name
+                  : '',
+            }
+          }
+          return state
+        }
       }
     },
     [ocmCredentials]
@@ -332,6 +373,14 @@ export default function ImportClusterPage() {
     },
     getInitialState
   )
+
+  const prevOcmCredentials = usePrevious(ocmCredentials)
+
+  useEffect(() => {
+    if (prevOcmCredentials !== ocmCredentials) {
+      dispatch({ type: 'updateCredentials' })
+    }
+  }, [ocmCredentials, prevOcmCredentials])
 
   useEffect(() => {
     if (state.importMode !== 'manual') {


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-14860

Bug Description:
The Import Cluster wizard does not dynamically update when OCM credentials are added or deleted. If a credential is removed or added from an external source while the wizard is open, the list of available credentials and the selected namespace/credential dropdowns are not refreshed accordingly. This can lead to situations where deleted credentials remain selected or unavailable credentials are shown.

Expected Behavior:

When OCM credentials are deleted:
  - If the currently selected credential no longer exists, the wizard should either reset the credential field to an empty state or select the first available credential in the current namespace (if any).
  - If the namespace no longer contains any credentials, the namespace field should be cleared, and the credential dropdown should reset.
When new OCM credentials are added:
  - The wizard should automatically update the credential list to reflect the newly available credentials in the appropriate namespace.