### PR TITLE
Remove uses of rejectUnauthorized except where required

### DIFF
--- a/backend/src/lib/agent.ts
+++ b/backend/src/lib/agent.ts
@@ -1,0 +1,28 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { Agent } from 'https'
+import { getCACertificate, getServiceCACertificate } from './serviceAccountToken'
+import { HttpsProxyAgent } from 'https-proxy-agent'
+
+let defaultAgent: Agent
+export function getDefaultAgent() {
+  if (!defaultAgent) {
+    defaultAgent = new Agent({ ca: getCACertificate() })
+  }
+  return defaultAgent
+}
+
+let serviceAgent: Agent
+export function getServiceAgent() {
+  if (!serviceAgent) {
+    serviceAgent = new Agent({ ca: getServiceCACertificate() })
+  }
+  return serviceAgent
+}
+
+let proxyAgent: HttpsProxyAgent<string>
+export function getProxyAgent() {
+  if (!proxyAgent && process.env.HTTPS_PROXY) {
+    proxyAgent = new HttpsProxyAgent(process.env.HTTPS_PROXY)
+  }
+  return proxyAgent
+}

--- a/backend/src/lib/fetch-retry.ts
+++ b/backend/src/lib/fetch-retry.ts
@@ -1,5 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch'
+import { getDefaultAgent } from './agent'
 
 export function fetchRetry(url: RequestInfo, init?: RequestInit, retry?: number): Promise<Response> {
   let retries: number
@@ -12,12 +13,17 @@ export function fetchRetry(url: RequestInfo, init?: RequestInit, retry?: number)
       retries = 0
   }
 
