### PR TITLE
[2.13] Revert search availability hook

### DIFF
--- a/frontend/src/atoms.ts
+++ b/frontend/src/atoms.ts
@@ -185,22 +185,6 @@ export function useIsObservabilityInstalled() {
   }, [clusterManagementAddons])
 }
 
-// Search is available if api, collector, indexer & postgres are in ready state
-export function useIsSearchAvailable() {
-  const searchOperator = useRecoilValue(searchOperatorState)
-  return useMemo(() => {
-    const isReady = (type: string) =>
-      searchOperator[0]?.status?.conditions.some((c) => c.type.toLowerCase() === type && c.status === 'True')
-    const searchServices = [
-      'ready--search-api',
-      'ready--search-collector',
-      'ready--search-indexer',
-      'ready--search-postgres',
-    ]
-    return searchOperator.length > 0 && searchServices.every(isReady)
-  }, [searchOperator])
-}
-
 export function useSavedSearchLimit() {
   const settings = useRecoilValue(settingsState)
   return useMemo(() => parseInt(settings.SAVED_SEARCH_LIMIT ?? '10'), [settings])

--- a/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
+++ b/frontend/src/routes/Infrastructure/VirtualMachines/VirtualMachinesPage.tsx
@@ -54,11 +54,10 @@ import { getVirtualMachineRowActions } from './utils'
 function VirtualMachineTable() {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { settingsState, useIsSearchAvailable } = useSharedAtoms()
+  const { settingsState } = useSharedAtoms()
   const vmActionsEnabled = useRecoilValue(settingsState)?.VIRTUAL_MACHINE_ACTIONS === 'enabled'
-  const isSearchAvailable = useIsSearchAvailable()
   const toast = useContext(AcmToastContext)
-  const { dataContext } = useContext(PluginContext)
+  const { dataContext, isSearchAvailable } = useContext(PluginContext)
   const { loadStarted } = useContext(dataContext)
   const allClusters = useAllClusters(true)
   const [deleteResource, setDeleteResource] = useState<IDeleteModalProps>(ClosedDeleteModalProps)


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Removes the useIsSearchAvailable hook. It was incorrectly erroring out the page in some cases. 

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->