### PR TITLE
ACM-16417 Fix redirect on click + spacing

### DIFF
--- a/frontend/src/routes/Applications/components/LabelWithPopover.tsx
+++ b/frontend/src/routes/Applications/components/LabelWithPopover.tsx
@@ -32,7 +32,6 @@ export function LabelWithPopover(props: {
             event.nativeEvent.preventDefault()
           }}
           color="grey"
-          href="#"
           icon={props.labelIcon}
         >
           {props.labelContent}

--- a/frontend/src/routes/Applications/css/ResourceLabels.css
+++ b/frontend/src/routes/Applications/css/ResourceLabels.css
@@ -13,8 +13,7 @@
   --pf-v5-c-popover__content--PaddingLeft: var(--pf-v5-c-popover__content--Padding);
   --pf-v5-c-popover__content--PaddingBottom: var(--pf-v5-c-popover__content--Padding);
   --pf-v5-c-popover__content--PaddingRight: var(--pf-v5-c-popover__content--Padding);
-  --pf-v5-c-popover--c-button--sibling--PaddingRight: var(--pf-v5-c-popover__content--Padding);
-  --pf-v5-c-popover--c-button--Right: var(--pf-v5-c-popover__content--Padding);
+  --pf-v5-c-popover__close--Right: 0;
 }
 .label-with-popover.pf-v5-c-popover .pf-v5-c-popover__content .pf-v5-c-button {
   --pf-v5-c-button--PaddingTop: 1rem;


### PR DESCRIPTION
Removes href from label and fixex custom CSS spacing for close button on popover.

## Before

https://github.com/user-attachments/assets/259ede29-ad7d-45bf-9ac4-0ded6e3279a8

## After

https://github.com/user-attachments/assets/9dbf7f0b-5806-43a2-ba4e-fc7b9c6c58bc





