### PR TITLE
Add the ConstraintTemplates link row to policy details page

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetails.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetails.tsx
@@ -25,7 +25,12 @@ import { useTemplateDetailsContext } from './PolicyTemplateDetailsPage'
 import { useParams } from 'react-router-dom-v5-compat'
 import { getEngineWithSvg } from '../../../common/util'
 import { useFetchKyvernoRelated, useFetchVapb, useFetchOnlyRelatedResources } from './PolicyTemplateDetailHooks'
-import { addRowsForHasVapb, addRowsForOperatorPolicy, addRowsForVapb } from './PolicyTemplateDetailsColumns'
+import {
+  addRowsForConstraint,
+  addRowsForHasVapb,
+  addRowsForOperatorPolicy,
+  addRowsForVapb,
+} from './PolicyTemplateDetailsColumns'
 import { KyvernoRelatedResources } from './KyvernoRelatedResources'
 
 export function PolicyTemplateDetails() {
@@ -148,6 +153,8 @@ export function PolicyTemplateDetails() {
         ...cols.slice(1),
       ]
     }
+
+    addRowsForConstraint(cols, clusterName, apiGroup, kind)
 
     addRowsForHasVapb(cols, hasVapb, vapb.loading, vapb.vapbItems, apiGroup, clusterName, name)
 

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsColumns.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsColumns.tsx
@@ -52,6 +52,24 @@ export const addRowsForHasVapb = (
   }
 }
 
+export const addRowsForConstraint = (cols: ListItems[], clusterName: string, apiGroup: string, kind: string) => {
+  // Gatekeeper mutation should not have this row
+  if (apiGroup === 'constraints.gatekeeper.sh') {
+    cols.push({
+      key: 'Constraint Template',
+      value: (
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href={`${NavigationPath.resourceYAML}?cluster=${clusterName}&kind=ConstraintTemplate&apiversion=templates.gatekeeper.sh%2Fv1&name=${kind.toLowerCase()}`}
+        >
+          {kind.toLowerCase()} <ExternalLinkAltIcon style={{ verticalAlign: '-0.125em', marginLeft: '8px' }} />
+        </a>
+      ),
+    })
+  }
+}
+
 export const addRowsForVapb = (cols: ListItems[], template: any, clusterName: string, kind: string) => {
   if (kind !== 'ValidatingAdmissionPolicyBinding') {
     return

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsPage.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsPage.test.tsx
@@ -830,6 +830,14 @@ describe('Policy Template Details Page', () => {
       `/multicloud/search/resources/yaml?cluster=test-cluster&kind=Namespace&apiversion=v1&name=default-broker`
     )
 
+    await waitForText('Constraint Template')
+    const constraintTempalteLink = screen.getByRole('link', {
+      name: 'k8srequiredlabels',
+    })
+    expect(constraintTempalteLink.getAttribute('href')).toEqual(
+      `/multicloud/search/resources/yaml?cluster=test-cluster&kind=ConstraintTemplate&apiversion=templates.gatekeeper.sh%2Fv1&name=k8srequiredlabels`
+    )
+
     // Verify the generated ValidatingAdmissionPolicyBinding
     await waitForText('gatekeeper-ns-must-have-gk')
     await waitForText('Validating Admission Policy Binding')


### PR DESCRIPTION
The VAP link is already present in the VAPB detail page, so this commit only adds the ConstraintTemplate link to the constraint detail page 
<img width="1166" alt="Screenshot 2025-04-15 at 2 20 40 PM" src="https://github.com/user-attachments/assets/6e89d1d3-1790-4c86-a202-c0f23ac86e2b" />

Ref: https://issues.redhat.com/browse/ACM-17884 (feature)
Ref: https://issues.redhat.com/browse/ACM-20056
Signed-off-by: yiraeChristineKim <yikim@redhat.com>