### PR TITLE
ACM-20777 autoImport retry removal

### DIFF
--- a/frontend/src/components/usePrevious.tsx
+++ b/frontend/src/components/usePrevious.tsx
@@ -2,6 +2,15 @@
 
 import { useRef, useEffect } from 'react'
 
+/**
+ * Custom React hook that returns the previous value of a variable from the last render.
+ *
+ * @template T The type of the value being tracked
+ * @param {T} value The current value to compare against its previous state
+ * @returns {T} The value from the previous render cycle
+ *
+ */
+
 export function usePrevious<T>(value: T): T {
   const ref = useRef<T>()
   useEffect(() => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.test.tsx
@@ -240,7 +240,7 @@ const mockAutoSecretResponse: Secret = {
     name: 'auto-import-secret',
     namespace: 'foobar',
   },
-  data: { autoImportRetry: '2', kubeconfig: 'Test text' },
+  data: { kubeconfig: 'Test text' },
   type: 'Opaque',
 }
 
@@ -252,7 +252,6 @@ const mockAutoSecret: Secret = {
     namespace: 'foobar',
   },
   stringData: {
-    autoImportRetry: '2',
     kubeconfig: 'Test text',
   },
   type: 'Opaque',
@@ -265,7 +264,7 @@ const mockAutoTokenSecretResponse: Secret = {
     name: 'auto-import-secret',
     namespace: 'foobar',
   },
-  data: { autoImportRetry: '2', token: 'Test token', server: 'Test server' },
+  data: { token: 'Test token', server: 'Test server' },
   type: 'Opaque',
 }
 
@@ -277,7 +276,6 @@ const mockAutoTokenSecret: Secret = {
     namespace: 'foobar',
   },
   stringData: {
-    autoImportRetry: '2',
     token: 'Test token',
     server: 'Test server',
   },
