### PR TITLE
Add watch script for auto-rebuild when SDK changes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17333,6 +17333,16 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "node_modules/exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "merge": "^1.2.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -26109,6 +26119,13 @@
         "map-or-similar": "^1.5.0"
       }
     },
+    "node_modules/merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -33557,6 +33574,23 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha512-1u+Z5n9Jc1E2c7qDO8SinPoZuHj7FgbgU1olSFoyaklduDvvtX7GMMtlE6OC9FTXq4KvNAOfj6Zu4vI1e9bAKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "watch": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.1.95"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
@@ -34613,7 +34647,8 @@
         "jest-sonar-reporter": "^2.0.0",
         "prettier": "^3.2.5",
         "tsdoc-markdown": "^1.3.0",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "watch": "^1.0.2"
       },
       "peerDependencies": {
         "@openshift-console/dynamic-plugin-sdk": ">=1.0.0 || >=4.19.0-prerelease"
@@ -39576,7 +39611,8 @@
         "react-transition-group": "^4.4.5",
         "react-virtualized": "^9.22.6",
         "tsdoc-markdown": "^1.3.0",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "watch": "^1.0.2"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -47485,6 +47521,15 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "exec-sh": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.2.tgz",
+      "integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
+      "dev": true,
+      "requires": {
+        "merge": "^1.2.0"
+      }
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -53958,6 +54003,12 @@
         "map-or-similar": "^1.5.0"
       }
     },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
+    },
     "merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -59482,6 +59533,16 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.12"
+      }
+    },
+    "watch": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
+      "integrity": "sha512-1u+Z5n9Jc1E2c7qDO8SinPoZuHj7FgbgU1olSFoyaklduDvvtX7GMMtlE6OC9FTXq4KvNAOfj6Zu4vI1e9bAKA==",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       }
     },
     "watchpack": {

--- a/frontend/packages/multicluster-sdk/package.json
+++ b/frontend/packages/multicluster-sdk/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/stolostron/console/tree/main/frontend/packages/multicluster-sdk#readme",
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
+    "watch": "watch 'npm run build' src",
     "tsc": "tsc --noEmit",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "lint:fix": "npm run lint -- --fix",
@@ -56,7 +57,8 @@
     "jest-sonar-reporter": "^2.0.0",
     "prettier": "^3.2.5",
     "tsdoc-markdown": "^1.3.0",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "watch": "^1.0.2"
   },
   "prettier": "@stolostron/prettier-config",
   "dependencies": {


### PR DESCRIPTION
# 📝 Summary

Adds a `watch` script for the multicluster-sdk workspace which watches for changes and rebuilds. This is convenient when developing or debugging and linking to the package from a consuming plugin.

This PR also modifies `npm run plugins` to automatically include calling this watch.

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [x] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->