### PR TITLE
OpenShiftSDN is not supported OpenShift 4.15 and later

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -367,7 +367,7 @@ export const onImageChange = (control, controlData) => {
   if (networkDefault) {
     const { setActive } = networkDefault
     const { active: version } = control
-    if (versionGreater(version, 4, 16)) {
+    if (versionGreater(version, 4, 14)) {
       networkDefault.type = 'text'
       networkDefault.active = 'OVNKubernetes'
       networkDefault.disabled = true


### PR DESCRIPTION
**Description:**
For [Ticket](https://issues.redhat.com/browse/ACM-19117)
Disabling openshiftsdn for Openshift 4.14+.