### PR TITLE
ACM-19511 Ansible Automation template next button disabling

### DIFF
--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -124,7 +124,8 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
 
   const { editorTitle, schema, secrets, immutables, formData, globalWizardAlert, hideYaml, isModalWizard } = props
   const [showFormErrors, setShowFormErrors] = useState(false)
-  const showErrors = showFormErrors
+  const showFieldErrors = showFormErrors || (formData.showErrors ?? false)
+  const showGlobalErrors = showFormErrors
 
   const mode = props.mode ?? 'form'
   const isHorizontal = props.isHorizontal ?? false
@@ -214,7 +215,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                 <AcmDataForm
                   {...props}
                   mode={mode}
-                  showFormErrors={showErrors}
+                  showFormErrors={mode === 'wizard' ? showFormErrors : showFieldErrors}
                   setShowFormErrors={setShowFormErrors}
                   isHorizontal={isHorizontal}
                   globalWizardAlert={globalWizardAlert}
@@ -226,7 +227,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                 <AcmDataForm
                   {...props}
                   mode={mode}
-                  showFormErrors={showErrors}
+                  showFormErrors={showFieldErrors}
                   setShowFormErrors={setShowFormErrors}
                   isHorizontal={isHorizontal}
                 />
@@ -277,7 +278,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                   )
                 }
               />
