### PR TITLE
Add loading component to delete resource modal while requesting user …

### DIFF
--- a/frontend/src/routes/Search/components/Modals/DeleteResourceModal.tsx
+++ b/frontend/src/routes/Search/components/Modals/DeleteResourceModal.tsx
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 // Copyright (c) 2021 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
-import { ButtonVariant, ModalVariant } from '@patternfly/react-core'
+import { ButtonVariant, ModalVariant, Skeleton } from '@patternfly/react-core'
 import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { useTranslation } from '../../../../lib/acm-i18next'
 import { canUser } from '../../../../lib/rbac-util'
@@ -295,9 +295,13 @@ export const DeleteResourceModal = (props: IDeleteModalProps) => {
       {deleteResourceError && (
         <AcmAlert data-testid={'delete-resource-error'} noClose={true} variant={'danger'} title={deleteResourceError} />
       )}
-      <div style={{ paddingTop: '1rem' }}>
-        {t('Are you sure that you want to delete {{resourceName}}?', { resourceName: resource?.name })}
-      </div>
+      {loadingAccessRequest ? (
+        <Skeleton width={'50%'} />
+      ) : (
+        <div style={{ paddingTop: '1rem' }}>
+          {t('Are you sure that you want to delete {{resourceName}}?', { resourceName: resource?.name })}
+        </div>
+      )}
     </AcmModal>
   )
 }


### PR DESCRIPTION
…auth

# 📝 Summary

**Ticket Summary (Title):**  
Adds a skeleton loading component to the delete resource modal while we are fetching user permissions

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->