### PR TITLE
ACM-14666: HCP kubevirt 4.15.0-x86_64 updates toa multi architecture instead of x86_64

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -46,6 +46,12 @@ const isUpdateVersionAcceptable = (currentVersion: string, newVersion: string) =
 
   return false
 }
+export const getCPUArchFromReleaseImage = (releaseImage = '') => {
+  const match = /.+:.*-(.*)/gm.exec(releaseImage)
+  if (match && match.length > 1 && match[1]) {
+    return match[1]
+  }
+}
 
 export function DistributionField(props: {
   cluster?: Cluster
@@ -76,7 +82,8 @@ export function DistributionField(props: {
     }
     const updates: any = {}
     clusterImageSets.forEach((cis) => {
-      if (cis.spec?.releaseImage.includes('multi')) {
+      const archType = getCPUArchFromReleaseImage(cis.spec?.releaseImage) ?? 'multi'
+      if (cis.spec?.releaseImage.includes(archType)) {
         const releaseImageVersion = getVersionFromReleaseImage(cis.spec?.releaseImage)
         if (
           releaseImageVersion &&

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -72,6 +72,8 @@ export function DistributionField(props: {
     name: props.cluster?.name,
     namespace: props.cluster?.namespace,
   })
+  const image = props.cluster?.distribution?.ocp?.desired?.image
+  const archType = getCPUArchFromReleaseImage(image) ?? 'multi'
 
   const openshiftText = 'OpenShift'
   const microshiftText = 'MicroShift'
@@ -82,7 +84,6 @@ export function DistributionField(props: {
     }
     const updates: any = {}
     clusterImageSets.forEach((cis) => {
-      const archType = getCPUArchFromReleaseImage(cis.spec?.releaseImage) ?? 'multi'
       if (cis.spec?.releaseImage.includes(archType)) {
         const releaseImageVersion = getVersionFromReleaseImage(cis.spec?.releaseImage)
         if (
@@ -96,6 +97,7 @@ export function DistributionField(props: {
 
     return updates
   }, [
+    archType,
     clusterImageSets,
     props.cluster?.distribution?.ocp?.version,
     props.cluster?.isHostedCluster,


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
ACM-14666: HCP kubevirt 4.15.0-x86_64 updates toa multi architecture instead of x86_64
**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
Ticket: https://issues.redhat.com/browse/ACM-14666

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->