### PR TITLE
adjust sdk dependencies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19003,6 +19003,7 @@
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
       "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
+      "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -34574,7 +34575,8 @@
         "@patternfly/react-component-groups": "^6.2.1",
         "@patternfly/react-core": "^6.2.2",
         "@patternfly/react-styles": "^6.2.2",
-        "react-i18next": "^15.5.2",
+        "graphql": "^16.9.0",
+        "react-i18next": "11.16.9",
         "react-router-dom-v5-compat": "^6.24.1",
         "react-transition-group": "^4.4.5",
         "react-virtualized": "^9.22.6"
@@ -39503,8 +39505,9 @@
         "@patternfly/react-core": "^6.2.2",
         "@patternfly/react-styles": "^6.2.2",
         "@types/react-virtualized": "^9.22.2",
+        "graphql": "^16.9.0",
         "prettier": "^3.2.5",
-        "react-i18next": "^15.5.2",
+        "react-i18next": "11.16.9",
         "react-router-dom-v5-compat": "^6.24.1",
         "react-transition-group": "^4.4.5",
         "react-virtualized": "^9.22.6",
@@ -39601,8 +39604,7 @@
           }
         },
         "react-i18next": {
-          "version": "15.5.2",
-          "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.2.tgz",
+          "version": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.2.tgz",
           "integrity": "sha512-ePODyXgmZQAOYTbZXQn5rRsSBu3Gszo69jxW6aKmlSgxKAI1fOhDwSu6bT4EKHciWPKQ7v7lPrjeiadR6Gi+1A==",
           "requires": {
             "@babel/runtime": "^7.25.0",

--- a/frontend/packages/multicluster-sdk/package.json
+++ b/frontend/packages/multicluster-sdk/package.json
@@ -46,7 +46,8 @@
     "@patternfly/react-component-groups": "^6.2.1",
     "@patternfly/react-core": "^6.2.2",
     "@patternfly/react-styles": "^6.2.2",
-    "react-i18next": "^15.5.2",
+    "graphql": "^16.9.0",
+    "react-i18next": "11.16.9",
     "react-router-dom-v5-compat": "^6.24.1",
     "react-transition-group": "^4.4.5",
     "react-virtualized": "^9.22.6"


### PR DESCRIPTION
graphql dependencies is in the `frontend` folder but not in the sdk `package.json` 

This led the `kubevirt-plugin` to not install `graphql` dependency in its `node_modules` and throw an expection when building 

```
Module not found: Error: Can't resolve 'graphql' in '/Users/upalatuc/kubevirt-plugin/node_modules/@apollo/client/utilities/graphql'
```
`graphql` for `@apollo/client` is a `peerDependencies` and not a direct `dependencies` this means that we need to specify both in the package.json 