### PR TITLE
ACM-21166 Move node-localstorage to production dependencies

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "got": "^12.5.3",
         "https-proxy-agent": "^7.0.4",
         "node-fetch": "2.6.7",
+        "node-localstorage": "^3.0.5",
         "object-sizeof": "^2.6.5",
         "pino": "7.11.0",
         "pluralize": "8.0.0",
@@ -44,7 +45,6 @@
         "jest": "^29.7.0",
         "jest-sonar-reporter": "^2.0.0",
         "nock": "13.2.8",
-        "node-localstorage": "^3.0.5",
         "nodemon": "^3.1.0",
         "pino-zen": "2.0.7",
         "prettier": "^3.2.5",
@@ -1567,6 +1567,7 @@
       "resolved": "https://registry.npmjs.org/@types/node-localstorage/-/node-localstorage-1.3.3.tgz",
       "integrity": "sha512-Wkn5g4eM5x10UNV9Xvl9K6y6m0zorocuJy4WjB5muUdyMZuPbZpSJG3hlhjGHe1HGxbOQO7RcB+jlHcNwkh+Jw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4000,7 +4001,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -5535,7 +5535,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-3.0.5.tgz",
       "integrity": "sha512-GCwtK33iwVXboZWYcqQHu3aRvXEBwmPkAMRBLeaX86ufhqslyUkLGsi4aW3INEfdQYpUB5M9qtYf3eHvAk2VBg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "write-file-atomic": "^5.0.1"
       },
@@ -5547,7 +5547,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=14"
       },
@@ -5559,7 +5559,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
       "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-      "dev": true,
+      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -10199,8 +10199,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -11372,7 +11371,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-3.0.5.tgz",
       "integrity": "sha512-GCwtK33iwVXboZWYcqQHu3aRvXEBwmPkAMRBLeaX86ufhqslyUkLGsi4aW3INEfdQYpUB5M9qtYf3eHvAk2VBg==",
-      "dev": true,
       "requires": {
         "write-file-atomic": "^5.0.1"
       },
@@ -11380,14 +11378,12 @@
         "signal-exit": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-          "dev": true
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
         },
         "write-file-atomic": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
           "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
-          "dev": true,
           "requires": {
             "imurmurhash": "^0.1.4",
             "signal-exit": "^4.0.1"

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,11 +30,12 @@
     "got": "^12.5.3",
     "https-proxy-agent": "^7.0.4",
     "node-fetch": "2.6.7",
+    "node-localstorage": "^3.0.5",
+    "object-sizeof": "^2.6.5",
     "pino": "7.11.0",
     "pluralize": "8.0.0",
     "prom-client": "^14.2.0",
-    "raw-body": "2.5.1",
-    "object-sizeof": "^2.6.5"
+    "raw-body": "2.5.1"
   },
   "devDependencies": {
     "@types/eslint": "8.4.5",
@@ -52,11 +53,10 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "got-11.8.2": "npm:got@11.8.2",
     "jest": "^29.7.0",
     "jest-sonar-reporter": "^2.0.0",
-    "got-11.8.2": "npm:got@11.8.2",
     "nock": "13.2.8",
-    "node-localstorage": "^3.0.5",
     "nodemon": "^3.1.0",
     "pino-zen": "2.0.7",
     "prettier": "^3.2.5",


### PR DESCRIPTION
# 📝 Summary

Moves dev dependency to production to avoid crashing at runtime. Even though it is only used in development mode, the dependency is imported in production.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-21166

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->