### PR TITLE
Update base image for Konflux builds

### DIFF
--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:acm
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm
 
-FROM brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent:v2.10.0_20-44
+FROM brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent:v2.10.0_20-49
 
 WORKDIR /app
 ENV NODE_ENV production

--- a/Containerfile.mce.konflux
+++ b/Containerfile.mce.konflux
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:mce
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm
 
-FROM brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent:v2.10.0_20-44
+FROM brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent:v2.10.0_20-49
 
 WORKDIR /app
 ENV NODE_ENV production


### PR DESCRIPTION
Update to brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent:v2.10.0_20-49