### PR TITLE
Adjust test timeout

### DIFF
--- a/frontend/src/routes/Credentials/CredentialsForm.test.tsx
+++ b/frontend/src/routes/Credentials/CredentialsForm.test.tsx
@@ -290,7 +290,7 @@ describe('add credentials page', () => {
     const createNock = nockCreate({ ...providerConnection })
     await clickByText('Add')
     await waitForNock(createNock)
-  }, 60000)
+  })
 
   it('should create ost (OpenStack) credentials', async () => {
     render(<Component credentialsType={Provider.openstack} />)
@@ -342,7 +342,7 @@ describe('add credentials page', () => {
     const createNock = nockCreate({ ...providerConnection })
     await clickByText('Add')
     await waitForNock(createNock)
-  }, 60000)
+  })
 
   it('should create ans (Ansible) credentials', async () => {
     render(<Component credentialsType={Provider.ansible} />)
@@ -544,5 +544,5 @@ current-context: 'mock-context'
     const createNock = nockCreate({ ...providerConnection })
     await clickByText('Add')
     await waitForNock(createNock)
-  }, 60000)
+  })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ClusterSets/ClusterSetDetails/ClusterSetDetails.test.tsx
@@ -1819,7 +1819,7 @@ describe('ClusterSetDetails page', () => {
       nockSCRoksSatelite,
       nockBroker,
     ])
-  }, 90000)
+  })
   test('can uninstall submariner add-ons', async () => {
     await waitForText(mockManagedClusterSet.metadata.name!, true)
     await waitForText('Details')

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -67,7 +67,7 @@ global.EventSource = class EventSource {
 global.TextEncoder = TextEncoder
 
 configure({ testIdAttribute: 'id' })
-jest.setTimeout((process.env.LAUNCH ? 3000 : 30) * 1000)
+jest.setTimeout((process.env.LAUNCH ? 3000 : 120) * 1000)
 
 async function setupBeforeAll(): Promise<void> {
   nock.disableNetConnect()


### PR DESCRIPTION
After upgrade to PF5, some tests are taking longer on slow build hardware. Increase global timeout to allow for long-running tests.