### PR TITLE
ACM-19723 Disable upgrade for managed HCP clusters

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -407,7 +407,7 @@ export function DistributionField(props: {
         </span>
       </>
     )
-  } else if ((props.cluster?.isHostedCluster || props.cluster?.isHypershift) && isUpdateAvailable) {
+  } else if (props.cluster?.isHypershift && isUpdateAvailable) {
     // UPGRADE AVAILABLE HYPERSHIFT
 
     return (

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.ts
@@ -63,7 +63,8 @@ export function clusterSupportsAction(
       return (
         !!cluster.name &&
         cluster.status === ClusterStatus.ready &&
-        (!!cluster.distribution?.upgradeInfo?.isReadyUpdates || (cluster.isHostedCluster && isHypershiftUpdatesReady))
+        ((!!cluster.distribution?.upgradeInfo?.isReadyUpdates && !cluster?.isHostedCluster) ||
+          (cluster.isHypershift && isHypershiftUpdatesReady))
       )
     case ClusterAction.SelectChannel:
       return (


### PR DESCRIPTION
https://issues.redhat.com/browse/ACM-19723

Small logic errors were causing us to offer hypershift upgrade for clusters where the HostedCluster resource is not actually present on the hub, such as a managed HCP cluster (ROSA HCP) imported to ACM.