### PR TITLE
[ACM-14990] Change VM table console column header to vm details

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -3207,6 +3207,7 @@
   "violations: {{count}} policy_plural": "violations: {{count}} policies",
   "Virtual machines": "Virtual machines",
   "Virtual Machines": "Virtual Machines",
+  "VM details": "VM details",
   "VM size": "VM size",
   "VMware": "VMware",
   "Volume mode": "Volume mode",

--- a/frontend/src/routes/Search/__snapshots__/searchDefinitions.test.tsx.snap
+++ b/frontend/src/routes/Search/__snapshots__/searchDefinitions.test.tsx.snap
@@ -2419,7 +2419,7 @@ Array [
       }
       t={[Function]}
     />,
-    "header": "Console URL",
+    "header": "VM details",
   },
   Object {
     "cell": "in a month",
@@ -2562,7 +2562,7 @@ Array [
       }
       t={[Function]}
     />,
-    "header": "Console URL",
+    "header": "VM details",
   },
   Object {
     "cell": "in a month",

--- a/frontend/src/routes/Search/searchDefinitions.tsx
+++ b/frontend/src/routes/Search/searchDefinitions.tsx
@@ -372,7 +372,7 @@ export const getSearchDefinitions: (t: TFunction, isGlobalHub?: boolean) => Reso
         AddColumn('status', t('Status')),
         AddColumn('ready', t('Ready')),
         {
-          header: t('Console URL'),
+          header: t('VM details'),
           cell: (item: any) => {
             return <CreateExternalVMLink item={item} t={t} />
           },
@@ -390,7 +390,7 @@ export const getSearchDefinitions: (t: TFunction, isGlobalHub?: boolean) => Reso
         AddColumn('node', t('Node')),
         AddColumn('ipaddress', t('IP address')),
         {
-          header: t('Console URL'),
+          header: t('VM details'),
           cell: (item: any) => {
             return <CreateExternalVMLink item={item} t={t} />
           },


### PR DESCRIPTION
Change VM table "Console URL" column header to "VM details". This avoids confusion with the VM Console (terminal)