### PR TITLE
ACM-20991, ACM-20992: Fix key in PF5 Tbody in AcmTable component.

### DIFF
--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -388,7 +388,9 @@ export default function ApplicationsOverview() {
   }, [allApplications, deletedApps, generateTransformData, resultCounts])
 
   const keyFn = useCallback(
-    (resource: IResource) => resource.metadata!.uid ?? `${resource.metadata!.namespace}/${resource.metadata!.name}`,
+    (resource: IResource) =>
+      resource.metadata!.uid ??
+      `${resource.status?.cluster ?? 'local-cluster'}/${resource.metadata!.namespace}/${resource.metadata!.name}`,
     []
   )
   const extensionColumns: IAcmTableColumn<IApplicationResource>[] = useMemo(

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -1663,7 +1663,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                 </Thead>
                 {primaryRows.map((row, rowIndex) => {
                   return (
-                    <Tbody isExpanded={row.isOpen} key={`${row.props.key}-tablebody`}>
+                    <Tbody key={`${row.props.key}-tablebody`} isExpanded={row.isOpen}>
                       <Tr key={`${row.props.key}-tablerow`} ouiaId={row?.props?.key}>
                         {onCollapse && (
                           <Td
@@ -1704,7 +1704,11 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                             ...iTransformCellProps,
                           }
                           return (
-                            <Td key={`row-${rowIndex}-cell-${cellIndex}`} {...rowProps} isActionCell={isActionKebab}>
+                            <Td
+                              key={`cell-${row.props.key}-${selectedSortedCols[cellIndex]?.header}`}
+                              {...rowProps}
+                              isActionCell={isActionKebab}
+                            >
                               {renderCellContent(cell)}
                             </Td>
                           )
@@ -1724,7 +1728,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                         )}
                       </Tr>
                       {addedSubRowCount > 0 && (
-                        <Tr isExpanded={row.isOpen} key={addedSubRows[rowIndex]?.props?.key}>
+                        <Tr isExpanded={row.isOpen} key={`${addedSubRows[rowIndex]?.props?.key}-subrow`}>
                           {/* include spacing for expandable and selection columns in subrow */}
                           {onCollapse && <Td />}
                           {hasSelectionColumn && <Td />}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Application Table filter is not properly filtering, including other types of applications in the filter.
Application Table creates duplicate rows when sorting

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-20991
https://issues.redhat.com/browse/ACM-20992

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

Note: I was passing a bad key to the Tbody PF5 component. There are situations where the `row.props.key` value can be the same across two or more rows. This is often the case when we have two similar app sets with one on the hub and the other on a managed cluster. This prop would have been passed to the html <tbody> element [as an attribute](https://github.com/patternfly/patternfly-react/blob/9d843f99842f39a8233c16c23c001aa22647dd82/packages/react-table/src/components/Table/Tbody.tsx#L29C4-L40). We are using multiple Tbody PF components ([following the example from PatternFly's expandable table rows](https://www.patternfly.org/components/table/#expandable)), so it appears that this design choice in combination with duplicate keys for the tbody within one table is responsible for this behavior, ALFWICT :)

I assume the other components where `row.props.key` is being used have either incidental or intentional guards in place to avoid duplication in the table. With the tbody component however, this does not appear to be the case.

As for the deviation in behavior between clusters, that remains a bit of a mystery to me.

For testing, we have QE cluster with the defect available. Please reach out to me if you'd like to test the fix locally using this cluster.