### PR TITLE
ACM-15271-Prevent unintended react form wizard submission

### DIFF
--- a/frontend/src/resources/utils/utils.ts
+++ b/frontend/src/resources/utils/utils.ts
@@ -17,6 +17,20 @@ export function getLatest<T>(items: T[], key: string) {
   })
 }
 
+export const preventDefaultSubmissionWithListener = () => {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+    }
+  }
+  document.addEventListener('keydown', handleKeyDown)
+
+  // Cleanup
+  return () => {
+    document.removeEventListener('keydown', handleKeyDown)
+  }
+}
+
 /* istanbul ignore next */
 export const createDownloadFile = (filename: string, content: string, type?: string) => {
   const a = document.createElement('a')

--- a/frontend/src/wizards/Argo/ArgoWizard.tsx
+++ b/frontend/src/wizards/Argo/ArgoWizard.tsx
@@ -50,6 +50,7 @@ import { SourceSelector } from './SourceSelector'
 import { MultipleSourcesSelector } from './MultipleSourcesSelector'
 import { NavigationPath } from '../../NavigationPath'
 import { AcmAlert } from '../../ui-components'
+import { preventDefaultSubmissionWithListener } from '../../resources/utils'
 
 export interface Channel {
   metadata?: {
@@ -155,6 +156,7 @@ export function ArgoWizard(props: ArgoWizardProps) {
 
   const requeueTimes = useMemo(() => [30, 60, 120, 180, 300], [])
   const { t } = useTranslation()
+  useEffect(preventDefaultSubmissionWithListener, [])
 
   const hubCluster = useMemo(
     () => props.clusters.find((cls) => cls.metadata?.labels && cls.metadata.labels['local-cluster'] === 'true'),

--- a/frontend/src/wizards/Governance/Policy/PolicyWizard.tsx
+++ b/frontend/src/wizards/Governance/Policy/PolicyWizard.tsx
@@ -55,6 +55,7 @@ import { PlacementSection } from '../../Placement/PlacementSection'
 import { Specifications } from './specifications'
 import { useWizardStrings } from '../../../lib/wizardStrings'
 import { useTranslation } from '../../../lib/acm-i18next'
+import { preventDefaultSubmissionWithListener } from '../../../resources/utils'
 
 export function PolicyWizard(props: {
   title: string
@@ -85,6 +86,8 @@ export function PolicyWizard(props: {
       spec: { disabled: false },
     },
   ]
+
+  useEffect(preventDefaultSubmissionWithListener, [])
 
   return (
     <WizardPage


### PR DESCRIPTION
Regarding: [ACM-15271](https://issues.redhat.com/browse/ACM-15271)

Before: 
Pressing enter while focused on a textInput will result in form submission.

https://github.com/user-attachments/assets/2d306cf4-48b8-4f43-bba9-69970cc4c575



After: 
Form submission via "Enter" key is suppressed within the ArgoWizard and PolicyWizard components.

https://github.com/user-attachments/assets/1a18d3cc-4c5c-457f-b78b-0c8eacbe6cc3


