### PR TITLE
ACM-21125: Incorrect locators(data-labels) in GRC policies table when one of the column is not enabled

### DIFF
--- a/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
+++ b/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
@@ -230,11 +230,13 @@ export default function VirtualMachinesPage() {
         (cm: ConfigMap) => cm.metadata.name === 'grafana-dashboard-acm-openshift-virtualization-clusters-overview'
       )
       if (vmDashboard.length > 0) {
-        const parsedDashboardData = JSON.parse(
-          vmDashboard[0].data?.['acm-openshift-virtualization-clusters-overview.json']
-        )
-        const dashboardId = parsedDashboardData?.uid
-        return `${grafanaLink}/d/${dashboardId}/executive-dashboards-clusters-overview?orgId=1`
+        try {
+          const parsedDashboardData = JSON.parse(
+            vmDashboard[0].data?.['acm-openshift-virtualization-clusters-overview.json']
+          )
+          const dashboardId = parsedDashboardData?.uid
+          return `${grafanaLink}/d/${dashboardId}/executive-dashboards-clusters-overview?orgId=1`
+        } catch (error) {}
       }
     }
     return ''

--- a/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
+++ b/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
@@ -236,7 +236,9 @@ export default function VirtualMachinesPage() {
           )
           const dashboardId = parsedDashboardData?.uid
           return `${grafanaLink}/d/${dashboardId}/executive-dashboards-clusters-overview?orgId=1`
-        } catch (error) {}
+        } catch (error) {
+          console.error(error)
+        }
       }
     }
     return ''

--- a/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
+++ b/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
@@ -409,7 +409,7 @@ export default function VirtualMachinesPage() {
         <AcmPageHeader
           title={t('Virtual machines')}
           actions={
-            isObservabilityInstalled ? (
+            isObservabilityInstalled && vmMetricLink ? (
               <AcmActionGroup>
                 {[
                   <AcmButton

--- a/frontend/src/ui-components/AcmTable/AcmTable.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.tsx
@@ -1700,7 +1700,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                             : []
                           const isActionKebab = isActionMenu(cellIndex)
                           const rowProps = {
-                            dataLabel: isActionKebab ? undefined : columns[cellIndex].header,
+                            dataLabel: isActionKebab ? undefined : selectedSortedCols[cellIndex].header,
                             ...iTransformCellProps,
                           }
                           return (


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
ACM-21125: Incorrect locators(data-labels) in GRC policies table when one of the column is not enabled
Fixing data label mismatch in ACM table

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
[Ticket](https://issues.redhat.com/browse/ACM-21125)

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->