### PR TITLE
MGMT-19879: Binding-day-2-host-to-cluster-defaults-host-to-worker-role

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/utils.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/components/assisted-installer/utils.ts
@@ -626,6 +626,15 @@ export const onChangeBMHHostname = async (bmh: BareMetalHostK8sResource, hostnam
     },
   ]).promise as Promise<BareMetalHostK8sResource>
 
+export const onEditHostRole = async (agent: AgentK8sResource, role: string) =>
+  patchResource(agent as IResource, [
+    {
+      op: 'replace',
+      path: '/spec/role',
+      value: role,
+    },
+  ]).promise as Promise<AgentK8sResource>
+
 export const useAgentsOfAIFlow = ({ name, namespace }: { name: string; namespace: string }): AgentK8sResource[] => {
   const { agentsState } = useSharedAtoms()
   const agents = useRecoilValue(agentsState)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/ScaleUpDialog.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/ScaleUpDialog.tsx
@@ -6,6 +6,7 @@ import {
   onChangeHostname,
   onSetInstallationDiskId,
   onChangeBMHHostname,
+  onEditHostRole,
 } from '../../CreateCluster/components/assisted-installer/utils'
 import { useSharedAtoms, useRecoilValue } from '../../../../../../shared-recoil'
 import { IResource } from '../../../../../../resources'
@@ -50,7 +51,7 @@ const ScaleUpDialog = ({ isOpen, closeDialog, clusterName }: ScaleUpDialogProps)
           {
             op: 'replace',
             path: '/spec/role',
-            value: 'worker',
+            value: agent.spec?.role,
           },
         ]).promise
       })
@@ -76,6 +77,7 @@ const ScaleUpDialog = ({ isOpen, closeDialog, clusterName }: ScaleUpDialogProps)
       onChangeBMHHostname={onChangeBMHHostname}
       onSetInstallationDiskId={onSetInstallationDiskId}
       isNutanix={agentClusterInstall?.spec?.platformType === 'Nutanix'}
+      onEditHostRole={onEditHostRole}
     />
   )
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-19879
removed the default behavior that was setting the role for any added host to be worker.
added the option to edit the host role in the add hosts modal.



