### PR TITLE
Use locally cached token for development only as last resort

### DIFF
--- a/backend/src/lib/token.ts
+++ b/backend/src/lib/token.ts
@@ -11,16 +11,16 @@ const ADMIN_TOKEN = 'admin-token'
 
 export function getToken(req: Http2ServerRequest): string | undefined {
   let token = parseCookies(req)['acm-access-token-cookie']
-  /* istanbul ignore if */
-  if (!token && process.env.NODE_ENV === 'development') {
-    const localStorage = new LocalStorage(LOCAL_STORAGE)
-    token = localStorage.getItem(ADMIN_TOKEN)
-  }
   if (!token) {
     const authorizationHeader = req.headers[HTTP2_HEADER_AUTHORIZATION]
     if (typeof authorizationHeader === 'string' && authorizationHeader.startsWith('Bearer ')) {
       token = authorizationHeader.slice(7)
     }
+  }
+  /* istanbul ignore if */
+  if (!token && process.env.NODE_ENV === 'development') {
+    const localStorage = new LocalStorage(LOCAL_STORAGE)
+    token = localStorage.getItem(ADMIN_TOKEN)
   }
   return token
 }


### PR DESCRIPTION
Check for locally cached token was originally after the check for the `acm-access-token-cookie`, but this is only used in local development mode with `npm start`. It needs to appear after the code that gets the token from the authorization header, which is used when running with `npm run plugins`.