### PR TITLE
ACM-20341: change advancedSearch option type

### DIFF
--- a/frontend/packages/multicluster-sdk/src/api/search/types.ts
+++ b/frontend/packages/multicluster-sdk/src/api/search/types.ts
@@ -6,7 +6,9 @@ export type SearchResult<R extends K8sResourceCommon | K8sResourceCommon[]> = R 
   ? MulticlusterResource<T>[]
   : MulticlusterResource<R>
 
+export type AdvacedSearchFilter = { property: string; values: string[] }[]
+
 export type UseMulticlusterSearchWatch = <T extends K8sResourceCommon | K8sResourceCommon[]>(
   watchOptions: WatchK8sResource,
-  advancedSearch?: { [key: string]: string }
+  advancedSearchFilters?: AdvacedSearchFilter
 ) => [SearchResult<T> | undefined, boolean, Error | undefined]


### PR DESCRIPTION
We should use an array instead of object because we can use multiple times the same key to have a strinct query like

`created:>DATE_FROM created:<DATE_TO` This type of query cannot be achieved with an object argument as the key `created` cannot be populated multiple times 