### PR TITLE
Use OpenShift console timestamp component

### DIFF
--- a/frontend/src/components/ACMNotReadyWarning.test.tsx
+++ b/frontend/src/components/ACMNotReadyWarning.test.tsx
@@ -7,8 +7,7 @@ import { clickByRole, waitForText } from '../lib/test-util'
 import { SubscriptionOperator, SubscriptionOperatorApiVersion, SubscriptionOperatorKind } from '../resources'
 import { nockIgnoreOperatorCheck } from '../lib/nock-util'
 import { ACMNotReadyWarning } from './ACMNotReadyWarning'
-import { PluginDataContext } from '../lib/PluginDataContext'
-import { PluginContext } from '../lib/PluginContext'
+import { defaultPlugin, PluginContext } from '../lib/PluginContext'
 
 const acm_unhealthy: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
@@ -88,17 +87,8 @@ describe('ACMNotReadyWarning', () => {
     render(
       <PluginContext.Provider
         value={{
+          ...defaultPlugin,
           isACMAvailable: false,
-          isOverviewAvailable: true,
-          isSubmarinerAvailable: true,
-          isApplicationsAvailable: true,
-          isGovernanceAvailable: true,
-          isSearchAvailable: true,
-          dataContext: PluginDataContext,
-          acmExtensions: {},
-          ocpApi: {
-            useK8sWatchResource: () => [[] as any, true, undefined],
-          },
         }}
       >
         <WrappedACMNotReadyWarning acmOperators={[acm]} />
@@ -125,17 +115,8 @@ describe('ACMNotReadyWarning', () => {
     render(
       <PluginContext.Provider
         value={{
+          ...defaultPlugin,
           isACMAvailable: false,
-          isOverviewAvailable: true,
-          isSubmarinerAvailable: true,
-          isApplicationsAvailable: true,
-          isGovernanceAvailable: true,
-          isSearchAvailable: true,
-          dataContext: PluginDataContext,
-          acmExtensions: {},
-          ocpApi: {
-            useK8sWatchResource: () => [[] as any, true, undefined],
-          },
         }}
       >
         <WrappedACMNotReadyWarning acmOperators={[acm]} />

--- a/frontend/src/components/PluginContextProvider.tsx
+++ b/frontend/src/components/PluginContextProvider.tsx
@@ -1,7 +1,12 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { isHrefNavItem, useResolvedExtensions, UseK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk'
+import {
+  isHrefNavItem,
+  Timestamp,
+  useK8sWatchResource,
+  useResolvedExtensions,
+} from '@openshift-console/dynamic-plugin-sdk'
 import { AcmTablePaginationContextProvider, AcmToastGroup, AcmToastProvider } from '../ui-components'
-import { ReactNode, useMemo, useEffect, useState } from 'react'
+import { ReactNode, useMemo } from 'react'
 import { PluginContext } from '../lib/PluginContext'
 import { useAcmExtension } from '../plugin-extensions/handler'
 import { LoadingPage } from './LoadingPage'
@@ -15,9 +20,6 @@ const isPluginDataContext = (e: Extension): e is SharedContext<PluginData> =>
   isSharedContext(e) && e.properties.id === 'mce-data-context'
 
 export function PluginContextProvider(props: { children?: ReactNode }) {
-  const [ocpApi, setOcpApi] = useState<{ useK8sWatchResource: UseK8sWatchResource }>({
-    useK8sWatchResource: () => [[] as any, false, undefined],
-  })
   const [hrefs] = useResolvedExtensions(isHrefNavItem)
 
   const [pluginDataContexts, extensionsReady] = useResolvedExtensions(isPluginDataContext)
@@ -38,20 +40,6 @@ export function PluginContextProvider(props: { children?: ReactNode }) {
   const isACMAvailable = isOverviewAvailable
   const isSubmarinerAvailable = isOverviewAvailable
 
-  useEffect(() => {
-    const loadOCPAPI = async () => {
-      try {
-        const api = await import('@openshift-console/dynamic-plugin-sdk')
-        setOcpApi({
-          useK8sWatchResource: api.useK8sWatchResource,
-        })
-      } catch (err) {
-        console.error('Failed to load OCP API', err)
-      }
-    }
-    loadOCPAPI()
-  }, [])
-
   // ACM Custom extensions
   const acmExtensions = useAcmExtension()
 
@@ -66,7 +54,7 @@ export function PluginContextProvider(props: { children?: ReactNode }) {
         isSubmarinerAvailable,
         dataContext: pluginDataContext.properties.context,
         acmExtensions,
-        ocpApi,
+        ocpApi: { Timestamp, useK8sWatchResource },
       }}
     >
       <AcmFeedbackModal />

--- a/frontend/src/lib/AcmTimestamp.test.tsx
+++ b/frontend/src/lib/AcmTimestamp.test.tsx
@@ -1,0 +1,123 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import AcmTimestamp from './AcmTimestamp'
+import { PluginContext } from './PluginContext'
+import { UseK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk'
+import { PluginDataContext } from './PluginDataContext'
+
+interface TimestampProps {
+  timestamp: string | number | Date
+  simple?: boolean
+  omitSuffix?: boolean
+  className?: string
+}
+
+const MockTimestamp: React.FC<TimestampProps> = ({ timestamp, simple, omitSuffix, className }) => (
+  <div className={className}>
+    {String(timestamp)} {simple && 'simple'} {omitSuffix && 'omitSuffix'}
+  </div>
+)
+
+const mockUseK8sWatchResource: UseK8sWatchResource = jest.fn()
+
+const mockPluginContextValue = {
+  ocpApi: {
+    Timestamp: MockTimestamp,
+    useK8sWatchResource: mockUseK8sWatchResource,
+  },
+  isACMAvailable: true,
+  isOverviewAvailable: true,
+  isSubmarinerAvailable: true,
+  isApplicationsAvailable: true,
+  isGovernanceAvailable: true,
+  isSearchAvailable: true,
+  dataContext: PluginDataContext,
+  acmExtensions: {},
+}
+
+describe('AcmTimestamp', () => {
+  const timestamp = 'Jan 3, 2025, 6:53 PM'
+
+  test('renders the component with the Timestamp from PluginContext', () => {
+    render(
+      <PluginContext.Provider value={mockPluginContextValue}>
+        <AcmTimestamp timestamp={timestamp} />
+      </PluginContext.Provider>
+    )
+    expect(screen.getByText(timestamp)).toBeInTheDocument()
+  })
+
+  test('renders the component with simple prop', () => {
+    render(
+      <PluginContext.Provider value={mockPluginContextValue}>
+        <AcmTimestamp timestamp={timestamp} simple />
+      </PluginContext.Provider>
+    )
+    expect(screen.getByText(`${timestamp} simple`)).toBeInTheDocument()
+  })
+
+  test('renders the component with omitSuffix prop', () => {
+    render(
+      <PluginContext.Provider value={mockPluginContextValue}>
+        <AcmTimestamp timestamp={timestamp} omitSuffix />
+      </PluginContext.Provider>
+    )
+    expect(screen.getByText(`${timestamp} omitSuffix`)).toBeInTheDocument()
+  })
+
+  test('renders the component with className prop', () => {
+    const className = 'test-class'
+    render(
+      <PluginContext.Provider value={mockPluginContextValue}>
+        <AcmTimestamp timestamp={timestamp} className={className} />
+      </PluginContext.Provider>
+    )
+    expect(screen.getByText(timestamp)).toHaveClass(className)
+  })
+
+  test('renders the component with showIcon prop', () => {
+    render(
+      <PluginContext.Provider value={mockPluginContextValue}>
+        <AcmTimestamp timestamp={timestamp} showIcon />
+      </PluginContext.Provider>
+    )
+    expect(screen.getByText(timestamp)).toBeInTheDocument()
+  })
+
+  test('renders the SimpleTimestamp component when Timestamp is not available in PluginContext', () => {
+    const mockContextWithoutTimestamp = {
+      ...mockPluginContextValue,
+      ocpApi: {
+        ...mockPluginContextValue.ocpApi,
+        Timestamp: undefined,
+      },
+    }
+
+    render(
+      <PluginContext.Provider value={mockContextWithoutTimestamp}>
+        <AcmTimestamp timestamp={timestamp} />
+      </PluginContext.Provider>
+    )
+    expect(screen.getByText(timestamp)).toBeInTheDocument()
+  })
+
+  test('renders the SimpleTimestamp component with an invalid timestamp', () => {
+    const invalidTimestamp = ''
+    const mockContextWithoutTimestamp = {
+      ...mockPluginContextValue,
+      ocpApi: {
+        ...mockPluginContextValue.ocpApi,
+        Timestamp: undefined,
+      },
+    }
+
+    render(
+      <PluginContext.Provider value={mockContextWithoutTimestamp}>
+        <AcmTimestamp timestamp={invalidTimestamp} />
+      </PluginContext.Provider>
+    )
+    expect(screen.getByText('Invalid Date')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/lib/AcmTimestamp.tsx
+++ b/frontend/src/lib/AcmTimestamp.tsx
@@ -1,0 +1,44 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { css } from '@emotion/css'
+import { SimpleTimestamp } from './SimpleTimestamp'
+import { PluginContext } from './PluginContext'
+import { useContext } from 'react'
+import { TimestampProps } from '@openshift-console/dynamic-plugin-sdk'
+
+type AcmTimestampProps = TimestampProps & {
+  showIcon?: boolean
+}
+
+const AcmTimestamp: React.FC<AcmTimestampProps> = ({
+  timestamp,
+  simple,
+  omitSuffix,
+  className = '',
+  showIcon = false,
+}) => {
+  const {
+    ocpApi: { Timestamp },
+  } = useContext(PluginContext)
+
+  return Timestamp ? (
+    <Timestamp
+      timestamp={timestamp}
+      simple={simple}
+      omitSuffix={omitSuffix}
+      className={`${className}${
+        !showIcon
+          ? ` ${css({
+              '.co-icon-and-text__icon': {
+                display: 'none',
+              },
+            })}`
+          : ''
+      }`}
+    />
+  ) : (
+    <SimpleTimestamp timestamp={timestamp} />
+  )
+}
+
+export default AcmTimestamp

--- a/frontend/src/lib/PluginContext.tsx
+++ b/frontend/src/lib/PluginContext.tsx
@@ -1,22 +1,25 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { Context, createContext } from 'react'
+import { Context, createContext, FC } from 'react'
 import { AcmExtension } from '../plugin-extensions/types'
 import { PluginData, PluginDataContext } from './PluginDataContext'
-import { UseK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types'
+import { TimestampProps, UseK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types'
 
-export const PluginContext = createContext<{
-  isACMAvailable?: boolean
-  isOverviewAvailable?: boolean
-  isSubmarinerAvailable?: boolean
-  isApplicationsAvailable?: boolean
-  isGovernanceAvailable?: boolean
-  isSearchAvailable?: boolean
+export type Plugin = {
+  isACMAvailable: boolean
+  isOverviewAvailable: boolean
+  isSubmarinerAvailable: boolean
+  isApplicationsAvailable: boolean
+  isGovernanceAvailable: boolean
+  isSearchAvailable: boolean
   dataContext: Context<PluginData>
-  acmExtensions?: AcmExtension
+  acmExtensions: AcmExtension
   ocpApi: {
+    Timestamp?: FC<TimestampProps>
     useK8sWatchResource: UseK8sWatchResource
   }
-}>({
+}
+
+export const defaultPlugin: Plugin = {
   isACMAvailable: true,
   isOverviewAvailable: true,
   isSubmarinerAvailable: true,
@@ -28,4 +31,6 @@ export const PluginContext = createContext<{
   ocpApi: {
     useK8sWatchResource: () => [[] as any, true, undefined],
   },
-})
+}
+
+export const PluginContext = createContext<Plugin>(defaultPlugin)

--- a/frontend/src/lib/SimpleTimestamp.test.tsx
+++ b/frontend/src/lib/SimpleTimestamp.test.tsx
@@ -4,7 +4,7 @@ import '@testing-library/jest-dom/extend-expect'
 import SimpleTimestamp from './SimpleTimestamp'
 
 describe('SimpleTimestamp', () => {
-  const timestamp = '2025-01-03T18:53:59Z'
+  const timestamp = '2025-01-03T18:53:59.000Z'
 
   test('renders the component with a valid timestamp', () => {
     render(<SimpleTimestamp timestamp={timestamp} />)

--- a/frontend/src/lib/SimpleTimestamp.test.tsx
+++ b/frontend/src/lib/SimpleTimestamp.test.tsx
@@ -1,0 +1,31 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import SimpleTimestamp from './SimpleTimestamp'
+
+describe('SimpleTimestamp', () => {
+  const timestamp = '2025-01-03T18:53:59Z'
+
+  test('renders the component with a valid timestamp', () => {
+    render(<SimpleTimestamp timestamp={timestamp} />)
+    expect(screen.getByText('Jan 3, 2025, 1:53 PM')).toBeInTheDocument()
+  })
+
+  test('renders the component with an invalid timestamp', () => {
+    const invalidTimestamp = ''
+    render(<SimpleTimestamp timestamp={invalidTimestamp} />)
+    expect(screen.getByText('Invalid Date')).toBeInTheDocument()
+  })
+
+  test('renders the component with a numeric timestamp', () => {
+    const numericTimestamp = new Date(timestamp).getTime() // Equivalent to '2025-01-03T18:53:59Z'
+    render(<SimpleTimestamp timestamp={numericTimestamp} />)
+    expect(screen.getByText('Jan 3, 2025, 1:53 PM')).toBeInTheDocument()
+  })
+
+  test('renders the component with a Date object timestamp', () => {
+    const dateObjectTimestamp = new Date(timestamp)
+    render(<SimpleTimestamp timestamp={dateObjectTimestamp} />)
+    expect(screen.getByText('Jan 3, 2025, 1:53 PM')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/lib/SimpleTimestamp.tsx
+++ b/frontend/src/lib/SimpleTimestamp.tsx
@@ -9,15 +9,19 @@ interface SimpleTimestampProps {
 export const SimpleTimestamp: React.FC<SimpleTimestampProps> = ({ timestamp }) => {
   const date = new Date(timestamp)
 
-  let formattedDate = date.toLocaleString('en-US', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-  })
+  if (isNaN(date.getTime())) {
+    return <>Invalid Date</>
+  }
 
-  formattedDate = formattedDate.replace(' am', ' AM').replace(' pm', ' PM')
+  const day = date.getDate()
+  const month = date.toLocaleString('en-US', { month: 'short' })
+  const year = date.getFullYear()
+  const hour = date.getHours() % 12 || 12
+  const minute = date.getMinutes().toString().padStart(2, '0')
+  const ampm = date.getHours() >= 12 ? 'PM' : 'AM'
+
+  const formattedDate = `${month} ${day}, ${year}, ${hour}:${minute} ${ampm}`
+
   return <>{formattedDate}</>
 }
 

--- a/frontend/src/lib/SimpleTimestamp.tsx
+++ b/frontend/src/lib/SimpleTimestamp.tsx
@@ -1,0 +1,24 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import React from 'react'
+
+interface SimpleTimestampProps {
+  timestamp: string | number | Date
+}
+
+export const SimpleTimestamp: React.FC<SimpleTimestampProps> = ({ timestamp }) => {
+  const date = new Date(timestamp)
+
+  let formattedDate = date.toLocaleString('en-US', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+
+  formattedDate = formattedDate.replace(' am', ' AM').replace(' pm', ' PM')
+  return <>{formattedDate}</>
+}
+
+export default SimpleTimestamp

--- a/frontend/src/lib/test-util.ts
+++ b/frontend/src/lib/test-util.ts
@@ -3,7 +3,6 @@
 import { act, ByRoleMatcher, ByRoleOptions, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { Scope } from 'nock/types'
-import { UseK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk'
 
 export const waitTimeout = 5 * 1000
 
@@ -375,11 +374,6 @@ export function isCardEnabled(card: HTMLElement) {
   return card.style.cursor === 'pointer'
 }
 
-export const ocpApi: {
-  useK8sWatchResource: UseK8sWatchResource
-} = {
-  useK8sWatchResource: () => [[] as any, true, undefined],
-}
 export const getCSVExportSpies = () => {
   const blobConstructorSpy = jest.fn()
   jest.spyOn(global, 'Blob').mockImplementationOnce(blobConstructorSpy)

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationDetails.test.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationDetails.test.tsx
@@ -18,9 +18,8 @@ import {
   subscriptionsState,
 } from '../../../atoms'
 import { nockIgnoreApiPaths, nockIgnoreRBAC, nockSearch } from '../../../lib/nock-util'
-import { PluginContext } from '../../../lib/PluginContext'
-import { PluginDataContext } from '../../../lib/PluginDataContext'
-import { ocpApi, waitForText } from '../../../lib/test-util'
+import { defaultPlugin, PluginContext } from '../../../lib/PluginContext'
+import { waitForText } from '../../../lib/test-util'
 import { ApplicationActionProps } from '../../../plugin-extensions/properties'
 import { AcmExtension } from '../../../plugin-extensions/types'
 import { GetMessagesDocument, SearchSchemaDocument } from '../../Search/search-sdk/search-sdk'
@@ -372,9 +371,8 @@ describe('Applications Page', () => {
           <MockedProvider mocks={mocks}>
             <PluginContext.Provider
               value={{
+                ...defaultPlugin,
                 acmExtensions: acmExtension,
-                dataContext: PluginDataContext,
-                ocpApi,
               }}
             >
               <ApplicationDetailsPage />

--- a/frontend/src/routes/Applications/Overview.test.tsx
+++ b/frontend/src/routes/Applications/Overview.test.tsx
@@ -12,9 +12,8 @@ import {
   nockSearch,
   nockAggegateRequest,
 } from '../../lib/nock-util'
-import { PluginContext } from '../../lib/PluginContext'
-import { PluginDataContext } from '../../lib/PluginDataContext'
-import { ocpApi, waitForText } from '../../lib/test-util'
+import { defaultPlugin, PluginContext } from '../../lib/PluginContext'
+import { waitForText } from '../../lib/test-util'
 import {
   ApplicationKind,
   ApplicationSetKind,
@@ -116,9 +115,8 @@ describe('Applications Page', () => {
         <MemoryRouter>
           <PluginContext.Provider
             value={{
+              ...defaultPlugin,
               acmExtensions: acmExtension,
-              dataContext: PluginDataContext,
-              ocpApi,
             }}
           >
             <Routes>

--- a/frontend/src/routes/Home/Overview/Overview.test.tsx
+++ b/frontend/src/routes/Home/Overview/Overview.test.tsx
@@ -5,8 +5,7 @@ import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom-v5-compat'
 import { RecoilRoot } from 'recoil'
 import { nockGet, nockIgnoreApiPaths } from '../../../lib/nock-util'
-import { PluginContext } from '../../../lib/PluginContext'
-import { PluginDataContext } from '../../../lib/PluginDataContext'
+import { defaultPlugin, PluginContext } from '../../../lib/PluginContext'
 import { clickByText, waitForNocks, waitForText } from '../../../lib/test-util'
 import Overview from './Overview'
 import { getAddonRequest, getAddonResponse } from './Overview.sharedmocks'
@@ -29,13 +28,8 @@ it('should render overview page with extension', async () => {
           <MockedProvider mocks={[]}>
             <PluginContext.Provider
               value={{
+                ...defaultPlugin,
                 isACMAvailable: false,
-                isOverviewAvailable: true,
-                isSubmarinerAvailable: true,
-                isApplicationsAvailable: true,
-                isGovernanceAvailable: true,
-                isSearchAvailable: true,
-                dataContext: PluginDataContext,
                 acmExtensions: {
                   overviewTab: [
                     {
@@ -49,9 +43,6 @@ it('should render overview page with extension', async () => {
                       },
                     },
                   ],
-                },
-                ocpApi: {
-                  useK8sWatchResource: () => [[] as any, true, undefined],
                 },
               }}
             >
@@ -81,13 +72,8 @@ it('should render overview page layout when extension tab crashes', async () => 
           <MockedProvider mocks={[]}>
             <PluginContext.Provider
               value={{
+                ...defaultPlugin,
                 isACMAvailable: false,
-                isOverviewAvailable: true,
-                isSubmarinerAvailable: true,
-                isApplicationsAvailable: true,
-                isGovernanceAvailable: true,
-                isSearchAvailable: true,
-                dataContext: PluginDataContext,
                 acmExtensions: {
                   overviewTab: [
                     {
@@ -103,9 +89,6 @@ it('should render overview page layout when extension tab crashes', async () => 
                       },
                     },
                   ],
-                },
-                ocpApi: {
-                  useK8sWatchResource: () => [[] as any, true, undefined],
                 },
               }}
             >

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.test.tsx
@@ -25,8 +25,7 @@ import {
   nockNamespacedList,
   nockPatch,
 } from '../../../../../lib/nock-util'
-import { PluginContext } from '../../../../../lib/PluginContext'
-import { PluginDataContext } from '../../../../../lib/PluginDataContext'
+import { defaultPlugin, PluginContext } from '../../../../../lib/PluginContext'
 import { mockGlobalManagedClusterSet, mockManagedClusterSet } from '../../../../../lib/test-metadata'
 import {
   clearByTestId,
@@ -39,7 +38,6 @@ import {
   waitForNotText,
   waitForTestId,
   waitForText,
-  ocpApi,
 } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
 import {
@@ -2084,7 +2082,7 @@ describe('ClusterSetDetails page without Submariner', () => {
     nockIgnoreRBAC()
     nockIgnoreApiPaths()
     render(
-      <PluginContext.Provider value={{ isSubmarinerAvailable: false, dataContext: PluginDataContext, ocpApi }}>
+      <PluginContext.Provider value={{ ...defaultPlugin, isSubmarinerAvailable: false }}>
         <Component />
       </PluginContext.Provider>
     )
@@ -2108,7 +2106,7 @@ describe('ClusterSetDetails page global clusterset', () => {
     nockIgnoreRBAC()
     nockIgnoreApiPaths()
     render(
-      <PluginContext.Provider value={{ isSubmarinerAvailable: false, dataContext: PluginDataContext, ocpApi }}>
+      <PluginContext.Provider value={{ ...defaultPlugin, isSubmarinerAvailable: false }}>
         <Component isGlobal />
       </PluginContext.Provider>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSets.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSets.test.tsx
@@ -12,7 +12,7 @@ import {
   managedClustersState,
 } from '../../../../atoms'
 import { nockCreate, nockDelete, nockIgnoreApiPaths, nockIgnoreRBAC } from '../../../../lib/nock-util'
-import { PluginContext } from '../../../../lib/PluginContext'
+import { defaultPlugin, PluginContext } from '../../../../lib/PluginContext'
 import { mockManagedClusterSet, mockGlobalClusterSet } from '../../../../lib/test-metadata'
 import {
   clickBulkAction,
@@ -23,7 +23,6 @@ import {
   waitForText,
   waitForNotText,
   typeByTestId,
-  ocpApi,
   clickByLabel,
 } from '../../../../lib/test-util'
 import {
@@ -31,7 +30,6 @@ import {
   mockManagedClusterInfos,
   mockManagedClusters,
 } from '../ManagedClusters/ManagedClusters.sharedmocks'
-import { PluginDataContext } from '../../../../lib/PluginDataContext'
 import { NavigationPath } from '../../../../NavigationPath'
 import Clusters from '../Clusters'
 
@@ -95,7 +93,7 @@ describe('ClusterSets page without Submariner', () => {
     nockIgnoreRBAC()
     nockIgnoreApiPaths()
     render(
-      <PluginContext.Provider value={{ isSubmarinerAvailable: false, dataContext: PluginDataContext, ocpApi }}>
+      <PluginContext.Provider value={{ ...defaultPlugin, isSubmarinerAvailable: false }}>
         <Component />
       </PluginContext.Provider>
     )
@@ -111,7 +109,7 @@ describe('ClusterSets page with csv export', () => {
     nockIgnoreRBAC()
     nockIgnoreApiPaths()
     render(
-      <PluginContext.Provider value={{ isSubmarinerAvailable: false, dataContext: PluginDataContext, ocpApi }}>
+      <PluginContext.Provider value={{ ...defaultPlugin, isSubmarinerAvailable: false }}>
         <Component />
       </PluginContext.Provider>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
@@ -22,14 +22,12 @@ import {
   nockIgnoreRBAC,
   nockList,
 } from '../../../../../lib/nock-util'
-import { PluginContext } from '../../../../../lib/PluginContext'
-import { PluginDataContext } from '../../../../../lib/PluginDataContext'
+import { defaultPlugin, PluginContext } from '../../../../../lib/PluginContext'
 import {
   clickByPlaceholderText,
   clickByRole,
   clickByTestId,
   clickByText,
-  ocpApi,
   pasteByTestId,
   typeByPlaceholderText,
   typeByTestId,
@@ -1052,7 +1050,7 @@ describe('CreateCluster AWS', () => {
 
     // create the form
     const { container } = render(
-      <PluginContext.Provider value={{ isACMAvailable: false, dataContext: PluginDataContext, ocpApi }}>
+      <PluginContext.Provider value={{ ...defaultPlugin, isACMAvailable: false }}>
         <Component />
       </PluginContext.Provider>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -71,14 +71,12 @@ import {
   waitForNocks,
   waitForNotText,
   waitForText,
-  ocpApi,
 } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
 import DiscoveredClustersPage from '../../DiscoveredClusters/DiscoveredClusters'
 import ImportClusterPage from './ImportCluster'
-import { PluginContext } from '../../../../../lib/PluginContext'
+import { defaultPlugin, PluginContext } from '../../../../../lib/PluginContext'
 import { AcmToastGroup, AcmToastProvider } from '../../../../../ui-components'
-import { PluginDataContext } from '../../../../../lib/PluginDataContext'
 import { PropsWithChildren, useEffect } from 'react'
 
 const mockProject: ProjectRequest = {
@@ -798,7 +796,7 @@ describe('ImportCluster', () => {
     const importSecretNock = nockGet(mockSecretResponse)
 
     render(
-      <PluginContext.Provider value={{ isACMAvailable: false, dataContext: PluginDataContext, ocpApi }}>
+      <PluginContext.Provider value={{ ...defaultPlugin, isACMAvailable: false }}>
         <Component />
       </PluginContext.Provider>
     )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -86,7 +86,6 @@ import keyBy from 'lodash/keyBy'
 import { HighlightSearchText } from '../../../../components/HighlightSearchText'
 import { SearchOperator } from '../../../../ui-components/AcmSearchInput'
 import { handleStandardComparison, handleSemverOperatorComparison } from '../../../../lib/search-utils'
-import AcmTimestamp from '../../../../lib/AcmTimestamp'
 
 const onToggle = (acmCardID: string, setOpen: (open: boolean) => void) => {
   setOpen(false)
@@ -996,7 +995,7 @@ export function useClusterCreatedDateColumn(): IAcmTableColumn<Cluster> {
     search: 'creationDate',
     cellTransforms: [nowrap],
     cell: (cluster) => {
-      return <AcmTimestamp timestamp={cluster.creationTimestamp ?? ''} />
+      return getCreationTimestampString(cluster)
     },
     exportContent: (cluster) => {
       return getCreationTimestampString(cluster)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -86,6 +86,7 @@ import keyBy from 'lodash/keyBy'
 import { HighlightSearchText } from '../../../../components/HighlightSearchText'
 import { SearchOperator } from '../../../../ui-components/AcmSearchInput'
 import { handleStandardComparison, handleSemverOperatorComparison } from '../../../../lib/search-utils'
+import AcmTimestamp from '../../../../lib/AcmTimestamp'
 
 const onToggle = (acmCardID: string, setOpen: (open: boolean) => void) => {
   setOpen(false)
@@ -995,7 +996,7 @@ export function useClusterCreatedDateColumn(): IAcmTableColumn<Cluster> {
     search: 'creationDate',
     cellTransforms: [nowrap],
     cell: (cluster) => {
-      return getCreationTimestampString(cluster)
+      return <AcmTimestamp timestamp={cluster.creationTimestamp ?? ''} />
     },
     exportContent: (cluster) => {
       return getCreationTimestampString(cluster)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusSummaryCount.test.tsx
@@ -5,9 +5,8 @@ import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom-v5-compat'
 import { RecoilRoot } from 'recoil'
 import { policiesState, policyreportState } from '../../../../../atoms'
 import { nockAggegateRequest, nockSearch } from '../../../../../lib/nock-util'
-import { PluginContext } from '../../../../../lib/PluginContext'
-import { PluginDataContext } from '../../../../../lib/PluginDataContext'
-import { clickByText, waitForNotText, waitForText, ocpApi } from '../../../../../lib/test-util'
+import { defaultPlugin, PluginContext } from '../../../../../lib/PluginContext'
+import { clickByText, waitForNotText, waitForText } from '../../../../../lib/test-util'
 import { Policy, PolicyReport } from '../../../../../resources'
 import { Cluster, ClusterStatus } from '../../../../../resources/utils'
 import {
@@ -330,7 +329,7 @@ describe('StatusSummaryCount', () => {
   test('renders without applications and governance', async () => {
     render(
       <PluginContext.Provider
-        value={{ isApplicationsAvailable: false, isGovernanceAvailable: false, dataContext: PluginDataContext, ocpApi }}
+        value={{ ...defaultPlugin, isApplicationsAvailable: false, isGovernanceAvailable: false }}
       >
         <Component />
       </PluginContext.Provider>


### PR DESCRIPTION
Makes the `<Timestamp />` component from OpenShift console available and simplifies the current mechanism for using console dynamic plugin SDK hooks and components while maintaining the ability to run in standalone mode.

The `<Timestamp />` component gives us an easy way to have consistent display of timestamps that are localized.

**Placeholder for standalone dev mode:**
![image](https://github.com/user-attachments/assets/93777f45-5167-4753-b018-fb670eace39e)

**Demonstrating translated date/time string (French) and tooltip, with icon removed:**
![image](https://github.com/user-attachments/assets/8d5eaa6e-c8c2-4c7c-a2c6-1b498ff22eb2)

**Relative time display (once the current bug is implemented):**
![image](https://github.com/user-attachments/assets/fc535056-4e59-4b2f-a3c2-6d6fc2269e68)


### TODOs:

- [x] Implement a simplified version of the component for standalone development use
- [x] Implement a wrapper component to handle removing the icon (which we will not want to use in a table context)
- [ ] Contribute a fix for the broken relative string support (see draft PR https://github.com/openshift/console/pull/14555)
