### PR TITLE
Make monaco globally accessible for testing

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -106,7 +106,7 @@ module.exports = function (env: any, argv: { hot?: boolean; mode: string | undef
             files: ['./src/**/*.{ts,tsx,js,jsx}'],
           },
         }),
-      new MonacoWebpackPlugin({ languages: ['yaml'] }),
+      new MonacoWebpackPlugin({ languages: ['yaml'], globalAPI: true }),
       isProduction &&
         new CopyPlugin({
           patterns: [{ from: 'public', globOptions: { ignore: ['**/*.html', '**/translation.json'] } }],

--- a/frontend/webpack.plugin.ts
+++ b/frontend/webpack.plugin.ts
@@ -78,7 +78,7 @@ module.exports = function (env: any, argv: { hot?: boolean; mode: string | undef
         'process.env.TRANSLATION_NAMESPACE': JSON.stringify(`plugin__${env.plugin}`),
       }) as unknown as webpack.WebpackPluginInstance,
       new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'], process: 'process' }),
-      new MonacoWebpackPlugin({ languages: ['yaml'] }),
+      new MonacoWebpackPlugin({ languages: ['yaml'], globalAPI: true }),
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash:8].css',
         chunkFilename: '[id].[contenthash:8].css',


### PR DESCRIPTION
This seems to work for ACM forms, but not for MCE forms. I am not sure why, as both have cases using SyncEditor which should be loading monaco in the same way. I thought perhaps one was overriding the other, but even if I only run MCE, it is still not effective in MCE.

With this change, ACM YAML editor contents can be obtained with:
`window.monaco.editor.getModels()[0].getValue()`