### PR TITLE
Fix ValidatingAdmisstionPolicyBinding filter in discovered policies

### DIFF
--- a/frontend/src/routes/Governance/discovered/ByCluster/common.tsx
+++ b/frontend/src/routes/Governance/discovered/ByCluster/common.tsx
@@ -108,7 +108,7 @@ export const byClusterCols = (
   subscriptions: Subscription[],
   channels: Channel[],
   policyKind: string,
-  diabledSeverityTooltip: boolean,
+  disabledSeverityTooltip: boolean,
   moreCols?: IAcmTableColumn<DiscoveredPolicyItem>[]
 ): IAcmTableColumn<DiscoveredPolicyItem>[] => [
   {
@@ -144,17 +144,17 @@ export const byClusterCols = (
     id: 'responseAction',
     exportContent: (item: DiscoveredPolicyItem) => item.responseAction,
   },
-  {
-    header: t('Severity'),
-    // TODO Add severity icon
-    cell: severityCell,
-    sort: 'severity',
-    id: 'severity',
-    ...(!diabledSeverityTooltip && { tooltip: t('discoveredPolicies.tooltip.severity') }),
-    exportContent: (item) => item.severity,
-  },
   ...(policyKind !== 'ValidatingAdmissionPolicyBinding'
     ? [
+        {
+          header: t('Severity'),
+          // TODO Add severity icon
+          cell: severityCell,
+          sort: 'severity',
+          id: 'severity',
+          ...(!disabledSeverityTooltip && { tooltip: t('discoveredPolicies.tooltip.severity') }),
+          exportContent: (item: DiscoveredPolicyItem) => item.severity,
+        },
         {
           header: t('Violations'),
           tooltip: t('discoveredPolicies.tooltip.clusterViolation'),
@@ -345,6 +345,7 @@ export function getResponseActionFilter(t: TFunction): ITableFilter<DiscoverdPol
       { label: 'enforce', value: 'enforce' },
       { label: 'inform', value: 'inform' },
       { label: 'warn', value: 'warn' },
+      { label: 'audit', value: 'audit' },
       { label: 'Kyverno Audit', value: 'Audit' },
       { label: 'Kyverno Enforce', value: 'Enforce' },
     ],

--- a/frontend/src/routes/Governance/discovered/DiscoveredPolicies.test.tsx
+++ b/frontend/src/routes/Governance/discovered/DiscoveredPolicies.test.tsx
@@ -418,6 +418,15 @@ describe('useFetchPolicies custom hook', () => {
     expect(container.querySelector('td[data-label="Severity"]')).toHaveTextContent('-')
     await waitForText('Source')
     await waitForText('Local')
+
+    // Validate filter
+    await waitForText('Filter')
+
+    screen.getByRole('button', { name: 'Options menu' }).click()
+    screen.getByRole('checkbox', { name: 'ValidatingAdmissionPolicyBinding 1' })
+    screen.getByRole('checkbox', {
+      name: 'audit 1',
+    })
   })
 
   test('Should render Kyverno Policy in multiple namespaces and ClusterPolicy', async () => {
@@ -574,7 +583,6 @@ describe('useFetchPolicies custom hook', () => {
     await waitForText('Filter')
 
     screen.getByRole('button', { name: 'Options menu' }).click()
-    screen.logTestingPlaygroundURL()
     screen.getByRole('checkbox', { name: 'Kyverno Policy 1' }).click()
     screen.getByRole('checkbox', { name: 'Kyverno ClusterPolicy 1' }).click()
   })

--- a/frontend/src/routes/Governance/discovered/DiscoveredPolicies.tsx
+++ b/frontend/src/routes/Governance/discovered/DiscoveredPolicies.tsx
@@ -177,6 +177,7 @@ export default function DiscoveredPolicies() {
           { label: 'ConfigurationPolicy', value: 'ConfigurationPolicy' },
           { label: 'Gatekeeper constraint', value: 'Gatekeeper' },
           { label: 'OperatorPolicy', value: 'OperatorPolicy' },
+          { label: 'ValidatingAdmissionPolicyBinding', value: 'ValidatingAdmissionPolicyBinding' },
           { label: 'Kyverno ClusterPolicy', value: 'ClusterPolicy' },
           { label: 'Kyverno Policy', value: 'Policy' },
         ],


### PR DESCRIPTION
- Fix typo in GRC common
- Delete dev log
- VAPB policy not available as filter in discovered policies table
- remove the severity column as well for vapb in ByClusterpag
- Fix that Response Action: Audit is not available as filter in discovered policies table
Ref: https://issues.redhat.com/browse/ACM-15839
Ref: https://issues.redhat.com/browse/ACM-15834
Signed-off-by: yiraeChristineKim <yikim@redhat.com>