+  const requestInit = { ...(init ?? {}) }
+  if (!requestInit.agent) {
+    requestInit.agent = getDefaultAgent()
+  }
+
   let delay = 1000
 
   return new Promise(function (resolve, reject) {
     async function fetchAttempt() {
       try {
-        const response = await fetch(url, init)
+        const response = await fetch(url, requestInit)
         switch (response.status) {
           case 429: // Too Many Requests
             {

--- a/backend/src/lib/request-retry.ts
+++ b/backend/src/lib/request-retry.ts
@@ -1,11 +1,10 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { IncomingMessage, OutgoingHttpHeaders } from 'http'
 import { constants } from 'http2'
-import { Agent, request, RequestOptions } from 'https'
+import { request, RequestOptions } from 'https'
 import { AbortSignal } from 'node-fetch/externals'
 import { logger } from './logger'
-
-const agent = new Agent({ rejectUnauthorized: false })
+import { getDefaultAgent } from './agent'
 
 const { HTTP2_HEADER_CONTENT_LENGTH, HTTP2_HEADER_CONTENT_TYPE, HTTP2_HEADER_AUTHORIZATION, HTTP2_HEADER_ACCEPT } =
   constants
@@ -35,7 +34,7 @@ export function requestRetry(options: {
     options.headers[HTTP2_HEADER_AUTHORIZATION] = `Bearer ${options.token}`
   }
   const requestOptions = options as RequestOptions
-  requestOptions.agent = agent
+  requestOptions.agent = getDefaultAgent()
 
   let delay = 10000
   let retries = 0

--- a/backend/src/lib/search.ts
+++ b/backend/src/lib/search.ts
@@ -24,19 +24,18 @@ export type ISearchResult = {
   message?: string
 }
 
-export async function getServiceAccountOptions() {
+export async function getServiceAccountSearchRequestOptions() {
   const serviceAccountToken = getServiceAccountToken()
   const headers: OutgoingHttpHeaders = {
     authorization: `Bearer ${serviceAccountToken}`,
     accept: 'application/json',
     'content-type': 'application/json',
   }
-  const options = await getSearchOptions(headers)
-  options.rejectUnauthorized = false
+  const options = await getSearchRequestOptions(headers)
   return options
 }
 
-export async function getSearchOptions(headers: OutgoingHttpHeaders): Promise<RequestOptions> {
+export async function getSearchRequestOptions(headers: OutgoingHttpHeaders): Promise<RequestOptions> {
   const mch = await getMultiClusterHub()
   const namespace = getNamespace()
   const machineNs = process.env.NODE_ENV === 'test' ? 'undefined' : `${mch?.metadata?.namespace || namespace}`
@@ -58,7 +57,7 @@ export async function getSearchOptions(headers: OutgoingHttpHeaders): Promise<Re
 }
 
 export async function getSearchResults(query: IQuery) {
-  const options = await getServiceAccountOptions()
+  const options = await getServiceAccountSearchRequestOptions()
   const requestTimeout = 2 * 60 * 1000
   return new Promise<ISearchResult>((resolve, reject) => {
     let body = ''
@@ -122,7 +121,7 @@ const ping = {
 }
 
 export async function pingSearchAPI() {
-  const options = await getServiceAccountOptions()
+  const options = await getServiceAccountSearchRequestOptions()
   return new Promise<boolean>((resolve, reject) => {
     let body = ''
     const id = setTimeout(

--- a/backend/src/lib/token.ts
+++ b/backend/src/lib/token.ts
@@ -1,12 +1,10 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
-import { Agent } from 'https'
 import { parseCookies } from '../lib/cookies'
 import { fetchRetry } from '../lib/fetch-retry'
 import { unauthorized } from './respond'
 
 const { HTTP2_HEADER_AUTHORIZATION } = constants
-const agent = new Agent({ rejectUnauthorized: false })
 
 export function getToken(req: Http2ServerRequest): string | undefined {
   let token = parseCookies(req)['acm-access-token-cookie']
@@ -22,7 +20,6 @@ export function getToken(req: Http2ServerRequest): string | undefined {
 export async function isAuthenticated(token: string) {
   return fetchRetry(process.env.CLUSTER_API_URL + '/apis', {
     headers: { [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${token}` },
-    agent,
   })
 }
 

--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -6,6 +6,7 @@ import { URL } from 'url'
 import { logger } from '../lib/logger'
 import { catchInternalServerError, notFound, respond, respondBadRequest } from '../lib/respond'
 import { getAuthenticatedToken } from '../lib/token'
+import { getProxyAgent } from '../lib/agent'
 
 interface AnsibleCredential {
   towerHost: string
@@ -47,6 +48,7 @@ export function ansibleTower(req: Http2ServerRequest, res: Http2ServerResponse):
           headers: {
             Authorization: `Bearer ${ansibleCredential.token}`,
           },
+          agent: getProxyAgent(),
           rejectUnauthorized: false, // NOSONAR - AAP connects insecurely by default
         }
 

--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -12,7 +12,7 @@ import { jsonPost } from '../lib/json-request'
 import { logger } from '../lib/logger'
 import { ITransformedResource } from '../lib/pagination'
 import { ServerSideEvent, ServerSideEvents } from '../lib/server-side-events'
-import { getServiceAccountToken } from '../lib/serviceAccountToken'
+import { getCACertificate, getServiceAccountToken } from '../lib/serviceAccountToken'
 import { getAuthenticatedToken } from '../lib/token'
 import { IResource } from '../resources/resource'
 
@@ -281,7 +281,7 @@ async function listKubernetesObjects(options: IWatchOptions) {
     const request = got
       .get(url, {
         headers: { authorization: `Bearer ${serviceAccountToken}` },
-        https: { rejectUnauthorized: false },
+        https: { certificateAuthority: getCACertificate() },
       })
       .json<{
         metadata: { _continue?: string; continue?: string; resourceVersion: string }
@@ -360,7 +360,7 @@ async function watchKubernetesObjects(options: IWatchOptions, resourceVersion: s
       const url = resourceUrl(options, { watch: undefined, allowWatchBookmarks: undefined, resourceVersion })
       const request = got.stream(url, {
         headers: { authorization: `Bearer ${serviceAccountToken}` },
-        https: { rejectUnauthorized: false },
+        https: { certificateAuthority: getCACertificate() },
         timeout: { socket: 5 * 60 * 1000 + Math.ceil(Math.random() * 10 * 1000) },
       })
       // TODO use abort signal when on node 16

--- a/backend/src/routes/liveness.ts
+++ b/backend/src/routes/liveness.ts
@@ -1,6 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
-import { Agent } from 'https'
 import { FetchError } from 'node-fetch'
 import { fetchRetry } from '../lib/fetch-retry'
 import { logger } from '../lib/logger'
@@ -29,14 +28,11 @@ export function setDead(): void {
   }
 }
 
-const agent = new Agent({ rejectUnauthorized: false })
-
 export async function apiServerPing(): Promise<void> {
   const msg = 'kube api server ping failed'
   try {
     const response = await fetchRetry(process.env.CLUSTER_API_URL + '/apis', {
       headers: { [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${getServiceAccountToken()}` },
-      agent,
     })
     if (response.status !== 200) {
       const { status } = response

--- a/backend/src/routes/oauth.ts
+++ b/backend/src/routes/oauth.ts
@@ -9,6 +9,7 @@ import { logger } from '../lib/logger'
 import { redirect, respondInternalServerError, unauthorized } from '../lib/respond'
 import { getToken } from '../lib/token'
 import { setDead } from './liveness'
+import { getCACertificate } from '../lib/serviceAccountToken'
 
 type OAuthInfo = { authorization_endpoint: string; token_endpoint: string }
 let oauthInfoPromise: Promise<OAuthInfo>
@@ -80,7 +81,10 @@ export function logout(req: Http2ServerRequest, res: Http2ServerResponse): void 
   const token = getToken(req)
   if (!token) return unauthorized(req, res)
 
-  const gotOptions = { headers: { Authorization: `Bearer ${token}` }, https: { rejectUnauthorized: false } }
+  const gotOptions = {
+    headers: { Authorization: `Bearer ${token}` },
+    https: { certificateAuthority: getCACertificate() },
+  }
 
   let tokenName = token
   const sha256Prefix = 'sha256~'

--- a/backend/src/routes/search.ts
+++ b/backend/src/routes/search.ts
@@ -5,7 +5,7 @@ import { pipeline } from 'stream'
 import { logger } from '../lib/logger'
 import { notFound } from '../lib/respond'
 import { getAuthenticatedToken } from '../lib/token'
-import { getSearchOptions } from '../lib/search'
+import { getSearchRequestOptions } from '../lib/search'
 
 const proxyHeaders = [
   constants.HTTP2_HEADER_ACCEPT,
@@ -22,7 +22,7 @@ export async function search(req: Http2ServerRequest, res: Http2ServerResponse):
     for (const header of proxyHeaders) {
       if (req.headers[header]) headers[header] = req.headers[header]
     }
-    const options = await getSearchOptions(headers)
+    const options = await getSearchRequestOptions(headers)
     pipeline(
       req,
       request(options, (response) => {

--- a/backend/src/routes/upgrade-risks-prediction.ts
+++ b/backend/src/routes/upgrade-risks-prediction.ts
@@ -1,6 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { Http2ServerRequest, Http2ServerResponse } from 'http2'
-import { HttpsProxyAgent } from 'https-proxy-agent'
 import { jsonPost, jsonRequest } from '../lib/json-request'
 import { logger } from '../lib/logger'
 import { respondInternalServerError } from '../lib/respond'
@@ -8,6 +7,7 @@ import { getServiceAccountToken } from '../lib/serviceAccountToken'
 import { getAuthenticatedToken } from '../lib/token'
 import { ResourceList } from '../resources/resource-list'
 import { Secret } from '../resources/secret'
+import { getProxyAgent } from '../lib/agent'
 interface Credential {
   auths: {
     'cloud.openshift.com': {
@@ -53,10 +53,6 @@ export async function upgradeRiskPredictions(req: Http2ServerRequest, res: Http2
         // https://github.com/RedHatInsights/insights-results-smart-proxy/blob/master/server/router_utils.go#L168
         const userAgent = 'acm-operator/v2.10.0 cluster/acm-hub'
         const insightsPath = 'https://console.redhat.com/api/insights-results-aggregator/v2/upgrade-risks-prediction'
-        let proxyAgent: HttpsProxyAgent<string> = undefined
-        if (process.env.HTTPS_PROXY) {
-          proxyAgent = new HttpsProxyAgent(process.env.HTTPS_PROXY)
-        }
 
         // create array of clusterIds with length of 100
         const clusterIds = body.clusterIds.reduce((resultArray: string[][], item, index) => {
@@ -70,10 +66,12 @@ export async function upgradeRiskPredictions(req: Http2ServerRequest, res: Http2
 
         // Create req for each 100 id chunk
         const reqs = clusterIds.map((idChunk: string[]) => {
-          return jsonPost(insightsPath, { clusters: idChunk }, crcToken, userAgent, proxyAgent).catch((err: Error) => {
-            logger.error({ msg: 'Error getting cluster upgrade risk predictions', error: err.message })
-            return { error: err.message }
-          })
+          return jsonPost(insightsPath, { clusters: idChunk }, crcToken, userAgent, getProxyAgent()).catch(
+            (err: Error) => {
+              logger.error({ msg: 'Error getting cluster upgrade risk predictions', error: err.message })
+              return { error: err.message }
+            }
+          )
         })
 
         await Promise.all(reqs).then((results) => {

--- a/backend/src/routes/userpreference.ts
+++ b/backend/src/routes/userpreference.ts
@@ -1,7 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
-import { Agent } from 'https'
 import { HeadersInit } from 'node-fetch'
 import { fetchRetry } from '../lib/fetch-retry'
 import { jsonPost, jsonRequest } from '../lib/json-request'
@@ -32,7 +31,6 @@ export async function userpreference<T = unknown>(req: Http2ServerRequest, res: 
   const token = await getAuthenticatedToken(req, res)
   if (token) {
     const serviceAccountToken = getServiceAccountToken()
-    const agent = new Agent({ rejectUnauthorized: false })
 
     const headers: HeadersInit = {
       [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${serviceAccountToken}`,
@@ -100,7 +98,6 @@ export async function userpreference<T = unknown>(req: Http2ServerRequest, res: 
               const fetchResponse = await fetchRetry(path, {
                 method: req.method,
                 headers,
-                agent,
                 body,
                 compress: true,
               })

--- a/backend/src/routes/virtualMachineProxy.ts
+++ b/backend/src/routes/virtualMachineProxy.ts
@@ -5,6 +5,7 @@ import { logger } from '../lib/logger'
 import { getMultiClusterEngine } from '../lib/multi-cluster-engine'
 import { respond, respondInternalServerError } from '../lib/respond'
 import { getServiceAccountToken } from '../lib/serviceAccountToken'
+import { getServiceAgent } from '../lib/agent'
 import { getAuthenticatedToken } from '../lib/token'
 import { ResourceList } from '../resources/resource-list'
 import { Secret } from '../resources/secret'
@@ -76,7 +77,7 @@ export async function virtualMachineProxy(req: Http2ServerRequest, res: Http2Ser
             if (req.headers[header]) headers[header] = req.headers[header]
           }
 
-          await jsonPut(path, {}, managedClusterToken)
+          await jsonPut(path, {}, managedClusterToken, getServiceAgent())
             .then((results) => {
               if (results?.statusCode >= 200 && results?.statusCode < 300) {
                 res.setHeader('Content-Type', 'application/json')


### PR DESCRIPTION
- Centralizes creation of Agent instances
- Removes all cases of `rejectUnauthorized` except where required (Ansible)