-              {showErrors && mode === 'form' && formHasErrors(t, formData) && (
+              {showGlobalErrors && mode === 'form' && formHasErrors(t, formData) && (
                 <PageSection variant="light" style={{ paddingTop: 0 }}>
                   <AlertGroup>
                     {formHasRequiredErrors(formData) ? (

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -124,7 +124,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
 
   const { editorTitle, schema, secrets, immutables, formData, globalWizardAlert, hideYaml, isModalWizard } = props
   const [showFormErrors, setShowFormErrors] = useState(false)
-  const showErrors = props.mode === 'wizard' ? showFormErrors : formData.showErrors ?? false
+  const showErrors = showFormErrors
 
   const mode = props.mode ?? 'form'
   const isHorizontal = props.isHorizontal ?? false

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -124,6 +124,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
 
   const { editorTitle, schema, secrets, immutables, formData, globalWizardAlert, hideYaml, isModalWizard } = props
   const [showFormErrors, setShowFormErrors] = useState(false)
+  const showErrors = formData.showErrors || showFormErrors
 
   const mode = props.mode ?? 'form'
   const isHorizontal = props.isHorizontal ?? false
@@ -213,7 +214,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                 <AcmDataForm
                   {...props}
                   mode={mode}
-                  showFormErrors={showFormErrors}
+                  showFormErrors={showErrors}
                   setShowFormErrors={setShowFormErrors}
                   isHorizontal={isHorizontal}
                   globalWizardAlert={globalWizardAlert}
@@ -225,7 +226,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                 <AcmDataForm
                   {...props}
                   mode={mode}
-                  showFormErrors={showFormErrors}
+                  showFormErrors={showErrors}
                   setShowFormErrors={setShowFormErrors}
                   isHorizontal={isHorizontal}
                 />
@@ -276,7 +277,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                   )
                 }
               />
-              {showFormErrors && mode === 'form' && formHasErrors(t, formData) && (
+              {showErrors && mode === 'form' && formHasErrors(t, formData) && (
                 <PageSection variant="light" style={{ paddingTop: 0 }}>
                   <AlertGroup>
                     {formHasRequiredErrors(formData) ? (

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -124,7 +124,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
 
   const { editorTitle, schema, secrets, immutables, formData, globalWizardAlert, hideYaml, isModalWizard } = props
   const [showFormErrors, setShowFormErrors] = useState(false)
-  const showErrors = formData.showErrors || showFormErrors
+  const showErrors = props.mode === 'wizard' ? showFormErrors : formData.showErrors ?? false
 
   const mode = props.mode ?? 'form'
   const isHorizontal = props.isHorizontal ?? false

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -588,6 +588,7 @@ export function AcmDataFormWizard(props: {
                   }}
                   isDisabled={
                     ((showFormErrors || showSectionErrors[section.title]) && sectionHasErrors(t, section)) ||
+                    formData.disableNext ||
                     isSubmitting
                   }
                 >

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -588,7 +588,6 @@ export function AcmDataFormWizard(props: {
                   }}
                   isDisabled={
                     ((showFormErrors || showSectionErrors[section.title]) && sectionHasErrors(t, section)) ||
-                    formData.disableNext ||
                     isSubmitting
                   }
                 >

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -123,9 +123,9 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
   const { t } = useTranslation()
 
   const { editorTitle, schema, secrets, immutables, formData, globalWizardAlert, hideYaml, isModalWizard } = props
-  const [showFormErrors, setShowFormErrors] = useState(false)
-  const showFieldErrors = showFormErrors || (formData.showErrors ?? false)
-  const showGlobalErrors = showFormErrors
+  const [internalShowFormErrors, setShowFormErrors] = useState(false)
+  // showFormErrors is true once validation starts or is forced for async validation
+  const showFormErrors = formData.showErrors || internalShowFormErrors
 
   const mode = props.mode ?? 'form'
   const isHorizontal = props.isHorizontal ?? false
@@ -215,7 +215,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                 <AcmDataForm
                   {...props}
                   mode={mode}
-                  showFormErrors={mode === 'wizard' ? showFormErrors : showFieldErrors}
+                  showFormErrors={showFormErrors}
                   setShowFormErrors={setShowFormErrors}
                   isHorizontal={isHorizontal}
                   globalWizardAlert={globalWizardAlert}
@@ -227,7 +227,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                 <AcmDataForm
                   {...props}
                   mode={mode}
-                  showFormErrors={showFieldErrors}
+                  showFormErrors={showFormErrors}
                   setShowFormErrors={setShowFormErrors}
                   isHorizontal={isHorizontal}
                 />
@@ -278,7 +278,7 @@ export function AcmDataFormPage(props: AcmDataFormProps): JSX.Element {
                   )
                 }
               />
-              {showGlobalErrors && mode === 'form' && formHasErrors(t, formData) && (
+              {showFormErrors && mode === 'form' && formHasErrors(t, formData) && (
                 <PageSection variant="light" style={{ paddingTop: 0 }}>
                   <AlertGroup>
                     {formHasRequiredErrors(formData) ? (

--- a/frontend/src/components/AcmFormData.ts
+++ b/frontend/src/components/AcmFormData.ts
@@ -14,6 +14,7 @@ export interface FormData {
   cancel: () => void
   back?: () => void
   submitText: string
+  disableNext?: boolean
   submittingText: string
   reviewTitle: string
   reviewDescription: string

--- a/frontend/src/components/AcmFormData.ts
+++ b/frontend/src/components/AcmFormData.ts
@@ -14,7 +14,7 @@ export interface FormData {
   cancel: () => void
   back?: () => void
   submitText: string
-  disableNext?: boolean
+  showErrors?: boolean
   submittingText: string
   reviewTitle: string
   reviewDescription: string

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -126,14 +126,13 @@ export function AnsibleAutomationsForm(props: {
 }) {
   const { t } = useTranslation()
   const { ansibleCredentials, clusterCurator, isEditing, isViewing } = props
-
   const { settingsState } = useSharedAtoms()
   const settings = useRecoilValue(settingsState)
   const { clusterCuratorSupportedCurationsValue } = useSharedSelectors()
   const supportedCurations = useRecoilValue(clusterCuratorSupportedCurationsValue)
 
   const navigate = useNavigate()
-  const [nextDisabled, setNextDisabled] = useState(false)
+  const [forceErrors] = useState(false)
   const [editAnsibleJob, setEditAnsibleJob] = useState<ClusterCuratorAnsibleJob | undefined>()
   const [editAnsibleJobList, setEditAnsibleJobList] = useState<{
     jobs: ClusterCuratorAnsibleJob[]
@@ -196,7 +195,6 @@ export function AnsibleAutomationsForm(props: {
     setAnsibleTowerJobTemplateList([])
     setAnsibleTowerWorkflowTemplateList([])
     setAnsibleTowerInventoryList([])
-    setNextDisabled(false)
 
     if (ansibleSelection) {
       const selectedCred = ansibleCredentials.find((credential) => credential.metadata.name === ansibleSelection)
@@ -249,7 +247,7 @@ export function AnsibleAutomationsForm(props: {
             ? t('validate.ansible.reason', { reason: err.reason })
             : t('validate.ansible.host')
         )
-        setNextDisabled(true)
+
         // clear lists again in case only some requests failed
         setAnsibleTowerJobTemplateList([])
         setAnsibleTowerWorkflowTemplateList([])
@@ -462,6 +460,7 @@ export function AnsibleAutomationsForm(props: {
   const handleModalToggle = () => {
     setIsModalOpen(!isModalOpen)
   }
+
   const formData: FormData = {
     title: isEditing ? t('template.edit.title') : t('template.create.title'),
     titleTooltip: isEditing ? t('template.edit.tooltip') : t('template.create.tooltip'),
@@ -506,9 +505,8 @@ export function AnsibleAutomationsForm(props: {
             footer: <CreateCredentialModal handleModalToggle={handleModalToggle} />,
             isDisabled: isEditing,
             validation: () => {
-              if (AnsibleTowerAuthError) return AnsibleTowerAuthError
+              return AnsibleTowerAuthError || undefined
             },
-            validate: !!AnsibleTowerAuthError,
           },
           {
             id: 'Inventory',
@@ -746,7 +744,7 @@ export function AnsibleAutomationsForm(props: {
         ],
       },
     ],
-    disableNext: nextDisabled,
+    showErrors: forceErrors,
     submit: () => {
       if (isEditing) {
         return replaceResource(stateToData() as IResource).promise.then(async () => {

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -132,7 +132,7 @@ export function AnsibleAutomationsForm(props: {
   const supportedCurations = useRecoilValue(clusterCuratorSupportedCurationsValue)
 
   const navigate = useNavigate()
-  const [forceErrors] = useState(false)
+  const [forceErrors, setForceErrors] = useState(false)
   const [editAnsibleJob, setEditAnsibleJob] = useState<ClusterCuratorAnsibleJob | undefined>()
   const [editAnsibleJobList, setEditAnsibleJobList] = useState<{
     jobs: ClusterCuratorAnsibleJob[]
@@ -247,7 +247,7 @@ export function AnsibleAutomationsForm(props: {
             ? t('validate.ansible.reason', { reason: err.reason })
             : t('validate.ansible.host')
         )
-
+        setForceErrors(true)
         // clear lists again in case only some requests failed
         setAnsibleTowerJobTemplateList([])
         setAnsibleTowerWorkflowTemplateList([])

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -133,6 +133,7 @@ export function AnsibleAutomationsForm(props: {
   const supportedCurations = useRecoilValue(clusterCuratorSupportedCurationsValue)
 
   const navigate = useNavigate()
+  const [nextDisabled, setNextDisabled] = useState(false)
   const [editAnsibleJob, setEditAnsibleJob] = useState<ClusterCuratorAnsibleJob | undefined>()
   const [editAnsibleJobList, setEditAnsibleJobList] = useState<{
     jobs: ClusterCuratorAnsibleJob[]
@@ -195,6 +196,7 @@ export function AnsibleAutomationsForm(props: {
     setAnsibleTowerJobTemplateList([])
     setAnsibleTowerWorkflowTemplateList([])
     setAnsibleTowerInventoryList([])
+    setNextDisabled(false)
 
     if (ansibleSelection) {
       const selectedCred = ansibleCredentials.find((credential) => credential.metadata.name === ansibleSelection)
@@ -247,6 +249,7 @@ export function AnsibleAutomationsForm(props: {
             ? t('validate.ansible.reason', { reason: err.reason })
             : t('validate.ansible.host')
         )
+        setNextDisabled(true)
         // clear lists again in case only some requests failed
         setAnsibleTowerJobTemplateList([])
         setAnsibleTowerWorkflowTemplateList([])
@@ -743,6 +746,7 @@ export function AnsibleAutomationsForm(props: {
         ],
       },
     ],
+    disableNext: nextDisabled,
     submit: () => {
       if (isEditing) {
         return replaceResource(stateToData() as IResource).promise.then(async () => {

--- a/frontend/src/routes/Search/SearchPage.test.tsx
+++ b/frontend/src/routes/Search/SearchPage.test.tsx
@@ -236,7 +236,7 @@ describe('SearchPage', () => {
 
     // Test that the component has rendered correctly with data
     await waitFor(() => expect(screen.queryByText('Open new search tab')).toBeTruthy())
-    await waitFor(() => expect(screen.getAllByText('Saved searches')[1]).toBeTruthy())
+    await waitFor(() => expect(screen.getAllByText('Saved searches').length).toBeGreaterThan(0))
 
     // Validate that message about disabled cluster doesn't appear.
     await waitFor(() => expect(screen.queryByText('More on disabled clusters')).toBeFalsy())


### PR DESCRIPTION
## Description
This PR is for bug [ticket](https://issues.redhat.com/browse/ACM-19511) 

## Acceptance Criteria
- [x] Automation Template Wizard Next Button Disabling
- [x] Unit test - should disable the Next button when an invalid credential is selected