### PR TITLE
ACM-18603 Fix false local-cluster offline warning in topology

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/computeStatuses.js
@@ -848,7 +848,7 @@ export const setSubscriptionDeployStatus = (node, details, activeFilters, t, hub
   }
 
   const subscriptionReportResults = _.get(node, 'report.results', [])
-  const onlineClusters = getOnlineClusters(node)
+  const onlineClusters = getOnlineClusters(node, hubClusterName)
   Object.values(resourceMap).forEach((subscriptions) => {
     subscriptions.forEach((subscription) => {
       const subsCluster = _.get(subscription, 'cluster', '')


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-18603

- Fix false local-cluster offline warning in topology
- This was introduced by the local-cluster rename work
- Forgot to pass the hub cluster name