@@ -291,7 +289,6 @@ const mockROSAAutoTokenSecretAPIToken: Secret = {
     namespace: 'rosa-discovery-cluster',
   },
   stringData: {
-    autoImportRetry: '2',
     cluster_id: '39ldt3r51vjjsho1eqntrg3m',
     auth_method: 'offline-token',
     api_token: 'fake_token',
@@ -307,7 +304,6 @@ const mockROSAAutoTokenSecretServiceAcc: Secret = {
     namespace: 'rosa-discovery-cluster',
   },
   stringData: {
-    autoImportRetry: '2',
     cluster_id: '39ldt3r51vjjsho1eqntrg3m',
     auth_method: 'service-account',
     client_id: 'fake_client_id1234',

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -881,8 +881,7 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
 
   if (prevImportMode !== importMode || prevCredential !== credential) {
     // Preserve anything added to the secret by the user, like annotations
-    const { ...currentAutoImportSecretRest } = getSecretTemplate() ?? {}
-    const newAutoImportSecret = { ...autoImportSecret, ...currentAutoImportSecretRest }
+    const newAutoImportSecret = { ...autoImportSecret, ...(getSecretTemplate() ?? {}), ...{ type: 'Opaque' } }
 
     switch (importMode) {
       case ImportMode.manual:

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -403,7 +403,6 @@ export default function ImportClusterPage() {
           namespace: initialClusterName,
         },
         stringData: {
-          autoImportRetry: '2',
           cluster_id: initialClusterID,
           auth_method: initialAuthMethod,
           api_token: initialAPIToken,
@@ -423,7 +422,6 @@ export default function ImportClusterPage() {
           namespace: initialClusterName,
         },
         stringData: {
-          autoImportRetry: '2',
           token: '',
           server: initialServer,
         },
@@ -790,9 +788,7 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
         name: AUTO_IMPORT_SECRET,
         namespace: clusterName,
       },
-      stringData: {
-        autoImportRetry: '2',
-      },
+      stringData: {},
       type: 'Opaque',
     }),
     [clusterName]
@@ -801,11 +797,10 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
   const updateROSAImportSecret = useCallback(
     (credentialName: string, discoverySecret: Secret) => {
       const selectedCredential = ocmCredentials.find((credential) => credential.metadata.name === credentialName)
-      const authMethod = selectedCredential?.stringData?.auth_method || 'offline-token'
+      const authMethod = selectedCredential?.stringData?.auth_method ?? 'offline-token'
       // Updating the discovery secret based on the auth_method
       if (authMethod === 'service-account') {
         discoverySecret.stringData = {
-          ...discoverySecret.stringData,
           cluster_id: clusterID,
           auth_method: 'service-account',
           client_id: selectedCredential?.stringData?.client_id ?? '',
@@ -813,7 +808,6 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
         }
       } else if (authMethod === 'offline-token') {
         discoverySecret.stringData = {
-          ...discoverySecret.stringData,
           cluster_id: clusterID,
           auth_method: 'offline-token',
           api_token: selectedCredential?.stringData?.ocmAPIToken ?? '',
@@ -886,11 +880,9 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
   if (prevImportMode !== importMode || prevCredential !== credential) {
     // Preserve anything added to the secret by the user, like annotations
     // For the stringData, preserve only changes to the autoImportRetry count
-    const {
-      stringData: { autoImportRetry = autoImportSecret?.stringData?.autoImportRetry ?? '' } = {},
-      ...currentAutoImportSecretRest
-    } = getSecretTemplate() ?? {}
-    const newAutoImportSecret = { ...autoImportSecret, stringData: { autoImportRetry }, ...currentAutoImportSecretRest }
+    const { ...currentAutoImportSecretRest } = getSecretTemplate() ?? {}
+    const newAutoImportSecret = { ...autoImportSecret, ...currentAutoImportSecretRest }
+
     switch (importMode) {
       case ImportMode.manual:
         // Delete auto-import secret
@@ -898,13 +890,13 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
         break
       case ImportMode.kubeconfig: {
         // Insert/Replace auto-import secret
-        newAutoImportSecret.stringData = { ...newAutoImportSecret.stringData, kubeconfig }
+        newAutoImportSecret.stringData = { kubeconfig }
         replaceSecretTemplate(newAutoImportSecret)
         break
       }
       case ImportMode.token: {
         // Insert/Replace auto-import secret
-        newAutoImportSecret.stringData = { ...newAutoImportSecret.stringData, token, server }
+        newAutoImportSecret.stringData = { token, server }
         replaceSecretTemplate(newAutoImportSecret)
         break
       }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -405,7 +405,6 @@ export default function ImportClusterPage() {
           namespace: initialClusterName,
         },
         stringData: {
-          autoImportRetry: '2',
           cluster_id: initialClusterID,
           auth_method: initialAuthMethod,
           api_token: initialAPIToken,
@@ -425,7 +424,6 @@ export default function ImportClusterPage() {
           namespace: initialClusterName,
         },
         stringData: {
-          autoImportRetry: '2',
           token: '',
           server: initialServer,
         },
@@ -792,9 +790,7 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
         name: AUTO_IMPORT_SECRET,
         namespace: clusterName,
       },
-      stringData: {
-        autoImportRetry: '2',
-      },
+      stringData: {},
       type: 'Opaque',
     }),
     [clusterName]
@@ -803,11 +799,10 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
   const updateROSAImportSecret = useCallback(
     (credentialName: string, discoverySecret: Secret) => {
       const selectedCredential = ocmCredentials.find((credential) => credential.metadata.name === credentialName)
-      const authMethod = selectedCredential?.stringData?.auth_method || 'offline-token'
+      const authMethod = selectedCredential?.stringData?.auth_method ?? 'offline-token'
       // Updating the discovery secret based on the auth_method
       if (authMethod === 'service-account') {
         discoverySecret.stringData = {
-          ...discoverySecret.stringData,
           cluster_id: clusterID,
           auth_method: 'service-account',
           client_id: selectedCredential?.stringData?.client_id ?? '',
@@ -815,7 +810,6 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
         }
       } else if (authMethod === 'offline-token') {
         discoverySecret.stringData = {
-          ...discoverySecret.stringData,
           cluster_id: clusterID,
           auth_method: 'offline-token',
           api_token: selectedCredential?.stringData?.ocmAPIToken ?? '',
@@ -887,12 +881,9 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
 
   if (prevImportMode !== importMode || prevCredential !== credential) {
     // Preserve anything added to the secret by the user, like annotations
-    // For the stringData, preserve only changes to the autoImportRetry count
-    const {
-      stringData: { autoImportRetry = autoImportSecret?.stringData?.autoImportRetry ?? '' } = {},
-      ...currentAutoImportSecretRest
-    } = getSecretTemplate() ?? {}
-    const newAutoImportSecret = { ...autoImportSecret, stringData: { autoImportRetry }, ...currentAutoImportSecretRest }
+    const { ...currentAutoImportSecretRest } = getSecretTemplate() ?? {}
+    const newAutoImportSecret = { ...autoImportSecret, ...currentAutoImportSecretRest }
+
     switch (importMode) {
       case ImportMode.manual:
         // Delete auto-import secret
@@ -900,13 +891,13 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
         break
       case ImportMode.kubeconfig: {
         // Insert/Replace auto-import secret
-        newAutoImportSecret.stringData = { ...newAutoImportSecret.stringData, kubeconfig }
+        newAutoImportSecret.stringData = { kubeconfig }
         replaceSecretTemplate(newAutoImportSecret)
         break
       }
       case ImportMode.token: {
         // Insert/Replace auto-import secret
-        newAutoImportSecret.stringData = { ...newAutoImportSecret.stringData, token, server }
+        newAutoImportSecret.stringData = { token, server }
         replaceSecretTemplate(newAutoImportSecret)
         break
       }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/ImportCluster.tsx
@@ -329,14 +329,16 @@ export default function ImportClusterPage() {
 
           const credentialExists = doesCredentialExist(filteredCredentials, state.credential)
 
+          let newCredential = ''
+          if (credentialExists) {
+            newCredential = state.credential
+          } else if (filteredCredentials.length > 0) {
+            newCredential = filteredCredentials[0].metadata.name ?? ''
+          }
           return {
             ...state,
             namespace: namespaceExists ? state.namespace : '',
-            credential: credentialExists
-              ? state.credential
-              : filteredCredentials.length > 0
-                ? filteredCredentials[0].metadata.name || ''
-                : '',
+            credential: newCredential,
             credentials: filteredCredentials,
           }
         }
@@ -403,6 +405,7 @@ export default function ImportClusterPage() {
           namespace: initialClusterName,
         },
         stringData: {
+          autoImportRetry: '2',
           cluster_id: initialClusterID,
           auth_method: initialAuthMethod,
           api_token: initialAPIToken,
@@ -422,6 +425,7 @@ export default function ImportClusterPage() {
           namespace: initialClusterName,
         },
         stringData: {
+          autoImportRetry: '2',
           token: '',
           server: initialServer,
         },
@@ -788,7 +792,9 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
         name: AUTO_IMPORT_SECRET,
         namespace: clusterName,
       },
-      stringData: {},
+      stringData: {
+        autoImportRetry: '2',
+      },
       type: 'Opaque',
     }),
     [clusterName]
@@ -797,10 +803,11 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
   const updateROSAImportSecret = useCallback(
     (credentialName: string, discoverySecret: Secret) => {
       const selectedCredential = ocmCredentials.find((credential) => credential.metadata.name === credentialName)
-      const authMethod = selectedCredential?.stringData?.auth_method ?? 'offline-token'
+      const authMethod = selectedCredential?.stringData?.auth_method || 'offline-token'
       // Updating the discovery secret based on the auth_method
       if (authMethod === 'service-account') {
         discoverySecret.stringData = {
+          ...discoverySecret.stringData,
           cluster_id: clusterID,
           auth_method: 'service-account',
           client_id: selectedCredential?.stringData?.client_id ?? '',
@@ -808,6 +815,7 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
         }
       } else if (authMethod === 'offline-token') {
         discoverySecret.stringData = {
+          ...discoverySecret.stringData,
           cluster_id: clusterID,
           auth_method: 'offline-token',
           api_token: selectedCredential?.stringData?.ocmAPIToken ?? '',
@@ -880,9 +888,11 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
   if (prevImportMode !== importMode || prevCredential !== credential) {
     // Preserve anything added to the secret by the user, like annotations
     // For the stringData, preserve only changes to the autoImportRetry count
-    const { ...currentAutoImportSecretRest } = getSecretTemplate() ?? {}
-    const newAutoImportSecret = { ...autoImportSecret, ...currentAutoImportSecretRest }
-
+    const {
+      stringData: { autoImportRetry = autoImportSecret?.stringData?.autoImportRetry ?? '' } = {},
+      ...currentAutoImportSecretRest
+    } = getSecretTemplate() ?? {}
+    const newAutoImportSecret = { ...autoImportSecret, stringData: { autoImportRetry }, ...currentAutoImportSecretRest }
     switch (importMode) {
       case ImportMode.manual:
         // Delete auto-import secret
@@ -890,13 +900,13 @@ const AutoImportControls = (props: { state: State; dispatch: Dispatch<Action> })
         break
       case ImportMode.kubeconfig: {
         // Insert/Replace auto-import secret
-        newAutoImportSecret.stringData = { kubeconfig }
+        newAutoImportSecret.stringData = { ...newAutoImportSecret.stringData, kubeconfig }
         replaceSecretTemplate(newAutoImportSecret)
         break
       }
       case ImportMode.token: {
         // Insert/Replace auto-import secret
-        newAutoImportSecret.stringData = { token, server }
+        newAutoImportSecret.stringData = { ...newAutoImportSecret.stringData, token, server }
         replaceSecretTemplate(newAutoImportSecret)
         break
       }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/schema.json
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ImportCluster/schema.json
@@ -53,7 +53,6 @@
         "stringData": {
           "type": "object",
           "properties": {
-            "autoImportRetry": { "type": "string" },
             "host": { "type": "string" },
             "kubeconfig": { "type": "string" },
             "server": { "type": "string" },
@@ -65,8 +64,8 @@
           },
           "oneOf": [
             { "required": ["host", "token"] },
-            { "required": ["autoImportRetry", "token", "server"] },
-            { "required": ["autoImportRetry", "kubeconfig"] },
+            { "required": ["token", "server"] },
+            { "required": ["kubeconfig"] },
             { "required": ["api_token", "cluster_id"] },
             { "required": ["client_id", "client_secret", "cluster_id"] }
           ]


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
Starting from 2.14, the data.autoImportRetry field in the auto-import secret is ignored. console includes autoImportRetry when creating auto-import secrets. While it won’t cause any issues, it would be better to remove it for clarity and consistency.

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-20777

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [X] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [X] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [X] Code builds and runs locally without errors
- [X] No console logs, commented-out code, or unnecessary files
- [X] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [X] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->