### PR TITLE
[ACM-21798] Edit VM action should use fine-grained rbac if enabled

### DIFF
--- a/backend/src/routes/virtualMachineProxy.ts
+++ b/backend/src/routes/virtualMachineProxy.ts
@@ -45,6 +45,7 @@ interface ActionBody {
 const getKubeVirtAPI = (url: string, name: string, namespace: string, action?: string) => {
   let path = ''
   switch (url) {
+    case '/virtualmachines/update':
     case '/virtualmachines/delete':
       path = `${path}/apis/kubevirt.io/v1/namespaces/${namespace}/virtualmachines/${name}`
       break
@@ -60,6 +61,7 @@ const getKubeVirtAPI = (url: string, name: string, namespace: string, action?: s
     case '/virtualmachinesnapshots/create':
       path = `${path}/apis/snapshot.kubevirt.io/v1beta1/namespaces/${namespace}/virtualmachinesnapshots`
       break
+    case '/virtualmachinesnapshots/update':
     case '/virtualmachinesnapshots/delete':
       path = `${path}/apis/snapshot.kubevirt.io/v1beta1/namespaces/${namespace}/virtualmachinesnapshots/${name}`
       break
@@ -128,7 +130,12 @@ export async function virtualMachineProxy(req: Http2ServerRequest, res: Http2Ser
         chucks.push(chuck)
       })
       req.on('end', async () => {
-        const body = JSON.parse(chucks.join()) as ActionBody
+        let body = {} as ActionBody
+        try {
+          body = JSON.parse(chucks.join('')) as ActionBody
+        } catch (err) {
+          logger.error(err)
+        }
         const action = req.url.split('/')[2]
         const path = `${proxyURL}/${body.managedCluster}${getKubeVirtAPI(req.url, body.vmName, body.vmNamespace, action)}`
         const reqBody = JSON.stringify(body.reqBody)
@@ -163,16 +170,25 @@ export async function virtualMachineProxy(req: Http2ServerRequest, res: Http2Ser
           }
         }
 
-        const headers: HeadersInit =
-          req.method !== 'PUT'
-            ? {
-                [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${token}`,
-                [HTTP2_HEADER_ACCEPT]: 'application/json',
-                [HTTP2_HEADER_CONTENT_TYPE]: 'application/json',
-              }
-            : {
-                [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${token}`,
-              }
+        let headers: HeadersInit = {}
+        switch (req.url) {
+          // start, stop, restart, pause, unpause all require */* for accept and content-type headers
+          case '/virtualmachines/start':
+          case '/virtualmachines/stop':
+          case '/virtualmachines/restart':
+          case '/virtualmachineinstances/pause':
+          case '/virtualmachineinstances/unpause':
+            headers = {
+              [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${token}`,
+            }
+            break
+          default:
+            headers = {
+              [HTTP2_HEADER_AUTHORIZATION]: `Bearer ${token}`,
+              [HTTP2_HEADER_ACCEPT]: 'application/json',
+              [HTTP2_HEADER_CONTENT_TYPE]: 'application/json',
+            }
+        }
 
         await fetchRetry(path, {
           method: req.method,
@@ -185,18 +201,19 @@ export async function virtualMachineProxy(req: Http2ServerRequest, res: Http2Ser
             if (results?.status > 300) {
               logger.error({
                 msg: 'Error in VirtualMachine action results (fine grained RBAC)',
-                error: results,
+                status: results.status,
+                statusText: results.statusText,
               })
               res.setHeader('Content-Type', 'application/json')
               res.writeHead(results.status ?? HTTP_STATUS_INTERNAL_SERVER_ERROR)
-              res.end(JSON.stringify(results))
+              res.end(JSON.stringify({ status: results.status, statusText: results.statusText }))
               return 'Error in VirtualMachine action results (fine grained RBAC)'
             }
             let response = undefined
             if (req.method === 'POST') {
               response = (await results.json()) as unknown
             } else {
-              response = { statusCode: results.status }
+              response = { statusCode: results.status, statusText: results.statusText }
             }
             res.setHeader('Content-Type', 'application/json')
             res.end(JSON.stringify(response))


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Edit VirtualMachine & VirtualMachineSnapshot should use fine-grained RBAC if enabled. And, if not enabled, fall back to ManagedClusterAction.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-21798

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->