### PR TITLE
ACM-20377 AcmDropdown bug

### DIFF
--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
@@ -301,14 +301,31 @@ export function AcmDropdown(props: AcmDropdownProps) {
     [isOpen, toggleMenu]
   )
 
+  const handleWindowFocus = useCallback(() => {
+    if (isOpen) {
+      setOpen(false)
+    }
+  }, [isOpen])
+
+  const handleVisibilityChange = useCallback(() => {
+    // when tab becomes hidden (user switches tabs or apps), closes the dropdown
+    if (document.visibilityState === 'hidden' && isOpen) {
+      setOpen(false)
+    }
+  }, [isOpen])
+
   useEffect(() => {
     window.addEventListener('keydown', handleMenuKeys)
     window.addEventListener('click', handleClickOutside)
+    window.addEventListener('focus', handleWindowFocus)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
     return () => {
       window.removeEventListener('keydown', handleMenuKeys)
       window.removeEventListener('click', handleClickOutside)
+      window.removeEventListener('focus', handleWindowFocus)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
-  }, [handleMenuKeys, handleClickOutside])
+  }, [handleMenuKeys, handleClickOutside, handleWindowFocus, handleVisibilityChange])
 
   let variant: 'default' | 'plain' | 'primary' | 'plainText' | 'secondary' | 'typeahead'
   if (isKebab) {
@@ -352,7 +369,7 @@ export function AcmDropdown(props: AcmDropdownProps) {
               ref={menuRef}
               menuItems={dropdownItems}
               onBlur={(e) => {
-                if (!e.currentTarget.contains(e.relatedTarget)) {
+                if (e.relatedTarget !== null && !e.currentTarget.contains(e.relatedTarget)) {
                   setOpen(false)
                 }
               }}

--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
@@ -16,7 +16,7 @@ import {
   PopperProps,
 } from '@patternfly/react-core'
 import { TooltipWrapper } from '../utils'
-import { forwardRef, useCallback, useEffect, useRef, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { EllipsisVIcon } from '@patternfly/react-icons'
 import { t } from 'i18next'
 
@@ -191,11 +191,6 @@ export function AcmDropdown(props: AcmDropdownProps) {
 
   const handleSelect = useCallback(
     (_event?: React.MouseEvent, itemId?: string | number) => {
-      // safety check
-      if (!menuRef.current || !document.body.contains(menuRef.current)) {
-        setOpen(false)
-        return
-      }
       const selectedItem = findItemById(dropdownItems, String(itemId))
 
       if (!itemId) return // prevents triggering if no itemId
@@ -205,9 +200,6 @@ export function AcmDropdown(props: AcmDropdownProps) {
 
       onSelect((itemId || '').toString())
       setOpen(false)
-
-      const element = document.getElementById(id)
-      if (element) element.focus()
     },
     [id, dropdownItems, findItemById, onSelect]
   )
@@ -301,31 +293,26 @@ export function AcmDropdown(props: AcmDropdownProps) {
     [isOpen, toggleMenu]
   )
 
-  const handleWindowFocus = useCallback(() => {
-    if (isOpen) {
-      setOpen(false)
-    }
-  }, [isOpen])
+  const containsFlyout = useMemo(() => dropdownItems.some((item) => item.flyoutMenu), [dropdownItems])
 
-  const handleVisibilityChange = useCallback(() => {
-    // when tab becomes hidden (user switches tabs or apps), closes the dropdown
-    if (document.visibilityState === 'hidden' && isOpen) {
+  const handleWindowFocus = useCallback(() => {
+    // Workaround for PF bug: https://github.com/patternfly/patternfly-react/issues/11802
+    // For flyout menus, when focus leaves the window, close the dropdown to avoid bug if user clicks flyout
+    if (containsFlyout && isOpen) {
       setOpen(false)
     }
-  }, [isOpen])
+  }, [containsFlyout, isOpen])
 
   useEffect(() => {
     window.addEventListener('keydown', handleMenuKeys)
     window.addEventListener('click', handleClickOutside)
     window.addEventListener('focus', handleWindowFocus)
-    document.addEventListener('visibilitychange', handleVisibilityChange)
     return () => {
       window.removeEventListener('keydown', handleMenuKeys)
       window.removeEventListener('click', handleClickOutside)
       window.removeEventListener('focus', handleWindowFocus)
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
     }
-  }, [handleMenuKeys, handleClickOutside, handleWindowFocus, handleVisibilityChange])
+  }, [handleMenuKeys, handleClickOutside, handleWindowFocus])
 
   let variant: 'default' | 'plain' | 'primary' | 'plainText' | 'secondary' | 'typeahead'
   if (isKebab) {
@@ -364,18 +351,7 @@ export function AcmDropdown(props: AcmDropdownProps) {
           enableFlip={true}
           minWidth="fit-content"
           placement={props.dropdownPosition ?? (isKebab ? 'bottom-end' : 'bottom-start')}
-          popper={
-            <MenuItems
-              ref={menuRef}
-              menuItems={dropdownItems}
-              onBlur={(e) => {
-                if (e.relatedTarget !== null && !e.currentTarget.contains(e.relatedTarget)) {
-                  setOpen(false)
-                }
-              }}
-              onSelect={handleSelect}
-            />
-          }
+          popper={<MenuItems ref={menuRef} menuItems={dropdownItems} onSelect={handleSelect} />}
         />
       </div>
     </TooltipWrapper>

--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
@@ -201,7 +201,7 @@ export function AcmDropdown(props: AcmDropdownProps) {
       onSelect((itemId || '').toString())
       setOpen(false)
     },
-    [id, dropdownItems, findItemById, onSelect]
+    [dropdownItems, findItemById, onSelect]
   )
 
   const handleToggleClick = useCallback(() => {

--- a/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
+++ b/frontend/src/ui-components/AcmDropdown/AcmDropdown.tsx
@@ -191,7 +191,7 @@ export function AcmDropdown(props: AcmDropdownProps) {
 
   const handleSelect = useCallback(
     (_event?: React.MouseEvent, itemId?: string | number) => {
-      // add this safety check
+      // safety check
       if (!menuRef.current || !document.body.contains(menuRef.current)) {
         setOpen(false)
         return


### PR DESCRIPTION
# 📝 Summary
**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
This PR fixes an issue where the AcmDropdown unexpectedly closes when the browser DevTools are opened. 

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-20377 -->
https://issues.redhat.com/browse/ACM-20377

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
## Changes
- Removes `onBlur` handler
- Added `handleWindowFocus` - for flyout menus, when focus leaves the window, close the dropdown to avoid a bug if the user clicks the flyout (Workaround for PF bug: https://github.com/patternfly/patternfly-react/issues/11802)

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference/errata)
- [ ] Fix tested thoroughly and resolve the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->