### PR TITLE
ACM-21337 Multi clusterSDK Fleet Resource link

### DIFF
--- a/frontend/packages/multicluster-sdk/src/api/FleetResourceLink.test.tsx
+++ b/frontend/packages/multicluster-sdk/src/api/FleetResourceLink.test.tsx
@@ -1,0 +1,285 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom-v5-compat'
+import { FleetResourceLink } from './FleetResourceLink'
+
+// mock ResourceLink from OpenShift Console SDK
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  ResourceLink: ({ name, groupVersionKind }: any) => (
+    <div id="resource-link-mock">
+      ResourceLink: {name} ({groupVersionKind?.kind})
+    </div>
+  ),
+  ResourceIcon: ({ groupVersionKind }: any) => <span id="resource-icon-mock">Icon: {groupVersionKind?.kind}</span>,
+}))
+
+describe('FleetResourceLink', () => {
+  const defaultProps = {
+    name: 'test-vm',
+    namespace: 'default',
+    groupVersionKind: {
+      group: 'kubevirt.io',
+      version: 'v1',
+      kind: 'VirtualMachine',
+    },
+  }
+
+  it('should render VM link with cluster for VirtualMachine', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink {...defaultProps} cluster="test-cluster" />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('href', '/multicloud/infrastructure/virtualmachines/test-cluster/default/test-vm')
+    expect(link).toHaveTextContent('test-vm')
+    expect(screen.getByTestId('resource-icon-mock')).toHaveTextContent('Icon: VirtualMachine')
+  })
+
+  it('should render search link for non-VM resources with cluster', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink
+          name="test-pod"
+          namespace="default"
+          cluster="test-cluster"
+          groupVersionKind={{
+            group: '',
+            version: 'v1',
+            kind: 'Pod',
+          }}
+        />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    const href = link.getAttribute('href')
+
+    // test for encoded URL parts (since getURLSearchParam encodes)
+    expect(href).toContain('/multicloud/search/resources')
+    expect(href).toContain('cluster%3Dtest-cluster')
+    expect(href).toContain('kind%3DPod')
+    expect(href).toContain('apiversion%3Dv1')
+    expect(href).toContain('namespace%3Ddefault')
+    expect(href).toContain('name%3Dtest-pod')
+  })
+
+  it('should fallback to ResourceLink when no cluster is provided', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink {...defaultProps} />
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('resource-link-mock')).toHaveTextContent('ResourceLink: test-vm (VirtualMachine)')
+  })
+
+  it('should handle displayName override', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink {...defaultProps} cluster="test-cluster" displayName="Custom VM Name" />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveTextContent('Custom VM Name')
+  })
+
+  it('should handle missing namespace for VM', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink
+          name="test-vm"
+          cluster="test-cluster"
+          groupVersionKind={{
+            group: 'kubevirt.io',
+            version: 'v1',
+            kind: 'VirtualMachine',
+          }}
+          // namespace is undefined
+        />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    const href = link.getAttribute('href')
+    expect(href).toBeTruthy() // Assert href exists
+
+    // should fall back to search URL, not VM URL
+    expect(href).toContain('/multicloud/search/resources')
+
+    const decodedUrl = decodeURIComponent(href!)
+    expect(decodedUrl).toContain('cluster=test-cluster')
+    expect(decodedUrl).toContain('kind=VirtualMachine')
+    expect(decodedUrl).toContain('apiversion=kubevirt.io/v1')
+    expect(decodedUrl).toContain('name=test-vm')
+    // namespace should NOT appear since it's undefined
+    expect(decodedUrl).not.toContain('namespace=')
+  })
+
+  it('should handle empty string namespace for VM by falling back to search', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink
+          name="test-vm"
+          cluster="test-cluster"
+          namespace="" // empty string, not undefined
+          groupVersionKind={{
+            group: 'kubevirt.io',
+            version: 'v1',
+            kind: 'VirtualMachine',
+          }}
+        />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    const href = link.getAttribute('href')
+    expect(href).toBeTruthy() // Assert href exists
+
+    // should fall back to search URL because empty string is falsy
+    expect(href).toContain('/multicloud/search/resources')
+
+    const decodedUrl = decodeURIComponent(href!)
+    expect(decodedUrl).toContain('cluster=test-cluster')
+    expect(decodedUrl).toContain('kind=VirtualMachine')
+    expect(decodedUrl).toContain('name=test-vm')
+    // namespace should NOT appear for empty string
+    expect(decodedUrl).not.toContain('namespace=')
+  })
+
+  it('should handle className and styling props', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink
+          {...defaultProps}
+          cluster="test-cluster"
+          className="custom-class"
+          inline={true}
+          truncate={true}
+        />
+      </MemoryRouter>
+    )
+
+    const wrapper = screen.getByText('test-vm').closest('span')
+    expect(wrapper).toHaveClass(
+      'co-resource-item',
+      'custom-class',
+      'co-resource-item--inline',
+      'co-resource-item--truncate'
+    )
+  })
+
+  it('should handle hideIcon prop', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink {...defaultProps} cluster="test-cluster" hideIcon={true} />
+      </MemoryRouter>
+    )
+
+    expect(screen.queryByTestId('resource-icon-mock')).not.toBeInTheDocument()
+  })
+
+  it('should handle nameSuffix', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink {...defaultProps} cluster="test-cluster" nameSuffix=" (suffix)" />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveTextContent('test-vm (suffix)')
+  })
+
+  it('should handle title and data-test attributes', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink {...defaultProps} cluster="test-cluster" title="VM Title" dataTest="custom-test-id" />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    expect(link).toHaveAttribute('title', 'VM Title')
+    expect(link).toHaveAttribute('data-test', 'custom-test-id')
+    expect(link).toHaveAttribute('data-test-id', 'test-vm')
+  })
+
+  it('should handle search link when no groupVersionKind provided', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink
+          name="test-resource"
+          cluster="test-cluster"
+          // no groupVersionKind provided
+        />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    const href = link.getAttribute('href')
+
+    expect(href).toContain('/multicloud/search/resources')
+    expect(href).toContain('cluster%3Dtest-cluster')
+    expect(href).toContain('name%3Dtest-resource')
+    expect(link).toHaveTextContent('test-resource')
+  })
+
+  it('should handle children prop', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink {...defaultProps} cluster="test-cluster">
+          <div id="child-content">Child Content</div>
+        </FleetResourceLink>
+      </MemoryRouter>
+    )
+
+    expect(screen.getByTestId('child-content')).toHaveTextContent('Child Content')
+  })
+
+  it('should handle search link for resource with apigroup', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink
+          name="test-deployment"
+          namespace="default"
+          cluster="test-cluster"
+          groupVersionKind={{
+            group: 'apps',
+            version: 'v1',
+            kind: 'Deployment',
+          }}
+        />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    const href = link.getAttribute('href')
+
+    expect(href).toContain('apiversion%3Dapps%2Fv1') // encoded = and /
+  })
+
+  it('should handle search link for core resource without apigroup', () => {
+    render(
+      <MemoryRouter>
+        <FleetResourceLink
+          name="test-service"
+          namespace="default"
+          cluster="test-cluster"
+          groupVersionKind={{
+            group: '',
+            version: 'v1',
+            kind: 'Service',
+          }}
+        />
+      </MemoryRouter>
+    )
+
+    const link = screen.getByRole('link')
+    const href = link.getAttribute('href')
+
+    expect(href).toContain('apiversion%3Dv1') // encoded =
+    expect(href).not.toContain('apiversion%3D%2Fv1') // should not have encoded /
+  })
+})

