### PR TITLE
ACM-20353 Remove OAuth check from liveness/readiness

### DIFF
--- a/backend/src/routes/liveness.ts
+++ b/backend/src/routes/liveness.ts
@@ -4,19 +4,16 @@ import { FetchError } from 'node-fetch'
 import { fetchRetry } from '../lib/fetch-retry'
 import { logger } from '../lib/logger'
 import { respondInternalServerError, respondOK } from '../lib/respond'
-import { getOauthInfoPromise } from './oauth'
 import { getServiceAccountToken } from '../lib/serviceAccountToken'
 const { HTTP2_HEADER_AUTHORIZATION } = constants
 
 // The kubelet uses liveness probes to know when to restart a container.
 export function liveness(req: Http2ServerRequest, res: Http2ServerResponse): void {
-  if (!isLive) return respondInternalServerError(req, res)
-  getOauthInfoPromise()
-    .then((oauthInfo) => {
-      if (!oauthInfo.authorization_endpoint) return respondInternalServerError(req, res)
-      respondOK(req, res)
-    })
-    .catch(() => respondInternalServerError(req, res))
+  if (!isLive) {
+    respondInternalServerError(req, res)
+  } else {
+    respondOK(req, res)
+  }
 }
 
 export let isLive = true

--- a/backend/src/routes/readiness.ts
+++ b/backend/src/routes/readiness.ts
@@ -2,12 +2,12 @@
 import { Http2ServerRequest, Http2ServerResponse } from 'http2'
 import { respondInternalServerError, respondOK } from '../lib/respond'
 import { isLive } from './liveness'
-import { getOauthInfoPromise } from './oauth'
 
 // The kubelet uses readiness probes to know when a container is ready to start accepting traffic
-export async function readiness(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
-  if (!isLive) return respondInternalServerError(req, res)
-  const oauthInfo = await getOauthInfoPromise()
-  if (!oauthInfo.authorization_endpoint) return respondInternalServerError(req, res)
-  return respondOK(req, res)
+export function readiness(req: Http2ServerRequest, res: Http2ServerResponse): void {
+  if (!isLive) {
+    respondInternalServerError(req, res)
+  } else {
+    respondOK(req, res)
+  }
 }

--- a/backend/test/routes/liveness.test.ts
+++ b/backend/test/routes/liveness.test.ts
@@ -5,9 +5,6 @@ import { apiServerPing } from '../../src/routes/liveness'
 
 describe(`liveness Route`, function () {
   it(`GET /livenessProbe should return status code 200`, async function () {
-    nock(process.env.CLUSTER_API_URL).get('/.well-known/oauth-authorization-server').reply(200, {
-      authorization_endpoint: 'https://oauth-openshift.apps.example.com/oauth/token',
-    })
     const res = await request('GET', '/livenessProbe')
     expect(res.statusCode).toEqual(200)
   })


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
ACM-20353 Remove OAuth check from liveness/readiness

The /.well-known/oauth-authorization-server is not available when OCP is configured with external authentication. This check was not really needed; it's a holdover from when console was a standalone app and needed to handle its own authentication. Now only used for the devlopment console, where the liveness/readiness probes do not apply.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-20353

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->