### PR TITLE
ACM-21488-The-clusters-field-is-None-for-appset-in-app-table

### DIFF
--- a/backend/src/routes/aggregators/applicationsArgo.ts
+++ b/backend/src/routes/aggregators/applicationsArgo.ts
@@ -126,7 +126,7 @@ export function cacheArgoApplications(applicationCache: ApplicationCacheType, re
   }
 
   try {
-    transform(getApplicationsHelper(applicationCache, ['appset']), false, localCluster, clusters)
+    transform(Object.values(applicationCache['appset'].resourceUidMap), false, localCluster, clusters)
   } catch (e) {
     logger.error(`aggregateLocalApplications appset exception ${e}`)
   }
@@ -155,7 +155,7 @@ export function polledArgoApplicationAggregation(
     resourceUidMap = applicationCache[appKey].resourceUidMap = {}
   }
 
-  // initialize data for this pass (pass continues until  shouldPostProcess)
+  // initialize data for this pass (pass continues until shouldPostProcess)
   if (!oldResourceUidSets[appKey]) {
     oldResourceUidSets[appKey] = new Set(Object.keys(resourceUidMap))
     hubClusterName = getHubClusterName()

--- a/backend/src/routes/aggregators/applicationsArgo.ts
+++ b/backend/src/routes/aggregators/applicationsArgo.ts
@@ -25,7 +25,6 @@ import {
   getNextApplicationPageChunk,
   ApplicationPageChunk,
   transform,
-  getApplicationsHelper,
   getApplicationType,
   getApplicationClusters,
   getTransform,


### PR DESCRIPTION
Cluster name list was created on a copy of the application resource object instead of on the actual resource object

Signed-off-by: John Swanke <jswanke@redhat.com>

# 📝 Summary

**Ticket Summary (Title):**  
The clusters field is 'None' for appset in app table

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-21488

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->