### PR TITLE
ACM-20341: fix null response in watch hooks

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -34581,7 +34581,7 @@
     },
     "packages/multicluster-sdk": {
       "name": "@stolostron/multicluster-sdk",
-      "version": "0.3.1-alpha.1",
+      "version": "0.3.2-alpha.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "3.10.8",

--- a/frontend/packages/multicluster-sdk/package.json
+++ b/frontend/packages/multicluster-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stolostron/multicluster-sdk",
-  "version": "0.3.1-alpha.1",
+  "version": "0.3.2-alpha.1",
   "description": "Provides extensions and APIs that dynamic plugins can use to leverage multicluster capabilities provided by Red Hat Advanced Cluster Management.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/frontend/packages/multicluster-sdk/src/api/search/useMulticlusterSearchWatch.ts
+++ b/frontend/packages/multicluster-sdk/src/api/search/useMulticlusterSearchWatch.ts
@@ -10,7 +10,7 @@ export const useMulticlusterSearchWatch: UseMulticlusterSearchWatch = (
   watchOptions: WatchK8sResource,
   advancedSearch?: { [key: string]: string }
 ) => {
-  const { groupVersionKind, limit, namespace, namespaced, name } = watchOptions
+  const { groupVersionKind, limit, namespace, namespaced, name, isList } = watchOptions
 
   const advancedSearchQueryString = Object.entries(advancedSearch || {})
     ?.map(([key, value]) => `${key}:${value}`)
@@ -78,5 +78,8 @@ export const useMulticlusterSearchWatch: UseMulticlusterSearchWatch = (
       }),
     [kind, result]
   )
-  return [data as SearchResult<any>, !loading, error]
+
+  const nullResponse = useMemo(() => (isList ? [] : undefined), [isList])
+
+  return [(data as SearchResult<any>) ?? nullResponse, !loading, error]
 }

--- a/frontend/packages/multicluster-sdk/src/api/use-fleet-k8s-watch-resource/use-fleet-k8s-watch-resource.ts
+++ b/frontend/packages/multicluster-sdk/src/api/use-fleet-k8s-watch-resource/use-fleet-k8s-watch-resource.ts
@@ -41,7 +41,7 @@ export const useFleetK8sWatchResource = <R extends FleetK8sResourceCommon | Flee
   const [model] = useK8sModel(groupVersionKind)
   const [backendAPIPath, backendPathLoaded] = useFleetK8sAPIPath(cluster)
 
-  const noCachedValue = (isList ? [] : {}) as R
+  const noCachedValue = useMemo(() => (isList ? [] : (undefined as unknown)) as R, [isList])
 
   const requestPath = useMemo(
     () =>
@@ -66,7 +66,7 @@ export const useFleetK8sWatchResource = <R extends FleetK8sResourceCommon | Flee
     const fetchData = async () => {
       setError(undefined)
       if (!useFleet || nullResource) {
-        setData((isList ? [] : {}) as R)
+        setData(noCachedValue)
         setLoaded(false)
         return
       }
@@ -128,7 +128,19 @@ export const useFleetK8sWatchResource = <R extends FleetK8sResourceCommon | Flee
       }
     }
     fetchData()
-  }, [cluster, isList, requestPath, name, namespace, nullResource, useFleet, backendPathLoaded, model, backendAPIPath])
+  }, [
+    cluster,
+    isList,
+    requestPath,
+    name,
+    namespace,
+    nullResource,
+    noCachedValue,
+    useFleet,
+    backendPathLoaded,
+    model,
+    backendAPIPath,
+  ])
 
   const [defaultData, defaultLoaded, defaultError] = useK8sWatchResource<R>(useFleet ? null : resource)
 

--- a/frontend/packages/multicluster-sdk/src/api/use-fleet-k8s-watch-resource/use-fleet-k8s-watch-resource.ts
+++ b/frontend/packages/multicluster-sdk/src/api/use-fleet-k8s-watch-resource/use-fleet-k8s-watch-resource.ts
@@ -36,7 +36,7 @@ export const useFleetK8sWatchResource = <R extends FleetK8sResourceCommon | Flee
 ): WatchK8sResult<R> | [undefined, boolean, any] => {
   const { cluster, ...resource } = initResource ?? {}
   const useFleet = cluster && cluster !== hubClusterName
-  const nullResource = resource === null || resource === undefined || resource?.groupVersionKind === undefined
+  const nullResource = !(resource?.groupVersionKind ?? resource)
   const { isList, groupVersionKind, namespace, name } = resource ?? {}
   const [model] = useK8sModel(groupVersionKind)
   const [backendAPIPath, backendPathLoaded] = useFleetK8sAPIPath(cluster)
@@ -58,7 +58,7 @@ export const useFleetK8sWatchResource = <R extends FleetK8sResourceCommon | Flee
     [model, namespace, name, cluster, backendPathLoaded, backendAPIPath]
   )
 
-  const [data, setData] = useState<R>(fleetResourceCache[requestPath] ? fleetResourceCache[requestPath] : noCachedValue)
+  const [data, setData] = useState<R>(fleetResourceCache[requestPath] ?? noCachedValue)
   const [loaded, setLoaded] = useState<boolean>(!!fleetResourceCache[requestPath])
   const [error, setError] = useState<any>(undefined)
 
@@ -147,10 +147,6 @@ export const useFleetK8sWatchResource = <R extends FleetK8sResourceCommon | Flee
   if (nullResource) return [undefined, false, undefined]
 
   return useFleet
-    ? [
-        fleetResourceCache[requestPath] ? fleetResourceCache[requestPath] : data,
-        fleetResourceCache[requestPath] ? !!fleetResourceCache[requestPath] : loaded,
-        error,
-      ]
+    ? [fleetResourceCache[requestPath] ?? data, fleetResourceCache[requestPath] ? true : loaded, error]
     : [defaultData, defaultLoaded, defaultError]
 }


### PR DESCRIPTION
During response loading, return empty array if the watch is a `list` otherwise, return `undefined` and not `{}` (empty object) following the openshift sdk behavior