### PR TITLE
Fix kyverno and mutation in discovered policies

### DIFF
--- a/frontend/src/routes/Governance/discovered/DiscoveredPolicies.tsx
+++ b/frontend/src/routes/Governance/discovered/DiscoveredPolicies.tsx
@@ -202,6 +202,7 @@ export default function DiscoveredPolicies() {
           { label: 'CertificatePolicy', value: 'CertificatePolicy' },
           { label: 'ConfigurationPolicy', value: 'ConfigurationPolicy' },
           { label: 'Gatekeeper constraint', value: 'Gatekeeper' },
+          { label: 'Gatekeeper mutations', value: 'Gatekeeper Mutations' },
           { label: 'OperatorPolicy', value: 'OperatorPolicy' },
           { label: 'ValidatingAdmissionPolicyBinding', value: 'ValidatingAdmissionPolicyBinding' },
           { label: 'Kyverno ClusterPolicy', value: 'ClusterPolicy' },
@@ -210,6 +211,10 @@ export default function DiscoveredPolicies() {
         tableFilterFn: (selectedValues, item) => {
           if (item.apigroup === 'constraints.gatekeeper.sh') {
             return selectedValues.includes('Gatekeeper')
+          }
+
+          if (item.apigroup === 'mutations.gatekeeper.sh') {
+            return selectedValues.includes('Gatekeeper Mutations')
           }
 
           if (item.apigroup === 'kyverno.io') {

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/KyvernoRelatedResources.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/KyvernoRelatedResources.tsx
@@ -6,6 +6,10 @@ import {
   ToggleGroup,
   ToggleGroupItem,
   EmptyState,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
 } from '@patternfly/react-core'
 import { FunctionComponent, useEffect, useMemo, useState } from 'react'
 import { AcmEmptyState, AcmTable, IAcmTableColumn } from '../../../../../ui-components'
@@ -99,26 +103,32 @@ export const KyvernoRelatedResources: FunctionComponent<IKyvernoRelatedResources
 
   return (
     <>
+      <Toolbar inset={{ default: 'insetMd', xl: 'insetLg' }}>
+        <ToolbarContent>
+          <ToolbarGroup align={{ default: 'alignLeft' }}>
+            <ToolbarItem>
+              <ToggleGroup aria-label="choose kyverno resource panel">
+                {Object.keys(classifiedRelatedObjects)
+                  .sort((a: string, b: string) => {
+                    const order = Object.keys(kyvernoPolicyMenuLabels)
+                    return order.indexOf(a) - order.indexOf(b)
+                  })
+                  .filter((policyTypeId: string) => kyvernoPolicyMenuLabels[policyTypeId])
+                  .map((policyTypeId: string) => (
+                    <ToggleGroupItem
+                      key={policyTypeId}
+                      text={kyvernoPolicyMenuLabels[policyTypeId]}
+                      buttonId={policyTypeId}
+                      isSelected={selectedId === policyTypeId}
+                      onChange={handleItemClick}
+                    />
+                  ))}
+              </ToggleGroup>
+            </ToolbarItem>
+          </ToolbarGroup>
+        </ToolbarContent>
+      </Toolbar>
       <AcmTable
-        extraToolbarControls={
-          <ToggleGroup aria-label="choose kyverno resource panel">
-            {Object.keys(classifiedRelatedObjects)
-              .sort((a: string, b: string) => {
-                const order = Object.keys(kyvernoPolicyMenuLabels)
-                return order.indexOf(a) - order.indexOf(b)
-              })
-              .filter((policyTypeId: string) => kyvernoPolicyMenuLabels[policyTypeId])
-              .map((policyTypeId: string) => (
-                <ToggleGroupItem
-                  key={policyTypeId}
-                  text={kyvernoPolicyMenuLabels[policyTypeId]}
-                  buttonId={policyTypeId}
-                  isSelected={selectedId === policyTypeId}
-                  onChange={handleItemClick}
-                />
-              ))}
-          </ToggleGroup>
-        }
         items={classifiedRelatedObjects[selectedId] ?? []}
         emptyState={
           <AcmEmptyState

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailHooks.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailHooks.tsx
@@ -67,7 +67,7 @@ export function useFetchVapb() {
   return { vapbItems: data?.searchResult?.[0]?.items, loading, err: error?.message }
 }
 
-const availableKindList = ['ValidatingAdmissionPolicyBinding', 'Assign', 'AssignImage', 'AssignMetadata']
+const availableKindList = ['ValidatingAdmissionPolicyBinding', 'Assign', 'AssignImage', 'AssignMetadata', 'ModifySet']
 const availableApiGroups = ['admissionregistration.k8s.io', 'mutations.gatekeeper.sh']
 
 export function useFetchOnlyRelatedResources() {


### PR DESCRIPTION
1. Add a gatekeeper mutation filter.
2. Align the Kyverno toolbar to the left.
Signed-off-by: yiraeChristineKim <yikim@redhat.com>