### PR TITLE
[ACM-20349] New base and builder images

### DIFF
--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-20-minimal:1-63.1726695170 AS builder
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf AS builder
 
 USER root
 ENV NPM_CONFIG_NODEDIR=/usr
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:acm
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm
 
-FROM brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent:v2.10.0_20-49
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf
 
 WORKDIR /app
 ENV NODE_ENV production

--- a/Containerfile.mce.konflux
+++ b/Containerfile.mce.konflux
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/nodejs-20-minimal:1-63.1726695170 AS builder
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf AS builder
 
 USER root
 ENV NPM_CONFIG_NODEDIR=/usr
@@ -16,7 +16,7 @@ RUN cd frontend && npm run build:plugin:mce
 # Remove build-time dependencies before packaging
 RUN cd backend && npm ci --omit=optional --only=production --unsafe-perm
 
-FROM brew.registry.redhat.io/rh-osbs/rhacm2-nodejs-parent:v2.10.0_20-49
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf
 
 WORKDIR /app
 ENV NODE_ENV production

--- a/Dockerfile.mce.prow
+++ b/Dockerfile.mce.prow
@@ -1,23 +1,23 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:nodejs20-linux as dynamic-plugin
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf as dynamic-plugin
 WORKDIR /app/frontend
 COPY ./frontend .
 RUN npm ci --legacy-peer-deps
 RUN npm run build:plugin:mce
 
-FROM registry.ci.openshift.org/stolostron/builder:nodejs20-linux as backend
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf as backend
 WORKDIR /app/backend
 COPY ./backend .
 RUN npm ci --omit=optional
 RUN npm run build
 
-FROM registry.ci.openshift.org/stolostron/builder:nodejs20-linux as production
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf as production
 WORKDIR /app/backend
 COPY ./backend/package-lock.json ./backend/package.json ./
 RUN npm ci --omit=optional --only=production
 
-FROM registry.ci.openshift.org/stolostron/common-nodejs-parent:nodejs-20
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf
 WORKDIR /app
 ENV NODE_ENV production
 COPY --from=production /app/backend/node_modules ./node_modules

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:nodejs20-linux as frontend-packages
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf as frontend-packages
 WORKDIR /app/frontend
 # Copy only package.json and package-lock.json so that the docker cache hash only changes if those change
 # This will cause the npm ci to only rerun if the package.json or package-lock.json changes
@@ -11,7 +11,7 @@ COPY ./frontend .
 FROM frontend-packages as dynamic-plugin
 RUN npm run build:plugin:acm
 
-FROM registry.ci.openshift.org/stolostron/builder:nodejs20-linux as backend
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf as backend
 WORKDIR /app/backend
 # Copy only package.json and package-lock.json so that the docker layer cache only changes if those change
 # This will cause the npm ci to only rerun if the package.json or package-lock.json changes
@@ -20,12 +20,12 @@ RUN npm ci --omit=optional
 COPY ./backend .
 RUN npm run build
 
-FROM registry.ci.openshift.org/stolostron/builder:nodejs20-linux as production
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf as production
 WORKDIR /app/backend
 COPY ./backend/package-lock.json ./backend/package.json ./
 RUN npm ci --omit=optional --only=production
 
-FROM registry.ci.openshift.org/stolostron/common-nodejs-parent:nodejs-20
+FROM registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf
 WORKDIR /app
 ENV NODE_ENV production
 COPY --from=production /app/backend/node_modules ./node_modules


### PR DESCRIPTION
# 📝 Summary

Updates both the Prow and Konflux container files to use the standard Red Hat nodejs-20-minimal image as both builder and base.

https://catalog.redhat.com/software/containers/ubi9/nodejs-20-minimal/64770ddd0e699534bb564b3b

registry.redhat.io/ubi9/nodejs-20-minimal@sha256:25be11c4ded58e78cfb268fe34cb41d63bad6fe674c64b8fa72b9a39a54670bf corresponds to tag 9.5-1742935170

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-20349

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [x] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
I tested by taking the PR images from Prow and updating the `weekly` cluster to use them. 