### PR TITLE
Fix VAP policies getting shown in parameter resources table

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailHooks.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailHooks.tsx
@@ -67,7 +67,14 @@ export function useFetchVapb() {
   return { vapbItems: data?.searchResult?.[0]?.items, loading, err: error?.message }
 }
 
-const availableKindList = ['ValidatingAdmissionPolicyBinding', 'Assign', 'AssignImage', 'AssignMetadata', 'ModifySet']
+const availableKindList = [
+  'ValidatingAdmissionPolicyBinding',
+  'ValidatingAdmissionPolicy',
+  'Assign',
+  'AssignImage',
+  'AssignMetadata',
+  'ModifySet',
+]
 const availableApiGroups = ['admissionregistration.k8s.io', 'mutations.gatekeeper.sh']
 
 export function useFetchOnlyRelatedResources() {

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsPage.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsPage.test.tsx
@@ -1838,5 +1838,9 @@ describe('Policy Template Details Page', () => {
     expect(name.getAttribute('href')).toEqual(
       `/multicloud/search/resources/yaml?cluster=local-cluster&kind=Pod&apiversion=v1&name=nginx-pod-a&namespace=default&_hubClusterResource=true`
     )
+
+    const parameterTable = screen.getByRole('grid')
+    expect(within(parameterTable).queryByText('ValidatingAdmissionPolicy')).not.toBeInTheDocument()
+    expect(within(parameterTable).queryByText('Cluster')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
VAP policies getting shown in parameter resources table of VAPB template details page. 
VAP policy should not appear in the list. 
Ref: https://issues.redhat.com/browse/ACM-18105
Signed-off-by: yiraeChristineKim <yikim@redhat.com>