### PR TITLE
ACM-18820 Use spec.name instead of metadata.name for operator check

### DIFF
--- a/backend/src/routes/operatorCheck.ts
+++ b/backend/src/routes/operatorCheck.ts
@@ -59,7 +59,7 @@ export function operatorCheck(req: Http2ServerRequest, res: Http2ServerResponse)
               if (typeof response === 'object' && 'items' in response && Array.isArray(response.items)) {
                 const items = response.items as unknown[]
                 const subscription = items.find(
-                  (item: unknown) => typeof item === 'object' && get(item, 'metadata.name') === operator
+                  (item: unknown) => typeof item === 'object' && get(item, 'spec.name') === operator
                 ) as object | undefined
                 const subscriptionConditions = get(subscription, 'status.conditions') as unknown[]
                 if (

--- a/backend/test/routes/operatorCheck.test.ts
+++ b/backend/test/routes/operatorCheck.test.ts
@@ -6,7 +6,8 @@ import nock from 'nock'
 const subscriptionOperators = {
   items: [
     {
-      metadata: { name: 'openshift-gitops-operator' },
+      metadata: { name: 'openshift-gitops' },
+      spec: { name: 'openshift-gitops-operator' },
       status: {
         installedCSV: 'openshift-gitops-operator.v1.8.2',
         conditions: [

--- a/frontend/src/components/ACMNotReadyWarning.test.tsx
+++ b/frontend/src/components/ACMNotReadyWarning.test.tsx
@@ -13,8 +13,11 @@ const acm_unhealthy: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'advanced-cluster-management',
+    name: 'acm-operator-subscription',
     namespace: 'open-cluster-management',
+  },
+  spec: {
+    name: 'advanced-cluster-management',
   },
   status: {
     installedCSV: 'advanced-cluster-management.v2.8.0',
@@ -28,15 +31,17 @@ const acm_unhealthy: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 const acm: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'advanced-cluster-management',
+    name: 'acm-operator-subscription',
     namespace: 'open-cluster-management',
+  },
+  spec: {
+    name: 'advanced-cluster-management',
   },
   status: {
     installedCSV: 'advanced-cluster-management.v2.8.0',
@@ -50,7 +55,6 @@ const acm: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 function WrappedACMNotReadyWarning(props: { acmOperators?: SubscriptionOperator[] }) {

--- a/frontend/src/components/AutomationProviderHint.test.tsx
+++ b/frontend/src/components/AutomationProviderHint.test.tsx
@@ -66,9 +66,10 @@ const aap_unhealthy: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'ansible-automation-platform-operator',
+    name: 'aap',
     namespace: 'ansible-automation-platform-operator',
   },
+  spec: { name: 'ansible-automation-platform-operator' },
   status: {
     conditions: [
       {
@@ -80,16 +81,16 @@ const aap_unhealthy: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 const aap: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'ansible-automation-platform-operator',
+    name: 'aap',
     namespace: 'ansible-automation-platform-operator',
   },
+  spec: { name: 'ansible-automation-platform-operator' },
   status: {
     conditions: [
       {
@@ -101,16 +102,16 @@ const aap: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 const aap_withWorkflowSupport: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'ansible-automation-platform-operator',
+    name: 'aap',
     namespace: 'ansible-automation-platform-operator',
   },
+  spec: { name: 'ansible-automation-platform-operator' },
   status: {
     conditions: [
       {
@@ -123,7 +124,6 @@ const aap_withWorkflowSupport: SubscriptionOperator = {
     ],
     installedCSV: 'aap-operator.v2.2.1+0.1668659261',
   },
-  spec: {},
 }
 
 function WrappedAutomationProviderHint(props: {

--- a/frontend/src/resources/subscription-operator.ts
+++ b/frontend/src/resources/subscription-operator.ts
@@ -17,7 +17,9 @@ export interface SubscriptionOperator extends IResource {
   apiVersion: SubscriptionOperatorApiVersionType
   kind: SubscriptionOperatorKindType
   metadata: Metadata
-  spec: object
+  spec: {
+    name: string
+  }
   status?: {
     conditions: {
       lastTransitionTime?: string

--- a/frontend/src/routes/Applications/Application.sharedmocks.tsx
+++ b/frontend/src/routes/Applications/Application.sharedmocks.tsx
@@ -68,9 +68,10 @@ export const gitOpsOperator: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'openshift-gitops-operator',
+    name: 'openshift-gitops',
     namespace: 'openshift-operators',
   },
+  spec: { name: 'openshift-gitops-operator' },
   status: {
     conditions: [
       {
@@ -82,7 +83,6 @@ export const gitOpsOperator: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 export const mockApplication0: Application = {

--- a/frontend/src/routes/Governance/governance.sharedMocks.tsx
+++ b/frontend/src/routes/Governance/governance.sharedMocks.tsx
@@ -790,9 +790,10 @@ export const mockSubscriptionOperator: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'ansible-automation-platform-operator',
+    name: 'aap',
     namespace: 'ansible-automation-platform-operator',
   },
+  spec: { name: 'ansible-automation-platform-operator' },
   status: {
     conditions: [
       {
@@ -804,7 +805,6 @@ export const mockSubscriptionOperator: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 export const mockPolicyAutomation: PolicyAutomation = {

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomations.test.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomations.test.tsx
@@ -129,9 +129,10 @@ const subscriptionOperator: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'ansible-automation-platform-operator',
+    name: 'aap',
     namespace: 'ansible-automation-platform-operator',
   },
+  spec: { name: 'ansible-automation-platform-operator' },
   status: {
     conditions: [
       {
@@ -143,7 +144,6 @@ const subscriptionOperator: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 const clusterCurators = [clusterCurator1, clusterCurator2]

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
@@ -178,9 +178,10 @@ const mockSubscriptionOperator: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'ansible-automation-platform-operator',
+    name: 'aap',
     namespace: 'ansible-automation-platform-operator',
   },
+  spec: { name: 'ansible-automation-platform-operator' },
   status: {
     conditions: [
       {
@@ -192,7 +193,6 @@ const mockSubscriptionOperator: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 describe('add automation template page', () => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
@@ -661,9 +661,10 @@ const subscriptionOperator: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'ansible-automation-platform-operator',
+    name: 'aap',
     namespace: 'ansible-automation-platform-operator',
   },
+  spec: { name: 'ansible-automation-platform-operator' },
   status: {
     conditions: [
       {
@@ -675,7 +676,6 @@ const subscriptionOperator: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 const mockPullSecretKubevirt: Secret = {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -646,9 +646,10 @@ const subscriptionOperator: SubscriptionOperator = {
   apiVersion: SubscriptionOperatorApiVersion,
   kind: SubscriptionOperatorKind,
   metadata: {
-    name: 'ansible-automation-platform-operator',
+    name: 'aap',
     namespace: 'ansible-automation-platform-operator',
   },
+  spec: { name: 'ansible-automation-platform-operator' },
   status: {
     conditions: [
       {
@@ -660,7 +661,6 @@ const subscriptionOperator: SubscriptionOperator = {
       },
     ],
   },
-  spec: {},
 }
 
 const mockClusterCurators = [clusterCurator]

--- a/frontend/src/selectors.ts
+++ b/frontend/src/selectors.ts
@@ -95,7 +95,7 @@ const findInstalledSubscription = (name: string, get: GetRecoilValue) => {
   const subscriptionOperators = get(subscriptionOperatorsState)
   return subscriptionOperators.filter(
     (op) =>
-      op.metadata.name === name &&
+      op.spec.name === name &&
       op?.status?.conditions?.find((c) => c.type === 'CatalogSourcesUnhealthy')?.status === 'False'
   )
 }


### PR DESCRIPTION
Name of the subscription could vary depending on how subscription is installed on clusters (i.e. using custom automation rather than OperatorHub UI install).

https://issues.redhat.com/browse/ACM-18820