### PR TITLE
ACM-18453-ClusterSets-not-included-in-First-Events-Packet

### DIFF
--- a/backend/src/lib/server-side-events.ts
+++ b/backend/src/lib/server-side-events.ts
@@ -321,10 +321,12 @@ export class ServerSideEvents {
     const remainder: ServerSideEvent<unknown>[] = []
     parts.forEach((event) => {
       const data = event.data as WatchEvent
+      // see frontend/src/components/LoadPluginData.tsx for what pages are fast loaded
       switch (data.object.kind) {
         case 'ManagedCluster':
         case 'HostedCluster':
         case 'ClusterDeployment':
+        case 'ManagedClusterSet':
           clusters.push(event)
           break
         case 'Policy':

--- a/backend/src/lib/server-side-events.ts
+++ b/backend/src/lib/server-side-events.ts
@@ -116,7 +116,7 @@ export class ServerSideEvents {
       client.eventQueue.push(
         this.eventFilter(client.token, event)
           .then((shouldSendEvent) => (shouldSendEvent ? event : undefined))
-          .catch((err) => undefined) as Promise<ServerSideEvent<unknown>>
+          .catch(() => undefined) as Promise<ServerSideEvent<unknown>>
       )
     } else {
       client.eventQueue.push(Promise.resolve(event))

--- a/frontend/src/components/LoadPluginData.tsx
+++ b/frontend/src/components/LoadPluginData.tsx
@@ -40,12 +40,7 @@ export const LoadPluginData = (props: { children?: ReactNode }) => {
       NavigationPath.advancedConfiguration,
       NavigationPath.createApplicationArgo,
       NavigationPath.createApplicationArgoPullModel,
-      NavigationPath.editApplicationArgo,
       NavigationPath.createApplicationSubscription,
-      NavigationPath.applicationDetails,
-      NavigationPath.applicationOverview,
-      NavigationPath.applicationTopology,
-      NavigationPath.editApplicationSubscription,
 
       // Governance
       NavigationPath.governance,
@@ -55,7 +50,7 @@ export const LoadPluginData = (props: { children?: ReactNode }) => {
       // Credentials
       NavigationPath.credentials,
     ] as string[]
-  ).includes(location.pathname)
+  ).includes(location.pathname.replace(/\/$/, ''))
   useEffect(() => {
     if (!loadStarted) {
       load()

--- a/frontend/src/components/LoadPluginData.tsx
+++ b/frontend/src/components/LoadPluginData.tsx
@@ -3,15 +3,68 @@ import { ReactNode, useContext, useEffect } from 'react'
 import { PluginContext } from '../lib/PluginContext'
 import { LostChangesProvider } from './LostChanges'
 import { LoadingPage } from './LoadingPage'
+import { useLocation } from 'react-router-dom-v5-compat'
+import { NavigationPath } from '../NavigationPath'
 
 export const LoadPluginData = (props: { children?: ReactNode }) => {
   const { dataContext } = useContext(PluginContext)
-  const { load, loadStarted } = useContext(dataContext)
+  const { load, loadStarted, loadCompleted } = useContext(dataContext)
+  const location = useLocation()
+  // some pages are loaded fast by sending it's events first
+  // which means these pages can appear immediately
+  // see backend/src/lib/server-side-events.ts #312 for what resources are fast loaded
+  const fastLoadPage = (
+    [
+      // Home
+      NavigationPath.home,
+      NavigationPath.welcome,
+      NavigationPath.overview,
+
+      // Search
+      NavigationPath.search,
+      NavigationPath.resources,
+      NavigationPath.resourceYAML,
+      NavigationPath.resourceRelated,
+      NavigationPath.resourceLogs,
+
+      // Infrastructure
+      NavigationPath.infrastructure,
+
+      // Infrastructure - Clusters - Managed Clusters
+      NavigationPath.clusters,
+      NavigationPath.managedClusters,
+
+      // Infrastructure - Clusters - Cluster Sets
+      NavigationPath.clusterSets,
+      NavigationPath.applications,
+      NavigationPath.advancedConfiguration,
+      NavigationPath.createApplicationArgo,
+      NavigationPath.createApplicationArgoPullModel,
+      NavigationPath.editApplicationArgo,
+      NavigationPath.createApplicationSubscription,
+      NavigationPath.applicationDetails,
+      NavigationPath.applicationOverview,
+      NavigationPath.applicationTopology,
+      NavigationPath.editApplicationSubscription,
+
+      // Governance
+      NavigationPath.governance,
+      NavigationPath.policies,
+      NavigationPath.policySets,
+
+      // Credentials
+      NavigationPath.credentials,
+    ] as string[]
+  ).includes(location.pathname)
   useEffect(() => {
     if (!loadStarted) {
       load()
     }
   }, [load, loadStarted])
 
-  return loadStarted ? <LostChangesProvider>{props.children}</LostChangesProvider> : <LoadingPage />
+  return (fastLoadPage && loadStarted) || loadCompleted ? (
+    <LostChangesProvider>{props.children}</LostChangesProvider>
+  ) : (
+    <LoadingPage />
+  )
 }


### PR DESCRIPTION
oh man--I got pr4321!!!!

I used to just check in a couple spots whether or not recoil states were fully loaded like this:
```
  const { dataContext } = useContext(PluginContext)
  const { loadCompleted } = useContext(dataContext)
  return loadCompleted ? (
    <PageSection>
      <Card>
        <CardBody>
          <ErrorState {...props} />
        </CardBody>
      </Card>
    </PageSection>
  ) : (
    <LoadingPage />
  )

```
but there'll always be something that gets through--instead I created a list of pages approved for fast load, everything else gets a loading page:

```
      // Credentials
      NavigationPath.credentials,
    ] as string[]
  ).includes(location.pathname)
  useEffect(() => {
    if (!loadStarted) {
      load()
    }
  }, [load, loadStarted])

  return (fastLoadPage && loadStarted) || loadCompleted ? (

```
Signed-off-by: John Swanke <jswanke@redhat.com>