### PR TITLE
SyncEditor - Do not use effect to respond to changes

### DIFF
--- a/frontend/src/components/SyncEditor/SyncEditor.tsx
+++ b/frontend/src/components/SyncEditor/SyncEditor.tsx
@@ -97,7 +97,6 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
   const [filteredRows, setFilteredRows] = useState<number[]>([])
   const [userEdits, setUserEdits] = useState<any>([])
   const [customValidationErrors, setCustomValidationErrors] = useState<any>([])
-  const [resourceChanges, setResourceChanges] = useState<ProcessedType>()
   const [statusChanges, setStatusChanges] = useState<{
     changes: any[]
     errors: any[]
@@ -485,6 +484,23 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
     ]
   )
 
+  // report resource changes to form
+  const reportResourceChanges = useCallback(
+    (resourceChanges: ProcessedType) => {
+      if (resourceChanges) {
+        const isArr = Array.isArray(resources)
+        const _resources = isArr ? resources : [resources]
+        if (onEditorChange && !isEqual(resourceChanges.resources, _resources)) {
+          const editChanges = {
+            resources: isArr ? resourceChanges.resources : resourceChanges.resources[0],
+          }
+          onEditorChange(editChanges)
+        }
+      }
+    },
+    [onEditorChange, resources]
+  )
+
   // react to changes from user editing yaml
   const editorChanged = useCallback(
     (value: string, e: { isFlush: any }) => {
@@ -532,7 +548,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
           let customErrors = []
           if (!editorHasErrors) {
             const clonedUnredactedChange = cloneDeep(unredactedChange)
-            setResourceChanges(clonedUnredactedChange)
+            reportResourceChanges(clonedUnredactedChange)
             customErrors = setFormValues(syncs, clonedUnredactedChange) || []
             setCustomValidationErrors(customErrors)
           }
@@ -587,6 +603,7 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
       lastUserEdits,
       monaco,
       readonly,
+      reportResourceChanges,
       secrets,
       showFiltered,
       showSecrets,
@@ -609,21 +626,6 @@ export function SyncEditor(props: SyncEditorProps): JSX.Element {
     },
     [debouncedEditorChange]
   )
-
-  // report resource changes to form
-  useEffect(() => {
-    if (resourceChanges) {
-      const isArr = Array.isArray(resources)
-      let _resources = isArr ? resourceChanges.resources : resourceChanges.resources[0]
-      _resources = isArr ? resources : [resources]
-      if (onEditorChange && !isEqual(resourceChanges.resources, _resources)) {
-        const editChanges = {
-          resources: isArr ? resourceChanges.resources : resourceChanges.resources[0],
-        }
-        onEditorChange(editChanges)
-      }
-    }
-  }, [onEditorChange, resourceChanges, resources])
 
   // report errors/user edits to form
   useEffect(() => {


### PR DESCRIPTION
Before the PF5 upgrade, the SyncEditor file had a global ignore in place for the `react-hooks/exhaustive-deps` rule. I removed that and added them back on a case-by-case basis, but I missed this one.

In this case, I was able to rewrite the effect as a callback. Using effects to detect changes should be avoided when possible as there are many pitfalls.