### PR TITLE
[ACM-21105] fix vm restore page action

### DIFF
--- a/frontend/src/routes/Search/Details/DetailsPage.tsx
+++ b/frontend/src/routes/Search/Details/DetailsPage.tsx
@@ -218,10 +218,10 @@ export default function DetailsPage() {
         ...createVMDropdownItems([
           {
             displayText: t('Restore VirtualMachine from snapshot'),
-            action: 'Restart',
+            action: 'Restore',
             method: 'PUT',
-            hubPath: `/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachines/${name}/restart`,
-            managedPath: '/virtualmachines/restart',
+            hubPath: `/apis/snapshot.kubevirt.io/v1beta1/namespaces/${namespace}/virtualmachinerestores`,
+            managedPath: '/virtualmachinerestores',
             isDisabled: false,
           },
         ]),


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Details page VM Restore action dropdown item fired incorrect action

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-21105

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->