### PR TITLE
Catch request aborted errors from effect cleanup

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,7 +26,7 @@ import './lib/test-shots'
 import { getUsername } from './lib/username'
 import { logout } from './logout'
 import { createRoutePathFunction, MatchType, NavigationPath } from './NavigationPath'
-import { ResourceError, ResourceErrorCode } from './resources/utils'
+import { isRequestAbortedError } from './resources/utils'
 import { setLightTheme, ThemeSwitcher } from './theme'
 import { AcmTablePaginationContextProvider, AcmToastGroup, AcmToastProvider } from './ui-components'
 
@@ -75,9 +75,7 @@ function UserDropdownToggle() {
         setName(payload.body.username ?? 'undefined')
       })
       .catch((error) => {
-        if (!(error instanceof ResourceError) || error.code !== ResourceErrorCode.RequestAborted) {
-          // eslint-disable-next-line no-console
-          console.error(error)
+        if (!isRequestAbortedError(error)) {
           setName('undefined')
         }
       })

--- a/frontend/src/resources/utils/resource-request.ts
+++ b/frontend/src/resources/utils/resource-request.ts
@@ -60,6 +60,10 @@ export class ResourceError extends Error {
   }
 }
 
+export function isRequestAbortedError(error: any) {
+  return error instanceof ResourceError && error.code === ResourceErrorCode.RequestAborted
+}
+
 export function getBackendUrl() {
   if (process.env.MODE === 'plugin') {
     const proxyPath = process.env.PLUGIN_PROXY_PATH

--- a/frontend/src/routes/Credentials/CredentialsForm.tsx
+++ b/frontend/src/routes/Credentials/CredentialsForm.tsx
@@ -41,7 +41,7 @@ import {
   Secret,
   unpackProviderConnection,
 } from '../../resources'
-import { createResource, patchResource } from '../../resources/utils'
+import { createResource, isRequestAbortedError, patchResource } from '../../resources/utils'
 import {
   AcmEmptyState,
   AcmIcon,
@@ -105,7 +105,11 @@ export function ViewEditCredentialsFormPage() {
         setError(undefined)
         setProviderConnection(unpackProviderConnection(secret as ProviderConnection))
       })
-      .catch(setError)
+      .catch((error) => {
+        if (!isRequestAbortedError(error)) {
+          setError(error)
+        }
+      })
     return result.abort
   }, [name, namespace])
   if (error) return <ErrorPage error={error} />

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../../resources'
 import {
   createResource,
+  isRequestAbortedError,
   listAnsibleTowerInventories,
   listAnsibleTowerJobs,
   replaceResource,
@@ -81,7 +82,11 @@ export default function AnsibleAutomationsFormPage() {
         .then((curator) => {
           setClusterCuratorTemplate(curator)
         })
-        .catch(setError)
+        .catch((error) => {
+          if (!isRequestAbortedError(error)) {
+            setError(error)
+          }
+        })
       return result.abort
     }
     return undefined


### PR DESCRIPTION
For the development console, attempting to edit an Automation Template results in an error being shown:
![image](https://github.com/user-attachments/assets/eb0da0e5-2a97-495a-b97c-01a7d607c151)


This has to do with React 18 safe mode mounting cycles, and effect clean-ups not being handled properly.