### PR TITLE
Konflux hermetic builds: Enable build-source-image

### DIFF
--- a/.tekton/console-acm-213-pull-request.yaml
+++ b/.tekton/console-acm-213-pull-request.yaml
@@ -34,6 +34,8 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   - name: prefetch-input
     value:
     - path: .

--- a/.tekton/console-acm-213-push.yaml
+++ b/.tekton/console-acm-213-push.yaml
@@ -32,6 +32,8 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   - name: prefetch-input
     value:
     - path: .

--- a/.tekton/console-mce-mce-28-pull-request.yaml
+++ b/.tekton/console-mce-mce-28-pull-request.yaml
@@ -35,6 +35,8 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   - name: prefetch-input
     value:
     - path: .

--- a/.tekton/console-mce-mce-28-push.yaml
+++ b/.tekton/console-mce-mce-28-push.yaml
@@ -32,6 +32,8 @@ spec:
     value: .
   - name: hermetic
     value: "true"
+  - name: build-source-image
+    value: "true"
   - name: prefetch-input
     value:
     - path: .


### PR DESCRIPTION
build-source-image tasks is skipped by default. Enabling.

See [discussion on Slack](https://redhat-internal.slack.com/archives/C04L50S5XM4/p1738255213495489).

This reduces the violations to 2:
<img width="538" alt="image" src="https://github.com/user-attachments/assets/4ad1c1d7-48ed-4570-b59c-c2843d3668df" />


```
Results:
✕ [Violation] base_image_registries.base_image_permitted
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/console-mce-mce-28@sha256:8d81a3a893a1e1224f8637bafbadf40ae526417a392b2679c1edb1ccf8c1cb82
  Reason: Base image "brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent" is from a disallowed registry
  Title: Base image comes from permitted registry
  Description: Verify that the base images used when building a container image come from a known set of trusted registries to
  reduce potential supply chain attacks. By default this policy defines trusted registries as registries that are fully maintained
  by Red Hat and only contain content produced by Red Hat. The list of permitted registries can be customized by setting the
  `allowed_registry_prefixes` list in the rule data. Base images that are found in the snapshot being validated are also allowed
  since EC will also validate those images individually. To exclude this rule add
  "base_image_registries.base_image_permitted:brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent" to the `exclude` section of
  the policy configuration. To exclude this rule add
  "base_image_registries.base_image_permitted:brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent" to the `exclude` section of
  the policy configuration.
  Solution: Make sure the image used in each task comes from a trusted registry. The list of trusted registries is a configurable
  xref:ec-cli:ROOT:configuration.adoc#_data_sources[data source].

✕ [Violation] base_image_registries.base_image_permitted
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/console-mce-mce-28@sha256:8d81a3a893a1e1224f8637bafbadf40ae526417a392b2679c1edb1ccf8c1cb82
  Reason: Base image "brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent" is from a disallowed registry
  Title: Base image comes from permitted registry
  Description: Verify that the base images used when building a container image come from a known set of trusted registries to
  reduce potential supply chain attacks. By default this policy defines trusted registries as registries that are fully maintained
  by Red Hat and only contain content produced by Red Hat. The list of permitted registries can be customized by setting the
  `allowed_registry_prefixes` list in the rule data. Base images that are found in the snapshot being validated are also allowed
  since EC will also validate those images individually. To exclude this rule add
  "base_image_registries.base_image_permitted:brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent" to the `exclude` section of
  the policy configuration. To exclude this rule add
  "base_image_registries.base_image_permitted:brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent" to the `exclude` section of
  the policy configuration.
  Solution: Make sure the image used in each task comes from a trusted registry. The list of trusted registries is a configurable
  xref:ec-cli:ROOT:configuration.adoc#_data_sources[data source].
```

This should be resolved soon. See [Slack thread](https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1738255544667079).