### PR TITLE
ACM-17837 Turn on checks for PRs against release-2.13

### DIFF
--- a/.tekton/console-acm-213-pull-request.yaml
+++ b/.tekton/console-acm-213-pull-request.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "release-2.13"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-acm-213

--- a/.tekton/console-mce-mce-28-pull-request.yaml
+++ b/.tekton/console-mce-mce-28-pull-request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "release-2.13"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: release-mce-28


### PR DESCRIPTION
Switch PR checks to run for the release branch, rather than for `main` which is now fast-forwarding to the next release, ACM 2.14.