### PR TITLE
ACM-20341: advancedSearch option to filter by indexes values

### DIFF
--- a/frontend/packages/multicluster-sdk/src/api/search/types.ts
+++ b/frontend/packages/multicluster-sdk/src/api/search/types.ts
@@ -7,5 +7,6 @@ export type SearchResult<R extends K8sResourceCommon | K8sResourceCommon[]> = R 
   : MulticlusterResource<R>
 
 export type UseMulticlusterSearchWatch = <T extends K8sResourceCommon | K8sResourceCommon[]>(
-  watchOptions: WatchK8sResource
+  watchOptions: WatchK8sResource,
+  advancedSearch?: { [key: string]: string }
 ) => [SearchResult<T> | undefined, boolean, Error | undefined]


### PR DESCRIPTION
This ensures that plugins can filter the search API using the available values for the chosen resource. Making it more flexible.  