### PR TITLE
ACM-17121 Fix global hub cluster detection

### DIFF
--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -1543,7 +1543,9 @@ export function getIsHostedCluster(managedCluster?: ManagedCluster) {
 export function getIsRegionalHubCluster(managedCluster?: ManagedCluster) {
   if (
     managedCluster?.metadata.labels &&
-    managedCluster?.metadata.labels?.['feature.open-cluster-management.io/addon-multicluster-global-hub-controller']
+    managedCluster?.metadata.labels?.['feature.open-cluster-management.io/addon-multicluster-global-hub-controller'] &&
+    managedCluster?.metadata.labels?.['feature.open-cluster-management.io/addon-multicluster-global-hub-controller'] ===
+      'available'
   ) {
     return true
   } else {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.sharedmocks.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.sharedmocks.tsx
@@ -116,6 +116,17 @@ export const mockManagedCluster8: ManagedCluster = {
   },
   spec: { hubAcceptsClient: true },
 }
+export const mockManagedCluster9: ManagedCluster = {
+  apiVersion: ManagedClusterApiVersion,
+  kind: ManagedClusterKind,
+  metadata: {
+    name: 'regional-cluster',
+    labels: {
+      'feature.open-cluster-management.io/addon-multicluster-global-hub-controller': 'unreachable',
+    },
+  },
+  spec: { hubAcceptsClient: true },
+}
 export const mockManagedClusters: ManagedCluster[] = [
   mockManagedCluster0,
   mockManagedCluster1,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.test.tsx
@@ -48,6 +48,7 @@ import {
   mockManagedClusterInfo7,
   mockHostedClusters,
   mockManagedClusterInfo8,
+  mockManagedCluster9,
 } from './ManagedClusters.sharedmocks'
 
 function getClusterCuratorCreateResourceAttributes(name: string) {
@@ -264,6 +265,30 @@ describe('Clusters Page regional hub cluster', () => {
     await waitForNock(metricNock)
     await waitForText(mockManagedCluster8.metadata.name!, true)
     await waitForText('Hub')
+  })
+  test('should treat regional hub clusters as standalone if addon unreachable', async () => {
+    nockIgnoreRBAC()
+    nockIgnoreApiPaths()
+    const metricNock = nockPostRequest('/metrics?clusters', {})
+    const mockRegionalHubClustersUnreachable: ManagedCluster[] = [mockManagedCluster9]
+    const mockRegionalHubClusterInfosUnreachable: ManagedClusterInfo[] = [mockManagedClusterInfo8]
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(managedClustersState, mockRegionalHubClustersUnreachable)
+          snapshot.set(managedClusterInfosState, mockRegionalHubClusterInfosUnreachable)
+          snapshot.set(certificateSigningRequestsState, mockCertificateSigningRequests)
+        }}
+      >
+        <MemoryRouter>
+          <ManagedClusters />
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+    await waitForNock(metricNock)
+    await waitForText(mockManagedCluster8.metadata.name!, true)
+    await waitForNotText('Hub')
+    await waitForText('Standalone')
   })
 })
 


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-17121

Code was originally only checking the presence of the `feature.open-cluster-management.io/addon-multicluster-global-hub-controller` label, but it needs to confirm the value is `available` otherwise non-regional hubs can display as control plane type **Hub**.