### PR TITLE
fix searchapi useMulticlusterSearchWatch when client is undefined

### DIFF
--- a/frontend/packages/multicluster-sdk/src/api/search/useMulticlusterSearchWatch.ts
+++ b/frontend/packages/multicluster-sdk/src/api/search/useMulticlusterSearchWatch.ts
@@ -16,7 +16,7 @@ export const useMulticlusterSearchWatch: UseMulticlusterSearchWatch = (watchOpti
     loading,
     error,
   } = useSearchResultItemsQuery({
-    skip: !searchClient,
+    skip: searchClient === undefined,
     client: searchClient,
     variables: {
       input: [


### PR DESCRIPTION
This will make sure not to throw an exception when searchapi is used, butthe  `backendURL` changes 