### PR TITLE
ACM-16423: Use cluster claims for hosted clusters

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -713,8 +713,11 @@ export function getProvider({
   // Hosted clusters imported from a managed MCE cluster will not have provider set
   // Look it up from the corresponding DiscoveredCluster
   if (getIsHostedCluster(managedCluster) && providerLabel === 'OTHER') {
-    if (discoveredCluster?.spec.isManagedCluster && discoveredCluster?.spec.cloudProvider)
+    if (discoveredCluster?.spec.isManagedCluster && discoveredCluster?.spec.cloudProvider) {
       providerLabel = discoveredCluster.spec.cloudProvider.toUpperCase()
+    } else if (platformClusterClaim !== undefined) {
+      providerLabel = platformClusterClaim.value.toUpperCase()
+    }
   }
 
   let provider: Provider | undefined
@@ -1520,11 +1523,17 @@ export function getClusterStatus(
 }
 
 export function getIsHostedCluster(managedCluster?: ManagedCluster) {
+  const hostedClusterClaim = managedCluster?.status?.clusterClaims?.find(
+    (claim) => claim.name === 'hostedcluster.hypershift.openshift.io'
+  )
+
   if (
     managedCluster?.metadata.annotations &&
     managedCluster?.metadata.annotations['import.open-cluster-management.io/klusterlet-deploy-mode'] &&
     managedCluster?.metadata.annotations['import.open-cluster-management.io/klusterlet-deploy-mode'] === 'Hosted'
   ) {
+    return true
+  } else if (hostedClusterClaim !== undefined && hostedClusterClaim.value === 'true') {
     return true
   } else {
     return false


### PR DESCRIPTION
Use the following cluster claims in ManagedCluster's status to determine hosted cluster's control plane type and cloud provider type. Using the cluster claims ensures the two columns show the correct data regardless of how and where the hosted clusters are imported. https://issues.redhat.com/browse/ACM-16423

```
  - name: hostedcluster.hypershift.openshift.io
    value: "true" 
``` 

```
  - name: platform.hypershift.openshift.io     
   value: KubeVirt 
```