### PR TITLE
fix useFleetK8sAPIPath throwing errors

### DIFF
--- a/frontend/packages/multicluster-sdk/src/api/useFleetK8sAPIPath.ts
+++ b/frontend/packages/multicluster-sdk/src/api/useFleetK8sAPIPath.ts
@@ -9,28 +9,35 @@ import { useHubClusterName } from './useHubClusterName'
 export const useFleetK8sAPIPath: UseFleetK8sAPIPath = (cluster) => {
   const [hubClusterName, loaded, error] = useHubClusterName()
 
+  if (!cluster) return [BASE_K8S_API_PATH, true, undefined]
+
   if (!loaded) return [undefined, false, error]
 
-  if (!cluster || cluster === hubClusterName) return [BASE_K8S_API_PATH, true, undefined]
+  if (cluster === hubClusterName) return [BASE_K8S_API_PATH, true, undefined]
 
   return [`${getBackendUrl()}/${MANAGED_CLUSTER_API_PATH}/${cluster}`, loaded, error]
 }
 
+const NO_MULTICLUSTER = 'NO_MULTICLUSTER'
 let cachedHubClusterName: string | undefined = undefined
 
 export const getFleetK8sAPIPath = async (cluster?: string) => {
+  if (!cluster) return BASE_K8S_API_PATH
+
   if (!cachedHubClusterName) {
     const hubClusters = await k8sListItems({
       model: ManagedClusterModel,
       queryParams: { labelSelector: { matchLabels: { [LOCAL_CLUSTER_LABEL]: true } } },
+    }).catch((error) => {
+      if (error.code === 404) {
+        return []
+      }
     })
 
-    cachedHubClusterName = hubClusters?.[0]?.metadata?.name
+    cachedHubClusterName = hubClusters?.[0]?.metadata?.name || NO_MULTICLUSTER
   }
 
-  if (cluster && cachedHubClusterName !== cluster) {
-    return `${getBackendUrl()}/${MANAGED_CLUSTER_API_PATH}/${cluster}`
-  } else {
-    return BASE_K8S_API_PATH
-  }
+  return cluster && cachedHubClusterName !== cluster
+    ? `${getBackendUrl()}/${MANAGED_CLUSTER_API_PATH}/${cluster}`
+    : BASE_K8S_API_PATH
 }

--- a/frontend/packages/multicluster-sdk/src/components/FleetResourceEventStream/EventComponent.tsx
+++ b/frontend/packages/multicluster-sdk/src/components/FleetResourceEventStream/EventComponent.tsx
@@ -76,7 +76,9 @@ const Inner: FC<EventComponentProps> = ({ event, cache, list, index }) => {
               {component === 'kubelet' && canGetNodes && (
                 <Trans ns="public">
                   Generated from {{ sourceComponent: component }} on{' '}
-                  <Link to={resourcePathFromModel(NodeModel, source.host)}>{{ sourceHost: source.host }}</Link>
+                  <Link to={resourcePathFromModel(NodeModel, source.host)}>
+                    <>{{ sourceHost: source.host }}</>
+                  </Link>
                 </Trans>
               )}
               {component === 'kubelet' &&
@@ -90,14 +92,16 @@ const Inner: FC<EventComponentProps> = ({ event, cache, list, index }) => {
               {count > 1 && firstTime && (
                 <Trans ns="public">
                   <small className="co-sysevent__count pf-v6-u-text-color-subtle">
-                    {{ eventCount: count }} times in the last{' '}
+                    <>{{ eventCount: count }}</> times in the last{' '}
                     <Timestamp timestamp={firstTime} simple={true} omitSuffix={true} />
                   </small>
                 </Trans>
               )}
               {count > 1 && !firstTime && (
                 <Trans ns="public">
-                  <small className="co-sysevent__count pf-v6-u-text-color-subtle">{{ eventCount: count }} times</small>
+                  <small className="co-sysevent__count pf-v6-u-text-color-subtle">
+                    <>{{ eventCount: count }}</> times
+                  </small>
                 </Trans>
               )}
             </div>

--- a/frontend/packages/multicluster-sdk/src/components/FleetResourceEventStream/EventStream.tsx
+++ b/frontend/packages/multicluster-sdk/src/components/FleetResourceEventStream/EventStream.tsx
@@ -102,7 +102,7 @@ const ResourceEventStream: FC<{ resource: K8sResourceCommon }> = ({ resource }) 
       ws.current.onclose = (evt: CloseEvent) => {
         setActive(false)
         if (evt?.wasClean === false) {
-          setError(evt.reason || t('public~Connection did not close cleanly.'))
+          setError(true)
         }
       }
 


### PR DESCRIPTION
We have to guard if the cluster that we are running does not have `ManagedCluster` CRD installed (as it does not have acm maybe)



If no cluster provided there is no need to fire requests and waiting. We already know that its the local cluster.

Other fixes are typescripts complains during build