### PR TITLE
ACM-20165 - Applications page breaks when <HighlightSearchText/> returns undefined.

### DIFF
--- a/frontend/src/components/HighlightSearchText.test.tsx
+++ b/frontend/src/components/HighlightSearchText.test.tsx
@@ -1,0 +1,39 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { render } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import { HighlightSearchText } from './HighlightSearchText'
+
+const highlightCssClass = 'css-uh6mpl' // Example class name for highlighted text
+describe('HighlightSearchText', () => {
+  it('should render highlighted text when searchText matches part of the text', () => {
+    render(<HighlightSearchText text="key=value" searchText="key" />)
+    expect(screen.getByText('key')).toHaveClass(highlightCssClass)
+    expect(screen.getByText('=value')).not.toHaveClass(highlightCssClass)
+  })
+
+  it('should render the full text without highlights when searchText is empty', () => {
+    render(<HighlightSearchText text="key=value" searchText="" />)
+    expect(screen.getByText('key=value')).not.toHaveClass(highlightCssClass)
+  })
+
+  it('should render a toggle button when supportsInequality is true', () => {
+    render(<HighlightSearchText text="key=value" supportsInequality={true} toggleEquality={() => {}} />)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('should truncate the text when isTruncate is true and text exceeds max length', () => {
+    const { container } = render(<HighlightSearchText text="very-very-very-long-key=value" isTruncate={true} />)
+    console.log(container.innerHTML)
+    expect(screen.getByText('very-very..ery-long-key=value')).toBeInTheDocument()
+  })
+
+  it('should render the full text when isTruncate is false', () => {
+    render(<HighlightSearchText text="key=value" isTruncate={false} />)
+    expect(screen.getByText('key=value')).toBeInTheDocument()
+  })
+
+  it('should render null when no text is provided', () => {
+    const { container } = render(<HighlightSearchText />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/frontend/src/components/HighlightSearchText.tsx
+++ b/frontend/src/components/HighlightSearchText.tsx
@@ -54,11 +54,11 @@ export function HighlightSearchText(
       </>
     )
   } else if (isTruncate) {
-    return truncate(text)
+    return truncate(text) ?? null
   } else if (supportsInequality && text) {
     return renderToggleButton(text, toggleEquality)
   }
-  return text
+  return text ?? null
 }
 
 const renderToggleButton = (label: string, toggleEquality: MouseEventHandler<HTMLButtonElement> | undefined) => {


### PR DESCRIPTION
Regarding: https://issues.redhat.com/browse/ACM-20165
Slack: https://redhat-internal.slack.com/archives/C027TN14SGJ/p1744904020464789