### PR TITLE
ACM-16020 Refactor multi-namespace self access checks [release-2.11]

### DIFF
--- a/frontend/src/components/LoadData.tsx
+++ b/frontend/src/components/LoadData.tsx
@@ -2,7 +2,7 @@
 import { Fragment, ReactNode, useContext, useEffect, useMemo, useState } from 'react'
 import { PluginDataContext } from '../lib/PluginDataContext'
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { SetterOrUpdater, useSetRecoilState } from 'recoil'
+import { SetterOrUpdater, useRecoilValue, useSetRecoilState } from 'recoil'
 import { tokenExpired } from '../logout'
 import {
   AgentClusterInstallApiVersion,
@@ -174,7 +174,6 @@ import {
   WatchEvent,
 } from '../atoms'
 import { useQuery } from '../lib/useQuery'
-import { useRecoilValue } from '../shared-recoil'
 
 export function LoadData(props: { children?: ReactNode }) {
   const { loaded, setLoaded } = useContext(PluginDataContext)

--- a/frontend/src/resources/self-subject-access-review.ts
+++ b/frontend/src/resources/self-subject-access-review.ts
@@ -61,23 +61,3 @@ export function createSubjectAccessReviews(resourceAttributes: Array<ResourceAtt
     abort: () => results.forEach((result) => result.abort()),
   }
 }
-
-export function createShortCircuitSubjectAccessReviews(resourceAttributes: Array<ResourceAttributes>) {
-  const results = resourceAttributes.map((resource) => createSubjectAccessReview(resource))
-  const abort = () => results.forEach((result) => result.abort())
-  return {
-    promise: Promise.any(
-      results.map((result) =>
-        result.promise.then((result) => {
-          if (result.status?.allowed) {
-            abort()
-            return true
-          } else {
-            throw new Error('access not allowed')
-          }
-        })
-      )
-    ),
-    abort,
-  }
-}

--- a/frontend/src/routes/Applications/AdvancedConfiguration.tsx
+++ b/frontend/src/routes/Applications/AdvancedConfiguration.tsx
@@ -47,7 +47,6 @@ export default function AdvancedConfiguration() {
   const {
     applicationsState,
     channelsState,
-    namespacesState,
     placementDecisionsState,
     placementsState,
     placementRulesState,
@@ -60,7 +59,6 @@ export default function AdvancedConfiguration() {
   const placements = useRecoilValue(placementsState)
   const placementDecisions = useRecoilValue(placementDecisionsState)
   const subscriptions = useRecoilValue(subscriptionsState)
-  const namespaces = useRecoilValue(namespacesState)
 
   const subscriptionsWithoutLocal = subscriptions.filter((subscription) => {
     return !_.endsWith(subscription.metadata.name, '-local')
@@ -732,9 +730,7 @@ export default function AdvancedConfiguration() {
         <StackItem>
           <ApplicationDeploymentHighlights />
         </StackItem>
-        <StackItem>
-          {<ToggleSelector modalProps={modalProps} table={table} keyFn={keyFn} t={t} namespaces={namespaces} />}
-        </StackItem>
+        <StackItem>{<ToggleSelector modalProps={modalProps} table={table} keyFn={keyFn} t={t} />}</StackItem>
       </Stack>
     </PageSection>
   )

--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -16,7 +16,7 @@ import {
 import { ExternalLinkAltIcon } from '@patternfly/react-icons'
 import { cellWidth } from '@patternfly/react-table'
 import { get } from 'lodash'
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useCallback, useContext, useMemo, useState } from 'react'
 import { TFunction } from 'react-i18next'
 import { useHistory } from 'react-router'
 import { Link } from 'react-router-dom'
@@ -25,7 +25,7 @@ import { Pages, usePageVisitMetricHandler } from '../../hooks/console-metrics'
 import { Trans, useTranslation } from '../../lib/acm-i18next'
 import { DOC_LINKS, ViewDocumentationLink } from '../../lib/doc-util'
 import { PluginContext } from '../../lib/PluginContext'
-import { checkPermission, rbacCreate, rbacDelete } from '../../lib/rbac-util'
+import { rbacCreate, rbacDelete, useIsAnyNamespaceAuthorized } from '../../lib/rbac-util'
 import { NavigationPath } from '../../NavigationPath'
 import {
   ApplicationApiVersion,
@@ -501,7 +501,6 @@ export default function ApplicationsOverview() {
     argoApplicationsState,
     channelsState,
     helmReleaseState,
-    namespacesState,
     placementRulesState,
     placementsState,
     placementDecisionsState,
@@ -516,7 +515,6 @@ export default function ApplicationsOverview() {
   const placementRules = useRecoilValue(placementRulesState)
   const placements = useRecoilValue(placementsState)
   const placementDecisions = useRecoilValue(placementDecisionsState)
-  const namespaces = useRecoilValue(namespacesState)
   const helmReleases = useRecoilValue(helmReleaseState)
   const { acmExtensions } = useContext(PluginContext)
 
@@ -872,9 +870,9 @@ export default function ApplicationsOverview() {
   )
 
   const history = useHistory()
-  const [canCreateApplication, setCanCreateApplication] = useState<boolean>(false)
-  const [canDeleteApplication, setCanDeleteApplication] = useState<boolean>(false)
-  const [canDeleteApplicationSet, setCanDeleteApplicationSet] = useState<boolean>(false)
+  const canCreateApplication = useIsAnyNamespaceAuthorized(rbacCreate(ApplicationDefinition))
+  const canDeleteApplication = useIsAnyNamespaceAuthorized(rbacDelete(ApplicationDefinition))
+  const canDeleteApplicationSet = useIsAnyNamespaceAuthorized(rbacDelete(ApplicationSetDefinition))
 
   const rowActionResolver = useCallback(
     (resource: IResource) => {
@@ -1082,16 +1080,6 @@ export default function ApplicationsOverview() {
       t,
     ]
   )
-
-  useEffect(() => {
-    checkPermission(rbacCreate(ApplicationDefinition), setCanCreateApplication, namespaces)
-  }, [namespaces])
-  useEffect(() => {
-    checkPermission(rbacDelete(ApplicationDefinition), setCanDeleteApplication, namespaces)
-  }, [namespaces])
-  useEffect(() => {
-    checkPermission(rbacDelete(ApplicationSetDefinition), setCanDeleteApplicationSet, namespaces)
-  }, [namespaces])
 
   const appCreationButton = useMemo(
     () => (

--- a/frontend/src/routes/Applications/components/ToggleSelector.tsx
+++ b/frontend/src/routes/Applications/components/ToggleSelector.tsx
@@ -6,11 +6,11 @@ import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core'
 import { TFunction } from 'react-i18next'
 import { Link, useHistory } from 'react-router-dom'
 import queryString from 'query-string'
-import { ApplicationDefinition, IResource, Namespace } from '../../../resources'
+import { ApplicationDefinition, IResource } from '../../../resources'
 import { DeleteResourceModal, IDeleteResourceModalProps } from './DeleteResourceModal'
 import { NavigationPath } from '../../../NavigationPath'
-import { Fragment, useEffect, useState } from 'react'
-import { checkPermission, rbacCreate } from '../../../lib/rbac-util'
+import { Fragment } from 'react'
+import { rbacCreate, useIsAnyNamespaceAuthorized } from '../../../lib/rbac-util'
 import { Trans } from '../../../lib/acm-i18next'
 import { DOC_LINKS, ViewDocumentationLink } from '../../../lib/doc-util'
 
@@ -19,7 +19,6 @@ export interface IToggleSelectorProps<T = any> {
   modalProps: IDeleteResourceModalProps | { open: false }
   table: any
   t: TFunction
-  namespaces: Namespace[]
 }
 
 export function ToggleSelector(props: IToggleSelectorProps) {
@@ -31,13 +30,9 @@ export function ToggleSelector(props: IToggleSelectorProps) {
     { id: 'placements', title: t('Placements'), emptyMessage: t("You don't have any placements") },
     { id: 'placementrules', title: t('Placement rules'), emptyMessage: t("You don't have any placement rules") },
   ] as const
-  const [canCreateApplication, setCanCreateApplication] = useState<boolean>(false)
+  const canCreateApplication = useIsAnyNamespaceAuthorized(rbacCreate(ApplicationDefinition))
   const selectedId = getSelectedId({ location, options, defaultOption, queryParam: 'resources' })
   const selectedResources = _.get(props.table, `${selectedId}`)
-
-  useEffect(() => {
-    checkPermission(rbacCreate(ApplicationDefinition), setCanCreateApplication, props.namespaces)
-  }, [props.namespaces])
 
   return (
     <AcmTablePaginationContextProvider localStorageKey="advanced-tables-pagination">

--- a/frontend/src/routes/Credentials/CredentialsPage.tsx
+++ b/frontend/src/routes/Credentials/CredentialsPage.tsx
@@ -14,14 +14,14 @@ import {
   ProviderLongTextMap,
 } from '../../ui-components'
 import moment from 'moment'
-import { Fragment, useEffect, useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { Link, useHistory } from 'react-router-dom'
 import { useRecoilValue, useSharedAtoms } from '../../shared-recoil'
 import { BulkActionModal, BulkActionModalProps } from '../../components/BulkActionModal'
 import { RbacDropdown } from '../../components/Rbac'
 import { Trans, useTranslation } from '../../lib/acm-i18next'
 import { DOC_LINKS, ViewDocumentationLink } from '../../lib/doc-util'
-import { checkPermission, rbacCreate, rbacDelete, rbacPatch } from '../../lib/rbac-util'
+import { rbacCreate, rbacDelete, rbacPatch, useIsAnyNamespaceAuthorized } from '../../lib/rbac-util'
 import { createBackCancelLocation, NavigationPath } from '../../NavigationPath'
 import {
   deleteResource,
@@ -81,13 +81,8 @@ export function CredentialsTable(props: {
   const [modalProps, setModalProps] = useState<BulkActionModalProps<Secret> | { open: false }>({
     open: false,
   })
-  const { namespacesState } = useSharedAtoms()
   const unauthorizedMessage = t('rbac.unauthorized')
-  const namespaces = useRecoilValue(namespacesState)
-  const [canAddCredential, setCanAddCredential] = useState<boolean>(false)
-  useEffect(() => {
-    checkPermission(rbacCreate(SecretDefinition), setCanAddCredential, namespaces)
-  }, [namespaces])
+  const canAddCredential = useIsAnyNamespaceAuthorized(rbacCreate(SecretDefinition))
 
   sessionStorage.removeItem('DiscoveryCredential')
 

--- a/frontend/src/routes/Governance/overview/Overview.tsx
+++ b/frontend/src/routes/Governance/overview/Overview.tsx
@@ -1,11 +1,11 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { Button, ButtonVariant, Card, CardBody, CardTitle, PageSection, Stack, Tooltip } from '@patternfly/react-core'
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
-import { Fragment, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { Fragment, useCallback, useContext, useMemo } from 'react'
 import { AcmMasonry } from '../../../components/AcmMasonry'
 import { Pages, usePageVisitMetricHandler } from '../../../hooks/console-metrics'
 import { useTranslation } from '../../../lib/acm-i18next'
-import { checkPermission, rbacCreate } from '../../../lib/rbac-util'
+import { rbacCreate, useIsAnyNamespaceAuthorized } from '../../../lib/rbac-util'
 import { ManagedCluster, Policy, PolicyDefinition } from '../../../resources'
 import { useRecoilValue, useSharedAtoms } from '../../../shared-recoil'
 import { AcmDrawerContext, compareStrings } from '../../../ui-components'
@@ -21,15 +21,11 @@ import { SecurityGroupPolicySummarySidebar } from './SecurityGroupPolicySummaryS
 
 export default function GovernanceOverview() {
   usePageVisitMetricHandler(Pages.governance)
-  const { usePolicies, namespacesState } = useSharedAtoms()
+  const { usePolicies } = useSharedAtoms()
   const policies = usePolicies()
-  const namespaces = useRecoilValue(namespacesState)
   const policyViolationSummary = usePolicyViolationSummary(policies)
-  const [canCreatePolicy, setCanCreatePolicy] = useState<boolean>(false)
+  const canCreatePolicy = useIsAnyNamespaceAuthorized(rbacCreate(PolicyDefinition))
   const { t } = useTranslation()
-  useEffect(() => {
-    checkPermission(rbacCreate(PolicyDefinition), setCanCreatePolicy, namespaces)
-  }, [namespaces])
 
   if (policies.length === 0) {
     return (

--- a/frontend/src/routes/Governance/policies/Policies.tsx
+++ b/frontend/src/routes/Governance/policies/Policies.tsx
@@ -42,7 +42,7 @@ import {
   resolveExternalStatus,
   resolveSource,
 } from '../common/util'
-import { checkPermission, rbacCreate, rbacUpdate, rbacPatch } from '../../../lib/rbac-util'
+import { rbacCreate, rbacUpdate, rbacPatch, useIsAnyNamespaceAuthorized } from '../../../lib/rbac-util'
 import { NavigationPath } from '../../../NavigationPath'
 import {
   patchResource,
@@ -125,17 +125,10 @@ export default function PoliciesPage() {
   )
   const policyClusterViolationsColumn = usePolicyViolationsColumn(policyClusterViolationSummaryMap)
   const [modal, setModal] = useState<ReactNode | undefined>()
-  const [canCreatePolicy, setCanCreatePolicy] = useState<boolean>(false)
-  const [canPatchPolicy, setCanPatchPolicy] = useState<boolean>(false)
-  const [canCreatePolicyAutomation, setCanCreatePolicyAutomation] = useState<boolean>(false)
-  const [canUpdatePolicyAutomation, setCanUpdatePolicyAutomation] = useState<boolean>(false)
-
-  useEffect(() => {
-    checkPermission(rbacCreate(PolicyDefinition), setCanCreatePolicy, namespaces)
-    checkPermission(rbacPatch(PolicyDefinition), setCanPatchPolicy, namespaces)
-    checkPermission(rbacCreate(PolicyAutomationDefinition), setCanCreatePolicyAutomation, namespaces)
-    checkPermission(rbacUpdate(PolicyAutomationDefinition), setCanUpdatePolicyAutomation, namespaces)
-  }, [namespaces])
+  const canCreatePolicy = useIsAnyNamespaceAuthorized(rbacCreate(PolicyDefinition))
+  const canPatchPolicy = useIsAnyNamespaceAuthorized(rbacPatch(PolicyDefinition))
+  const canCreatePolicyAutomation = useIsAnyNamespaceAuthorized(rbacCreate(PolicyAutomationDefinition))
+  const canUpdatePolicyAutomation = useIsAnyNamespaceAuthorized(rbacUpdate(PolicyAutomationDefinition))
 
   const policyColumns = useMemo<IAcmTableColumn<PolicyTableItem>[]>(
     () => [

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyDetailsResults.tsx
@@ -3,11 +3,11 @@ import { PageSection, Title, Tooltip } from '@patternfly/react-core'
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
 import { AcmEmptyState, AcmTable, AcmTablePaginationContextProvider, compareStrings } from '../../../../ui-components'
 import moment from 'moment'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { generatePath, Link } from 'react-router-dom'
 import { useTranslation } from '../../../../lib/acm-i18next'
-import { checkPermission, rbacCreate } from '../../../../lib/rbac-util'
+import { rbacCreate, useIsAnyNamespaceAuthorized } from '../../../../lib/rbac-util'
 import { transformBrowserUrlToFilterPresets } from '../../../../lib/urlQuery'
 import { NavigationPath, UNKNOWN_NAMESPACE } from '../../../../NavigationPath'
 import { getGroupFromApiVersion, Policy, PolicyDefinition, PolicyStatusDetails } from '../../../../resources'
@@ -32,14 +32,9 @@ export default function PolicyDetailsResults(props: { policy: Policy }) {
   const { t } = useTranslation()
   const filterPresets = transformBrowserUrlToFilterPresets(window.location.search)
   const { policy } = props
-  const { namespacesState, policiesState } = useSharedAtoms()
+  const { policiesState } = useSharedAtoms()
   const policies = useRecoilValue(policiesState)
-  const namespaces = useRecoilValue(namespacesState)
-  const [canCreatePolicy, setCanCreatePolicy] = useState<boolean>(false)
-
-  useEffect(() => {
-    checkPermission(rbacCreate(PolicyDefinition), setCanCreatePolicy, namespaces)
-  }, [namespaces])
+  const canCreatePolicy = useIsAnyNamespaceAuthorized(rbacCreate(PolicyDefinition))
 
   const policiesDeployedOnCluster: ResultsTableData[] = useMemo(() => {
     const policyName = policy.metadata.name ?? ''

--- a/frontend/src/routes/Governance/policy-sets/PolicySets.tsx
+++ b/frontend/src/routes/Governance/policy-sets/PolicySets.tsx
@@ -13,7 +13,7 @@ import { Link } from 'react-router-dom'
 import { AcmMasonry } from '../../../components/AcmMasonry'
 import { useTranslation } from '../../../lib/acm-i18next'
 import { usePaginationTitles } from '../../../lib/paginationStrings'
-import { checkPermission, rbacCreate, rbacDelete, rbacUpdate } from '../../../lib/rbac-util'
+import { rbacCreate, rbacDelete, rbacUpdate, useIsAnyNamespaceAuthorized } from '../../../lib/rbac-util'
 import { transformBrowserUrlToFilterPresets } from '../../../lib/urlQuery'
 import { NavigationPath } from '../../../NavigationPath'
 import { PolicySet, PolicySetDefinition } from '../../../resources/policy-set'
@@ -65,9 +65,8 @@ export default function PolicySetsPage() {
   const { t } = useTranslation()
   const presets = transformBrowserUrlToFilterPresets(window.location.search)
   const { presetNames, presetNs } = getPresetURIFilters(presets.initialSearch)
-  const { namespacesState, policySetsState } = useSharedAtoms()
+  const { policySetsState } = useSharedAtoms()
   const policySets = useRecoilValue(policySetsState)
-  const namespaces = useRecoilValue(namespacesState)
   const [searchFilter, setSearchFilter] = useState<Record<string, string[]>>({
     Name: presetNames,
     Namespace: presetNs,
@@ -77,17 +76,11 @@ export default function PolicySetsPage() {
   const [perPage, setPerPage] = useState<number>(10)
   const [filteredPolicySets, setFilteredPolicySets] = useState<PolicySet[]>(policySets)
   const [selectedCardID, setSelectedCardID] = useState<string>('')
-  const [canCreatePolicySet, setCanCreatePolicySet] = useState<boolean>(false)
-  const [canEditPolicySet, setCanEditPolicySet] = useState<boolean>(false)
-  const [canDeletePolicySet, setCanDeletePolicySet] = useState<boolean>(false)
+  const canCreatePolicySet = useIsAnyNamespaceAuthorized(rbacCreate(PolicySetDefinition))
+  const canEditPolicySet = useIsAnyNamespaceAuthorized(rbacUpdate(PolicySetDefinition))
+  const canDeletePolicySet = useIsAnyNamespaceAuthorized(rbacDelete(PolicySetDefinition))
 
   const translatedPaginationTitles = usePaginationTitles()
-
-  useEffect(() => {
-    checkPermission(rbacCreate(PolicySetDefinition), setCanCreatePolicySet, namespaces)
-    checkPermission(rbacUpdate(PolicySetDefinition), setCanEditPolicySet, namespaces)
-    checkPermission(rbacDelete(PolicySetDefinition), setCanDeletePolicySet, namespaces)
-  }, [namespaces])
 
   const updatePerPage = useCallback(
     (newPerPage: number) => {

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomations.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomations.tsx
@@ -14,13 +14,13 @@ import {
 } from '../../../ui-components'
 import { Fragment, useContext, useEffect, useState } from 'react'
 import { Link, useHistory } from 'react-router-dom'
-import { useRecoilValue, useSharedAtoms, useSharedSelectors } from '../../../shared-recoil'
+import { useRecoilValue, useSharedSelectors } from '../../../shared-recoil'
 import { BulkActionModal, BulkActionModalProps } from '../../../components/BulkActionModal'
 import { DropdownActionModal, IDropdownActionModalProps } from '../../../components/DropdownActionModal'
 import { RbacDropdown } from '../../../components/Rbac'
 import { Trans, useTranslation } from '../../../lib/acm-i18next'
 import { DOC_LINKS, ViewDocumentationLink } from '../../../lib/doc-util'
-import { checkPermission, rbacCreate, rbacDelete, rbacPatch } from '../../../lib/rbac-util'
+import { rbacCreate, rbacDelete, rbacPatch, useIsAnyNamespaceAuthorized } from '../../../lib/rbac-util'
 import { createBackCancelLocation, NavigationPath } from '../../../NavigationPath'
 import {
   ClusterCurator,
@@ -68,12 +68,7 @@ function AnsibleJobTemplateTable() {
   })
   const { t } = useTranslation()
   const unauthorizedMessage = t('rbac.unauthorized')
-  const { namespacesState } = useSharedAtoms()
-  const namespaces = useRecoilValue(namespacesState)
-  const [canCreateAutomationTemplate, setCanCreateAutomationTemplate] = useState<boolean>(false)
-  useEffect(() => {
-    checkPermission(rbacCreate(ClusterCuratorDefinition), setCanCreateAutomationTemplate, namespaces)
-  }, [namespaces])
+  const canCreateAutomationTemplate = useIsAnyNamespaceAuthorized(rbacCreate(ClusterCuratorDefinition))
   const history = useHistory()
 
   // Set table

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { ReactNode, useCallback, useContext, useMemo, useState } from 'react'
 import {
   ButtonVariant,
   ExpandableSectionToggle,
@@ -22,8 +22,7 @@ import { AcmButton } from '../../../../../ui-components'
 import { AddNodePoolModal } from './AddNodePoolModal'
 import { ClusterContext } from '../ClusterDetails/ClusterDetails'
 import { HypershiftCloudPlatformType } from '../../../../../resources/utils/constants'
-import { checkPermission, rbacCreate } from '../../../../../lib/rbac-util'
-import { useRecoilValue, useSharedAtoms } from '../../../../../shared-recoil'
+import { rbacCreate, useIsAnyNamespaceAuthorized } from '../../../../../lib/rbac-util'
 import { onToggle } from '../utils/utils'
 
 export type NodePoolStatus = {
@@ -88,14 +87,8 @@ const NodePoolsProgress = ({ nodePools, ...rest }: NodePoolsProgressProps) => {
     () => toggleOpenAddNodepoolModal(!openAddNodepoolModal),
     [openAddNodepoolModal]
   )
-  const [canCreateNodepool, setCanCreateNodepool] = useState<boolean>(false)
-  const { namespacesState } = useSharedAtoms()
-  const namespaces = useRecoilValue(namespacesState)
+  const canCreateNodepool = useIsAnyNamespaceAuthorized(rbacCreate(NodePoolDefinition))
   const nodepoolList = nodePools.map((nodePool) => nodePool.metadata?.name) as string[]
-
-  useEffect(() => {
-    checkPermission(rbacCreate(NodePoolDefinition), setCanCreateNodepool, namespaces)
-  }, [namespaces])
 
   const addNodePoolStatusMessage = useMemo(() => {
     if (hostedCluster?.spec?.platform?.type !== HypershiftCloudPlatformType.AWS) {


### PR DESCRIPTION
Previously, when a user could see a large number of namespaces, UI buttons could sometimes flap between enabled and disabled. This was because a failed network connection counted as no access. This PR makes a few improvements:

- Self access checks across multiple namespaces are batched to avoid overwhelming the browser
- Once a button becomes enabled, it will not become disabled until we confirm that there is no access in any namespace
- Logic is centralized in a reusable hook to reduce code duplication for each button that uses this RBAC check

[ACM-16020](https://issues.redhat.com/browse/ACM-16020)