--- a/frontend/packages/multicluster-sdk/src/api/FleetResourceLink.tsx
+++ b/frontend/packages/multicluster-sdk/src/api/FleetResourceLink.tsx
@@ -30,7 +30,7 @@ export const FleetResourceLink: React.FC<FleetResourceLinkProps> = ({ cluster, .
     })
 
     const path =
-      groupVersionKind?.kind === 'VirtualMachine'
+      groupVersionKind?.kind === 'VirtualMachine' && namespace
         ? `/multicloud/infrastructure/virtualmachines/${cluster}/${namespace}/${name}`
         : `/multicloud/search/resources${getURLSearchParam({
             cluster,

--- a/frontend/plugins/mce/console-extensions.ts
+++ b/frontend/plugins/mce/console-extensions.ts
@@ -137,6 +137,18 @@ const virtualMachinesRoute: EncodedExtension<RoutePage> = {
   },
 }
 
+// Virtual Machines Detail Route - type: 'console.page/route'
+const virtualMachinesDetailRoute: EncodedExtension<RoutePage> = {
+  type: 'console.page/route',
+  properties: {
+    path: '/multicloud/infrastructure/virtualmachines/:cluster/:namespace/:name', // with parameters
+    component: { $codeRef: 'vmRedirect.default' }, // points to VMRedirect
+  },
+  flags: {
+    disallowed: ['KUBEVIRT_DYNAMIC_ACM'],
+  },
+}
+
 // Credentials Navigation Item - type: 'console.navigation/href'
 const credentialsNavItem: EncodedExtension<HrefNavItem> = {
   type: 'console.navigation/href',
@@ -169,6 +181,7 @@ export const extensions: EncodedExtension[] = [
   hostInventoryNavItem,
   hostInventoryRoute,
   virtualMachinesNavItem,
+  virtualMachinesDetailRoute,
   virtualMachinesRoute,
   credentialsNavItem,
   credentialsRoute,

--- a/frontend/plugins/mce/console-plugin-metadata.ts
+++ b/frontend/plugins/mce/console-plugin-metadata.ts
@@ -19,6 +19,7 @@ export const pluginMetadata: ConsolePluginBuildMetadata = {
     automations: '../../src/routes/Infrastructure/Automations/AutomationsPlugin.tsx',
     environments: '../../src/routes/Infrastructure/InfraEnvironments/InfraEnvironmentsPlugin.tsx',
     virtualmachines: '../../src/routes/Infrastructure/VirtualMachines/VirtualMachinesPlugin.tsx',
+    vmRedirect: '../../src/routes/Infrastructure/VirtualMachines/VMRedirect.tsx',
     credentials: '../../src/routes/Credentials/CredentialsPlugin.tsx',
   },
   dependencies: {

--- a/frontend/src/routes/Infrastructure/VirtualMachines/VMRedirect.test.tsx
+++ b/frontend/src/routes/Infrastructure/VirtualMachines/VMRedirect.test.tsx
@@ -1,0 +1,195 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom-v5-compat'
+import VMRedirect from './VMRedirect'
+
+// mock useParams and Navigate
+const mockNavigate = jest.fn()
+const mockUseParams = jest.fn()
+
+jest.mock('react-router-dom-v5-compat', () => ({
+  ...jest.requireActual('react-router-dom-v5-compat'),
+  useParams: () => mockUseParams(),
+  Navigate: ({ to, replace }: { to: string; replace: boolean }) => {
+    mockNavigate(to, replace)
+    return <div data-testid="navigate-mock">Redirecting to: {to}</div>
+  },
+}))
+
+describe('VMRedirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should redirect to search page with correct parameters for VM', () => {
+    mockUseParams.mockReturnValue({
+      cluster: 'test-cluster',
+      namespace: 'default',
+      name: 'test-vm',
+    })
+
+    render(
+      <MemoryRouter>
+        <VMRedirect />
+      </MemoryRouter>
+    )
+
+    const [urlCalled, replaceFlag] = mockNavigate.mock.calls[0]
+
+    expect(urlCalled).toContain('/multicloud/search/resources')
+
+    // Decode the URL to check readable parameters
+    const decodedUrl = decodeURIComponent(urlCalled)
+    expect(decodedUrl).toContain('cluster=test-cluster')
+    expect(decodedUrl).toContain('kind=VirtualMachine')
+    expect(decodedUrl).toContain('apiversion=kubevirt.io/v1')
+    expect(decodedUrl).toContain('namespace=default')
+    expect(decodedUrl).toContain('name=test-vm')
+    expect(replaceFlag).toBe(true)
+  })
+
+  it('should redirect with special characters in cluster name', () => {
+    mockUseParams.mockReturnValue({
+      cluster: 'test-cluster-01',
+      namespace: 'kube-system',
+      name: 'my-vm-test',
+    })
+
+    render(
+      <MemoryRouter>
+        <VMRedirect />
+      </MemoryRouter>
+    )
+
+    const [urlCalled, replaceFlag] = mockNavigate.mock.calls[0]
+
+    expect(urlCalled).toContain('/multicloud/search/resources')
+
+    const decodedUrl = decodeURIComponent(urlCalled)
+    expect(decodedUrl).toContain('cluster=test-cluster-01')
+    expect(decodedUrl).toContain('kind=VirtualMachine')
+    expect(decodedUrl).toContain('apiversion=kubevirt.io/v1')
+    expect(decodedUrl).toContain('namespace=kube-system')
+    expect(decodedUrl).toContain('name=my-vm-test')
+    expect(replaceFlag).toBe(true)
+  })
+
+  it('should redirect with empty namespace', () => {
+    mockUseParams.mockReturnValue({
+      cluster: 'test-cluster',
+      namespace: '',
+      name: 'test-vm',
+    })
+
+    render(
+      <MemoryRouter>
+        <VMRedirect />
+      </MemoryRouter>
+    )
+
+    const [urlCalled, replaceFlag] = mockNavigate.mock.calls[0]
+
+    expect(urlCalled).toContain('/multicloud/search/resources')
+
+    const decodedUrl = decodeURIComponent(urlCalled)
+    expect(decodedUrl).toContain('cluster=test-cluster')
+    expect(decodedUrl).toContain('kind=VirtualMachine')
+    expect(decodedUrl).toContain('apiversion=kubevirt.io/v1')
+    expect(decodedUrl).toContain('name=test-vm')
+    expect(decodedUrl).not.toContain('namespace=')
+    expect(replaceFlag).toBe(true)
+  })
+
+  it('should redirect with missing parameters', () => {
+    mockUseParams.mockReturnValue({
+      cluster: 'test-cluster',
+      namespace: undefined,
+      name: undefined,
+    })
+
+    render(
+      <MemoryRouter>
+        <VMRedirect />
+      </MemoryRouter>
+    )
+
+    const [urlCalled, replaceFlag] = mockNavigate.mock.calls[0]
+
+    expect(urlCalled).toContain('/multicloud/search/resources')
+
+    const decodedUrl = decodeURIComponent(urlCalled)
+    expect(decodedUrl).toContain('cluster=test-cluster')
+    expect(decodedUrl).toContain('kind=VirtualMachine')
+    expect(decodedUrl).toContain('apiversion=kubevirt.io/v1')
+    // namespace and name should not appear when missing
+    expect(decodedUrl).not.toContain('namespace=')
+    expect(decodedUrl).not.toContain('name=')
+    expect(replaceFlag).toBe(true)
+  })
+
+  it('should always use replace navigation', () => {
+    mockUseParams.mockReturnValue({
+      cluster: 'cluster',
+      namespace: 'ns',
+      name: 'vm',
+    })
+
+    render(
+      <MemoryRouter>
+        <VMRedirect />
+      </MemoryRouter>
+    )
+
+    const [urlCalled, replaceFlag] = mockNavigate.mock.calls[0]
+
+    expect(urlCalled).toContain('/multicloud/search/resources')
+    expect(replaceFlag).toBe(true)
+  })
+
+  it('should handle complex VM names and namespaces', () => {
+    mockUseParams.mockReturnValue({
+      cluster: 'prod-cluster',
+      namespace: 'my-app-namespace',
+      name: 'web-server-vm-001',
+    })
+
+    render(
+      <MemoryRouter>
+        <VMRedirect />
+      </MemoryRouter>
+    )
+
+    const [urlCalled, replaceFlag] = mockNavigate.mock.calls[0]
+
+    expect(urlCalled).toContain('/multicloud/search/resources')
+
+    const decodedUrl = decodeURIComponent(urlCalled)
+    expect(decodedUrl).toContain('cluster=prod-cluster')
+    expect(decodedUrl).toContain('kind=VirtualMachine')
+    expect(decodedUrl).toContain('apiversion=kubevirt.io/v1')
+    expect(decodedUrl).toContain('namespace=my-app-namespace')
+    expect(decodedUrl).toContain('name=web-server-vm-001')
+    expect(replaceFlag).toBe(true)
+  })
+
+  it('should always redirect to VirtualMachine kind regardless of input', () => {
+    mockUseParams.mockReturnValue({
+      cluster: 'any-cluster',
+      namespace: 'any-namespace',
+      name: 'any-name',
+    })
+
+    render(
+      <MemoryRouter>
+        <VMRedirect />
+      </MemoryRouter>
+    )
+
+    const [urlCalled] = mockNavigate.mock.calls[0]
+
+    // should always hardcode VM-specific values
+    const decodedUrl = decodeURIComponent(urlCalled)
+    expect(decodedUrl).toContain('kind=VirtualMachine')
+    expect(decodedUrl).toContain('apiversion=kubevirt.io/v1')
+  })
+})

--- a/frontend/src/routes/Infrastructure/VirtualMachines/VMRedirect.tsx
+++ b/frontend/src/routes/Infrastructure/VirtualMachines/VMRedirect.tsx
@@ -1,0 +1,18 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { Navigate, useParams } from 'react-router-dom-v5-compat'
+import { GetUrlSearchParam } from '../../Search/searchDefinitions'
+
+export default function VMRedirect() {
+  const { cluster, namespace, name } = useParams()
+
+  const searchParams = GetUrlSearchParam({
+    cluster,
+    namespace,
+    name,
+    kind: 'VirtualMachine',
+    apigroup: 'kubevirt.io',
+    apiversion: 'v1',
+  })
+
+  return <Navigate to={`/multicloud/search/resources${searchParams}`} replace />
+}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
Implemented fallback routing that redirects VM URLs to search when CNV is missing, allows CNV override when present.

- [X] VMRedirect component: Redirects VM detail URLs to search results with proper VM parameters
- [X] Plugin metadata: Registered VMRedirect component
- [X] CNV not installed: `/virtualmachines/cluster/ns/vm` → redirects to search results
- [X] CNV installed: VM routes disabled by existing flag, CNV provides native VM pages
- [X] Tests


**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-21337

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [X] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [X] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [X] Code builds and runs locally without errors
- [X] No console logs, commented-out code, or unnecessary files
- [X] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [X] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->