### PR TITLE
Configure Compliance Operator for ROSA HCP

### DIFF
--- a/frontend/src/wizards/Governance/Policy/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
+++ b/frontend/src/wizards/Governance/Policy/stable/CA-Security-Assessment-and-Authorization/policy-compliance-operator-install.yaml
@@ -40,6 +40,7 @@ spec:
           remediationAction: inform
           severity: high
           complianceType: musthave
+          upgradeApproval: Automatic
           operatorGroup:
             name: compliance-operator
             namespace: openshift-compliance
@@ -50,7 +51,12 @@ spec:
             namespace: openshift-compliance
             source: redhat-operators
             sourceNamespace: openshift-marketplace
-          upgradeApproval: Automatic
+            # Conditionally configure a nodeSelector for installing on ROSA hosted control planes
+            config: '{{ if and (eq "ROSA" (fromClusterClaim
+              "product.open-cluster-management.io")) (eq "true"
+              (fromClusterClaim "hostedcluster.hypershift.openshift.io"))
+              }}{"nodeSelector":{"node-role.kubernetes.io/worker":""} }{{ else
+              }}{{ "{}" | toLiteral }}{{ end }}'
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: PlacementBinding


### PR DESCRIPTION
This conditionally configures a node selector to allow the operator to run on ROSA HCP clusters. This update matches what is in the policy-collection.

Refs:
 - https://issues.redhat.com/browse/ACM-14161
 - https://github.com/open-cluster-management-io/policy-collection/pull/510