### PR TITLE
Revert "Make monaco globally accessible for testing (#4170)"

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -106,7 +106,7 @@ module.exports = function (env: any, argv: { hot?: boolean; mode: string | undef
             files: ['./src/**/*.{ts,tsx,js,jsx}'],
           },
         }),
-      new MonacoWebpackPlugin({ languages: ['yaml'], globalAPI: true }),
+      new MonacoWebpackPlugin({ languages: ['yaml'] }),
       isProduction &&
         new CopyPlugin({
           patterns: [{ from: 'public', globOptions: { ignore: ['**/*.html', '**/translation.json'] } }],

--- a/frontend/webpack.plugin.ts
+++ b/frontend/webpack.plugin.ts
@@ -78,7 +78,7 @@ module.exports = function (env: any, argv: { hot?: boolean; mode: string | undef
         'process.env.TRANSLATION_NAMESPACE': JSON.stringify(`plugin__${env.plugin}`),
       }) as unknown as webpack.WebpackPluginInstance,
       new webpack.ProvidePlugin({ Buffer: ['buffer', 'Buffer'], process: 'process' }),
-      new MonacoWebpackPlugin({ languages: ['yaml'], globalAPI: true }),
+      new MonacoWebpackPlugin({ languages: ['yaml'] }),
       new MiniCssExtractPlugin({
         filename: '[name].[contenthash:8].css',
         chunkFilename: '[id].[contenthash:8].css',


### PR DESCRIPTION
This reverts commit fc39a0f64ab480bc6c99cd5e1fab0713275811df.

This was crashing the OpenShift console YAML editors:
<img width="1723" alt="image" src="https://github.com/user-attachments/assets/bb20003b-9cb0-435f-8e23-4bd9fec6ed8f" />

QE no longer needs global Monaco access for testing purposes. 
https://redhat-internal.slack.com/archives/CUPTCTQR2/p1737668979352489?thread_ts=1734632687.028309&cid=CUPTCTQR2