### PR TITLE
ACM-20685: Release images not displayed in console after creation of ClusterImageSet in Openshift virt cluster.

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -782,7 +782,7 @@ export const architectureData = (t) => {
 
 export const getName = ({ data }) => data.root.ai?.name ?? data.root.name
 
-const versionRegex = /release:([\d]{1,5})\.([\d]{1,5})\.([\d]{1,5})/
+const versionRegex = /:([\d]{1,5})\.([\d]{1,5})\.([\d]{1,5})/
 function versionGreater(version, x, y) {
   const matches = version.match(versionRegex)
   return matches && parseInt(matches[1], 10) >= x && parseInt(matches[2], 10) > y


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
Release images not displayed in console after creation of ClusterImageSet in Openshift virt cluster.
Issue is in the regex used in versionGreater function ControlDataHelpers.
Updating regex to: "/:([\d]{1,5})\.([\d]{1,5})\.([\d]{1,5})/"

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
[Ticket](https://issues.redhat.com/browse/ACM-20685)

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->