### PR TITLE
ACM-21291 Filter ConfigPolicies from related resources

### DIFF
--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetails.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetails.tsx
@@ -65,7 +65,10 @@ export function PolicyTemplateDetails() {
       relatedResourcesFromSearch.relatedItems !== undefined &&
       relatedResourcesFromSearch.relatedItems
     ) {
-      setRelatedObjects(relatedResourcesFromSearch.relatedItems)
+      const filteredRelated = relatedResourcesFromSearch.relatedItems.filter((item) => {
+        return item.kind !== 'ConfigurationPolicy'
+      })
+      setRelatedObjects(filteredRelated)
     }
   }, [relatedResourcesFromSearch, apiGroup, kind, isVAPB, isGatekeeperMutation])
 

--- a/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsPage.test.tsx
+++ b/frontend/src/routes/Governance/policies/policy-details/PolicyTemplateDetail/PolicyTemplateDetailsPage.test.tsx
@@ -1725,6 +1725,29 @@ describe('Policy Template Details Page', () => {
                     },
                   ],
                 },
+                {
+                  kind: 'ConfigurationPolicy',
+                  items: [
+                    {
+                      _hubClusterResource: 'true',
+                      _isExternal: 'false',
+                      _relatedUids: ['local-cluster/0d76dcdd-c5d6-4b61-a85c-34079188b16c'],
+                      _uid: 'local-cluster/e277dd21-02d9-43cd-9506-d10c759acc49',
+                      apigroup: 'policy.open-cluster-management.io',
+                      apiversion: 'v1',
+                      cluster: 'local-cluster',
+                      compliant: 'Compliant',
+                      created: '2025-06-10T18:55:46Z',
+                      disabled: 'false',
+                      kind: 'ConfigurationPolicy',
+                      kind_plural: 'configurationpolicies',
+                      name: 'jkuli-vapb-check',
+                      namespace: 'local-cluster',
+                      remediationAction: 'inform',
+                      severity: 'low',
+                    },
+                  ],
+                },
               ],
             },
           ],
@@ -1850,5 +1873,6 @@ describe('Policy Template Details Page', () => {
     const parameterTable = screen.getByRole('grid')
     expect(within(parameterTable).queryByText('ValidatingAdmissionPolicy')).not.toBeInTheDocument()
     expect(within(parameterTable).queryByText('Cluster')).not.toBeInTheDocument()
+    expect(within(parameterTable).queryByText('ConfigurationPolicy')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Previously, Search did not populate edges from ConfigurationPolicies to the objects they managed, so this table for parameter resources did not need any filtering. Now, if a ConfigurationPolicy is what distributed the VAPB or Gatekeeper resource, it will not appear in its resources table.

Refs:
 - https://issues.redhat.com/browse/ACM-21291

# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-21291

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->