### PR TITLE
ACM-21111: Truncate, highlightSearchText

### DIFF
--- a/frontend/src/components/HighlightSearchText.test.tsx
+++ b/frontend/src/components/HighlightSearchText.test.tsx
@@ -2,18 +2,18 @@
 import { render } from '@testing-library/react'
 import { screen } from '@testing-library/dom'
 import { HighlightSearchText } from './HighlightSearchText'
+import { getFragmentedTextMatcher } from '../lib/test-util'
 
-const highlightCssClass = 'css-uh6mpl' // Example class name for highlighted text
 describe('HighlightSearchText', () => {
   it('should render highlighted text when searchText matches part of the text', () => {
     render(<HighlightSearchText text="key=value" searchText="key" />)
-    expect(screen.getByText('key')).toHaveClass(highlightCssClass)
-    expect(screen.getByText('=value')).not.toHaveClass(highlightCssClass)
+    expect(screen.getByText('key')).toHaveAttribute('data-highlight', 'true')
+    expect(screen.getByText('=value')).not.toHaveAttribute('data-highlight')
   })
 
   it('should render the full text without highlights when searchText is empty', () => {
     render(<HighlightSearchText text="key=value" searchText="" />)
-    expect(screen.getByText('key=value')).not.toHaveClass(highlightCssClass)
+    expect(screen.getByText('key=value')).not.toHaveAttribute('data-highlight')
   })
 
   it('should render a toggle button when supportsInequality is true', () => {
@@ -21,18 +21,125 @@ describe('HighlightSearchText', () => {
     expect(screen.getByRole('button')).toBeInTheDocument()
   })
 
-  it('should truncate the text when isTruncate is true and text exceeds max length', () => {
-    render(<HighlightSearchText text="very-very-very-long-key=value" isTruncate={true} />)
-    expect(screen.getByText('very-very..ery-long-key=value')).toBeInTheDocument()
+  it('should truncate the text when text exceeds max length', () => {
+    render(<HighlightSearchText text="very-very-very-very-very-very-long-key=value" />)
+    // Text may be fragmented across multiple elements due to truncation
+    expect(
+      screen.getAllByText(getFragmentedTextMatcher('very-very-very-very-very-very-long-key=value'))[0]
+    ).toBeInTheDocument()
   })
 
-  it('should render the full text when isTruncate is false', () => {
-    render(<HighlightSearchText text="key=value" isTruncate={false} />)
+  it('should render the full text when it does not exceed max length', () => {
+    render(<HighlightSearchText text="key=value" />)
     expect(screen.getByText('key=value')).toBeInTheDocument()
   })
-
   it('should render null when no text is provided', () => {
     const { container } = render(<HighlightSearchText />)
     expect(container.firstChild).toBeNull()
+  })
+
+  it('should render links with data-link attribute when isLink is true', () => {
+    render(<HighlightSearchText text="example.com" isLink={true} />)
+    expect(screen.getByText('example.com')).toHaveAttribute('data-link', 'true')
+  })
+
+  it('should render highlighted links when isLink is true and searchText matches', () => {
+    render(<HighlightSearchText text="example.com" searchText="example" isLink={true} />)
+    expect(screen.getByText('example')).toHaveAttribute('data-highlight', 'true')
+    expect(screen.getByText('example')).toHaveAttribute('data-link', 'true')
+    expect(screen.getByText('.com')).toHaveAttribute('data-link', 'true')
+    expect(screen.getByText('.com')).not.toHaveAttribute('data-highlight')
+  })
+
+  describe('Fuzzy highlighting', () => {
+    it('should use exact matching when found', () => {
+      render(<HighlightSearchText text="operation" searchText="oper" useFuzzyHighlighting={true} />)
+      expect(screen.getByText('oper')).toHaveAttribute('data-highlight', 'true')
+      expect(screen.getByText('ation')).not.toHaveAttribute('data-highlight')
+    })
+
+    it('should fall back to fuzzy highlighting when exact match not found', () => {
+      const { container } = render(
+        <HighlightSearchText text="operation" searchText="opr" useFuzzyHighlighting={true} />
+      )
+
+      // Look for highlighted elements instead of specific text
+      const highlightedElements = container.querySelectorAll('[data-highlight="true"]')
+      expect(highlightedElements.length).toBeGreaterThan(0)
+
+      // Check that we have the expected highlighted text content
+      // With substring matching, "opr" should highlight all o, p, r characters in "operation"
+      // This includes both 'o' characters, so we get "opro"
+      const highlightedText = Array.from(highlightedElements)
+        .map((el) => el.textContent)
+        .join('')
+      expect(highlightedText).toBe('opro')
+    })
+
+    it('should highlight fuzzy matches in sequence', () => {
+      render(<HighlightSearchText text="operation" searchText="ope" useFuzzyHighlighting={true} />)
+      expect(screen.getByText('ope')).toHaveAttribute('data-highlight', 'true')
+      expect(screen.getByText('ration')).not.toHaveAttribute('data-highlight')
+    })
+
+    it('should highlight all matching substrings regardless of order', () => {
+      const { container } = render(
+        <HighlightSearchText text="operation" searchText="otn" useFuzzyHighlighting={true} />
+      )
+
+      // With substring matching, all 'o', 't', 'n' characters should be highlighted
+      const highlightedElements = container.querySelectorAll('[data-highlight="true"]')
+      expect(highlightedElements.length).toBeGreaterThan(0)
+
+      // Check that we highlight all instances of o, t, n
+      // This includes both 'o' characters, so we get "oton"
+      const highlightedText = Array.from(highlightedElements)
+        .map((el) => el.textContent)
+        .join('')
+      expect(highlightedText).toBe('oton')
+    })
+
+    it('should highlight repeated characters multiple times', () => {
+      const { container } = render(<HighlightSearchText text="pepper" searchText="pp" useFuzzyHighlighting={true} />)
+
+      // Both 'p' characters should be highlighted
+      const highlightedElements = container.querySelectorAll('[data-highlight="true"]')
+      const highlightedText = Array.from(highlightedElements)
+        .map((el) => el.textContent)
+        .join('')
+      expect(highlightedText).toBe('pp')
+    })
+
+    it('should not highlight when fuzzy highlighting is disabled', () => {
+      render(<HighlightSearchText text="operation" searchText="opr" useFuzzyHighlighting={false} />)
+      expect(screen.getByText('operation')).not.toHaveAttribute('data-highlight')
+    })
+
+    it('should work with links and fuzzy highlighting', () => {
+      const { container } = render(
+        <HighlightSearchText text="operation.com" searchText="opr" isLink={true} useFuzzyHighlighting={true} />
+      )
+
+      // Look for highlighted elements
+      const highlightedElements = container.querySelectorAll('[data-highlight="true"]')
+      expect(highlightedElements.length).toBeGreaterThan(0)
+
+      // Check that we have the expected highlighted text content
+      // This includes all 'o' characters (3 total: positions 0, 7, 11) plus 'p' and 'r', so we get "oproo"
+      const highlightedText = Array.from(highlightedElements)
+        .map((el) => el.textContent)
+        .join('')
+      expect(highlightedText).toBe('oproo')
+
+      // Check that link attributes are present
+      const linkElements = container.querySelectorAll('[data-link="true"]')
+      expect(linkElements.length).toBeGreaterThan(0)
+    })
+
+    it('should handle case-insensitive fuzzy matching', () => {
+      render(<HighlightSearchText text="Operation" searchText="oper" useFuzzyHighlighting={true} />)
+      expect(screen.getByText('Oper')).toHaveAttribute('data-highlight', 'true')
+      expect(screen.getByText('ation')).not.toHaveAttribute('data-highlight')
+    })
   })
 })

--- a/frontend/src/components/HighlightSearchText.tsx
+++ b/frontend/src/components/HighlightSearchText.tsx
@@ -2,24 +2,27 @@
 import { css } from '@emotion/css'
 import { Button } from '@patternfly/react-core'
 import { parseLabel } from '../resources/utils'
-import { MouseEventHandler } from 'react'
-
-const MAX_LABEL_WIDTH = 28
+import { Truncate } from './Truncate'
 
 const buttonDivClass = css({
   '&:hover > button:after': {
-    borderColor: 'rgb(21, 21, 21) !important',
+    borderColor: 'rgb(21, 21, 21)',
   },
   '&:hover > button': {
-    backgroundColor: 'white !important',
+    backgroundColor: 'white',
   },
 })
 
 const buttonClass = css({
-  padding: '4px 0px !important',
-  lineHeight: '10px !important',
+  padding: '4px 0px',
+  lineHeight: '10px',
   margin: '0 2px',
   minWidth: '16px',
+  // Higher specificity to override PatternFly button styles
+  '&.pf-v5-c-button.pf-m-plain': {
+    padding: '4px 0px',
+    lineHeight: '10px',
+  },
 })
 
 const highlightClass = css({
@@ -27,49 +30,239 @@ const highlightClass = css({
   textDecoration: 'underline',
   background: 'none',
   fontWeight: 600,
+  // Higher specificity to ensure underline is preserved
+  '&[data-highlight="true"]': {
+    textDecoration: 'underline',
+  },
 })
+
+const linkClass = css({
+  color: 'var(--pf-v5-global--link--Color)',
+  textDecoration: 'underline',
+  background: 'none',
+  fontWeight: 'normal',
+  // Higher specificity to ensure underline is preserved
+  '&[data-link="true"]': {
+    textDecoration: 'underline',
+  },
+})
+
+// Helper function to create highlighted text segments for fuzzy matching
+// This matches every character from searchText that appears anywhere in the text
+const createFuzzyHighlightedSegments = (text: string, searchText: string) => {
+  if (!searchText) return [{ text, isMatch: false, key: `${text}-0-false` }]
+
+  const segments: { text: string; isMatch: boolean; key: string }[] = []
+  const searchLower = searchText.toLowerCase()
+  const textLower = text.toLowerCase()
+
+  // Create a set of characters to highlight (each character from searchText)
+  const searchChars = new Set(searchLower.split(''))
+
+  let currentSegment = ''
+  let isCurrentSegmentMatch = false
+
+  for (let textIndex = 0; textIndex < text.length; textIndex++) {
+    const textChar = textLower[textIndex]
+
+    // Check if current character is one we want to highlight
+    const isMatch = searchChars.has(textChar)
+
+    if (isMatch !== isCurrentSegmentMatch) {
+      // Segment type is changing, finish the current segment
+      if (currentSegment) {
+        segments.push({
+          text: currentSegment,
+          isMatch: isCurrentSegmentMatch,
+          key: `${currentSegment}-${textIndex - currentSegment.length}-${isCurrentSegmentMatch}`,
+        })
+        currentSegment = ''
+      }
+      isCurrentSegmentMatch = isMatch
+    }
+
+    // Add character to current segment
+    currentSegment += text[textIndex]
+  }
+
+  // Add final segment
+  if (currentSegment) {
+    segments.push({
+      text: currentSegment,
+      isMatch: isCurrentSegmentMatch,
+      key: `${currentSegment}-${text.length - currentSegment.length}-${isCurrentSegmentMatch}`,
+    })
+  }
+
+  return segments
+}
+
+// Helper function to create highlighted text segments for exact matching (original logic)
+const createExactHighlightedSegments = (text: string, searchText: string) => {
+  if (!searchText) return [{ text, isMatch: false, key: `${text}-0-false` }]
+
+  const segments: { text: string; isMatch: boolean; key: string }[] = []
+  const searchLower = searchText.toLowerCase()
+  const textLower = text.toLowerCase()
+
+  let lastIndex = 0
+  let searchIndex = textLower.indexOf(searchLower)
+
+  while (searchIndex !== -1) {
+    // Add non-matching segment before the match
+    if (searchIndex > lastIndex) {
+      const segmentText = text.slice(lastIndex, searchIndex)
+      segments.push({
+        text: segmentText,
+        isMatch: false,
+        key: `${segmentText}-${lastIndex}-false`,
+      })
+    }
+
+    // Add matching segment using the actual found match length
+    const matchText = text.slice(searchIndex, searchIndex + searchLower.length)
+    segments.push({
+      text: matchText,
+      isMatch: true,
+      key: `${matchText}-${searchIndex}-true`,
+    })
+
+    lastIndex = searchIndex + searchLower.length
+    searchIndex = textLower.indexOf(searchLower, lastIndex)
+  }
+
+  // Add remaining non-matching segment
+  if (lastIndex < text.length) {
+    const segmentText = text.slice(lastIndex)
+    segments.push({
+      text: segmentText,
+      isMatch: false,
+      key: `${segmentText}-${lastIndex}-false`,
+    })
+  }
+
+  return segments
+}
+
+// Main function to create highlighted segments - tries exact match first, then fuzzy
+const createHighlightedSegments = (text: string, searchText: string, useFuzzyHighlighting = false) => {
+  if (!searchText) return [{ text, isMatch: false, key: `${text}-0-false` }]
+
+  // First try exact matching
+  const exactSegments = createExactHighlightedSegments(text, searchText)
+  const hasExactMatch = exactSegments.some((seg) => seg.isMatch)
+
+  // If we found exact matches or fuzzy highlighting is disabled, use exact matching
+  if (hasExactMatch || !useFuzzyHighlighting) {
+    return exactSegments
+  }
+
+  // Otherwise, try fuzzy matching
+  const fuzzySegments = createFuzzyHighlightedSegments(text, searchText)
+  const hasFuzzyMatch = fuzzySegments.some((seg) => seg.isMatch)
+
+  // Only return fuzzy segments if they actually found matches
+  return hasFuzzyMatch ? fuzzySegments : exactSegments
+}
 
 // render text with highlights for searched filter text
 // if text is a label like 'key=value', add a toggle button that toggles between = and !=
-// if truncate is set, also make label smaller with ellipses
+// truncation is always handled by the Truncate component
 export function HighlightSearchText(
   props: Readonly<{
     text?: string
     searchText?: string
     supportsInequality?: boolean
     toggleEquality?: () => void
-    isTruncate?: boolean
+    isLink?: boolean
+    useFuzzyHighlighting?: boolean
   }>
 ) {
-  const { text, searchText, supportsInequality, toggleEquality, isTruncate } = props
-  const segments = getSlicedText(text, searchText)
-  if (segments.length > 1) {
-    const isTruncateLabel = isTruncate && text && text.length > MAX_LABEL_WIDTH
-    return (
-      <>
-        {segments.map((seg, inx) => {
-          if (supportsInequality && !!parseLabel(seg.text).oper) {
-            return <ToggleButton key={Number(inx)} label={seg.text} toggleEquality={toggleEquality} />
-          }
-          return (
-            <span key={Number(inx)} className={seg.isBold ? highlightClass : ''}>
-              {isTruncateLabel && !seg.isBold ? '...' : seg.text}
-            </span>
-          )
-        })}
-      </>
-    )
-  } else if (isTruncate) {
-    return truncate(text) ?? null
-  } else if (supportsInequality && text) {
+  const { text, searchText, supportsInequality, toggleEquality, isLink, useFuzzyHighlighting = false } = props
+
+  if (!text) return null
+
+  // Handle toggle button case for inequality operators
+  if (supportsInequality && parseLabel(text).oper) {
     return <ToggleButton label={text} toggleEquality={toggleEquality} />
   }
-  return text ?? null
+
+  // Handle link rendering (with or without search highlighting)
+  if (isLink) {
+    let content
+    if (searchText) {
+      const segments = createHighlightedSegments(text, searchText, useFuzzyHighlighting)
+      if (segments.some((seg) => seg.isMatch)) {
+        // Link with search highlighting
+        content = segments.map((segment) => (
+          <span
+            key={segment.key}
+            className={segment.isMatch ? highlightClass : linkClass}
+            data-highlight={segment.isMatch ? 'true' : undefined}
+            data-link="true"
+          >
+            {segment.text}
+          </span>
+        ))
+      } else {
+        // Fallback to simple link
+        content = (
+          <span className={linkClass} data-link="true">
+            {text}
+          </span>
+        )
+      }
+    } else {
+      // Simple link without search
+      content = (
+        <span className={linkClass} data-link="true">
+          {text}
+        </span>
+      )
+    }
+
+    return (
+      <Truncate content={text} position="end" isLink={true}>
+        {content}
+      </Truncate>
+    )
+  }
+
+  // Handle search highlighting (non-link)
+  if (searchText) {
+    const segments = createHighlightedSegments(text, searchText, useFuzzyHighlighting)
+
+    // Only create segments if there are actual matches
+    if (segments.some((seg) => seg.isMatch)) {
+      const highlightedContent = (
+        <>
+          {segments.map((segment) => (
+            <span
+              key={segment.key}
+              className={segment.isMatch ? highlightClass : ''}
+              data-highlight={segment.isMatch ? 'true' : undefined}
+            >
+              {segment.text}
+            </span>
+          ))}
+        </>
+      )
+
+      return (
+        <Truncate content={text} position="end">
+          {highlightedContent}
+        </Truncate>
+      )
+    }
+  }
+
+  // Default case - truncate the text using position="end" to avoid fragmentation
+  return <Truncate content={text} position="end" />
 }
 
 interface ToggleButtonProps {
   label: string
-  toggleEquality?: MouseEventHandler<HTMLButtonElement>
+  toggleEquality?: () => void
 }
 
 const ToggleButton = ({ label, toggleEquality }: ToggleButtonProps) => {
@@ -83,140 +276,4 @@ const ToggleButton = ({ label, toggleEquality }: ToggleButtonProps) => {
       <span style={{ marginRight: '4px' }}>{suffix}</span>
     </div>
   )
-}
-
-interface SlicedText {
-  text: string
-  isBold: boolean
-}
-
-export const truncate = (label?: string) => {
-  return label && label?.length > MAX_LABEL_WIDTH
-    ? label.slice(0, MAX_LABEL_WIDTH / 3) + '..' + label.slice((-MAX_LABEL_WIDTH * 2) / 3)
-    : label
-}
-
-const getSlicedText = (itemId: string = '', filterText: string = ''): SlicedText[] => {
-  const slicedText = []
-  if (filterText) {
-    const lcs = lcss(itemId, filterText)
-    let pos = 0
-
-    lcs.forEach(({ beg, end }) => {
-      slicedText.push({ text: itemId.slice(pos, beg), isBold: false })
-      slicedText.push({ text: itemId.slice(beg, end + 1), isBold: true })
-      pos = end + 1
-    })
-    if (pos < itemId.length) {
-      slicedText.push({ text: itemId.slice(pos), isBold: false })
-    }
-  } else {
-    return [{ text: itemId, isBold: false }]
-  }
-  return slicedText
-}
-
-const lcs = (str1: string, str2: string) => {
-  let sequence = ''
-  const str1Length = str1.length
-  const str2Length = str2.length
-  const num = new Array(str1Length)
-  let maxlen = 0
-  let lastSubsBegin = 0
-  let i = 0
-  let j = 0
-  while (i < str1Length) {
-    // create an array the length of the 2nd string
-    // to count the number of times a character is present in both strings
-    const subArray = new Array(str2Length)
-    j = 0
-    while (j < str2Length) {
-      subArray[j] = 0
-      j += 1
-    }
-    num[i] = subArray
-    i += 1
-  }
-  let thisSubsBegin = null
-  i = 0
-  while (i < str1Length) {
-    j = 0
-    while (j < str2Length) {
-      // if the characters don't match, set count to 0
-      // also set matching spaces to 0 since we are replacing previouly found
-      //  matches above with spaces, we don't want spaces to match either
-      // otherwise the spaces in these two strings '987   89' and '873   '
-      //  will be returned as the longest common string instead of 87
-      if (str1[i] !== str2[j] || (str1[i] === ' ' && str2[j] === ' ')) {
-        num[i][j] = 0
-      } else {
-        if (i === 0 || j === 0) {
-          num[i][j] = 1
-        } else {
-          num[i][j] = 1 + num[i - 1][j - 1]
-        }
-        if (num[i][j] > maxlen) {
-          maxlen = num[i][j]
-          thisSubsBegin = i - num[i][j] + 1
-          if (lastSubsBegin === thisSubsBegin) {
-            sequence += str1[i]
-          } else {
-            lastSubsBegin = thisSubsBegin
-            sequence = str1.substring(lastSubsBegin, i + 1)
-          }
-        }
-      }
-      j += 1
-    }
-    i += 1
-  }
-  return sequence
-}
-
-// find the longest common string between two strings
-// iow for these two strings 873456 and 98745687 the longest common string is 456
-// we use this to find the characters that match with the search term in order to boldface it
-const lcss = (str1: string, str2: string) => {
-  let matches
-  let item = str1
-  let find = str2
-  let ret: { beg: number; end: number }[] = []
-  do {
-    // find all occurances of current longest string
-    // save them and replace with spaces
-    let match
-    matches = []
-    let res = lcs(item, find)
-    if (res.length > 0) {
-      // escape search pattern (ex: if there's a period, escape to \\.)
-      const { length: len } = res
-      res = res.replace(/[-[\]{}()*+?.,\\^$|#]/g, '\\$&')
-      const regex = new RegExp(res, 'g')
-      do {
-        match = regex.exec(item)
-        if (match) matches.push(match)
-      } while (match !== null)
-      if (matches.length) {
-        ret = [
-          ...ret,
-          ...matches.map((match) => {
-            const beg = match.index
-            const end = beg + match[0].length - 1
-            return { beg, end }
-          }),
-        ]
-        // so that we don't constantly find the same matches over and over again
-        // we replace the matching characters with spaces
-        // iow the above strings (873456 and 98745687) become '987   87' and '873   ' so that 456 isn't found again
-        item = item.replace(regex, () => ' '.repeat(len))
-        find = find.replace(regex, () => ' '.repeat(len))
-      }
-    }
-  } while (find.length && matches.length)
-
-  // longest common strings will be found out of order
-  // but when we create the string it needs in order
-  ret.sort(({ beg: begA }, { beg: begB }) => begA - begB)
-
-  return ret
 }

--- a/frontend/src/components/Truncate.tsx
+++ b/frontend/src/components/Truncate.tsx
@@ -1,6 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { Tooltip, TooltipPosition } from '@patternfly/react-core'
 import React from 'react'
+import useResizeObserver from '@react-hook/resize-observer'
 import './Truncate.css'
 
 export enum TruncatePosition {
@@ -41,9 +42,96 @@ interface TruncateProps extends React.HTMLProps<HTMLSpanElement> {
     | 'left-end'
     | 'right-start'
     | 'right-end'
+  /** Children to render (for highlighted content) */
+  children?: React.ReactNode
+  /** Whether this is a link (affects tooltip styling) */
+  isLink?: boolean
 }
 
 const sliceContent = (str: string, slice: number) => [str.slice(0, str.length - slice), str.slice(-slice)]
+
+// Helper function to create styled tooltip content
+const createTooltipContent = (children: React.ReactNode, content: string, isLink: boolean) => {
+  // Helper to extract text content and create styled HTML
+  const createStyledTooltipElement = (element: React.ReactElement): React.ReactElement => {
+    const PF_VAR_WHITE = 'var(--pf-v5-global--palette--white)'
+    const PF_VAR_LINK_COLOR = 'var(--pf-v5-global--link--Color)'
+
+    if (React.isValidElement(element)) {
+      const props = element.props as any
+      let style: React.CSSProperties = {}
+
+      // Apply tooltip-specific styling based on data attributes
+      const isHighlighted = props['data-highlight'] === 'true'
+      const isLinkText = props['data-link'] === 'true' || isLink
+
+      if (isHighlighted) {
+        // Highlighted search matches: bold and underlined
+        style = {
+          fontWeight: 'bold',
+          textDecoration: 'underline',
+          color: isLink ? PF_VAR_LINK_COLOR : 'inherit',
+        }
+      } else if (isLinkText && isLink) {
+        // Link text (highlighted or not): white color
+        style = {
+          color: PF_VAR_WHITE,
+        }
+      }
+
+      const textContent = props.children
+
+      return <span style={style}>{textContent}</span>
+    }
+    return element
+  }
+
+  // Handle different types of children
+  if (children) {
+    // Handle array of elements (like from segments.map())
+    if (Array.isArray(children)) {
+      return (
+        <>
+          {children.map((child, index) => {
+            if (React.isValidElement(child)) {
+              // Use existing key or generate stable key based on content
+              const stableKey =
+                child.key || `tooltip-child-${index}-${String((child.props as any)?.children || '').slice(0, 10)}`
+              return React.cloneElement(createStyledTooltipElement(child), { key: stableKey })
+            }
+            return child
+          })}
+        </>
+      )
+    }
+
+    // Handle single React element
+    if (React.isValidElement(children)) {
+      return createStyledTooltipElement(children)
+    }
+
+    // Handle React fragments or other complex node types
+    const childrenArray = React.Children.toArray(children)
+    if (childrenArray.length > 0) {
+      return (
+        <>
+          {childrenArray.map((child, index) => {
+            if (React.isValidElement(child)) {
+              // Use existing key or generate stable key based on content
+              const stableKey =
+                child.key || `tooltip-fragment-${index}-${String(child.props?.children || '').slice(0, 10)}`
+              return React.cloneElement(createStyledTooltipElement(child), { key: stableKey })
+            }
+            return child
+          })}
+        </>
+      )
+    }
+  }
+
+  // Fallback to plain content
+  return content
+}
 
 export const Truncate: React.FunctionComponent<TruncateProps> = ({
   className,
@@ -51,10 +139,113 @@ export const Truncate: React.FunctionComponent<TruncateProps> = ({
   tooltipPosition = 'top',
   trailingNumChars = 7,
   content,
+  children,
+  isLink = false,
   ...props
-}: TruncateProps) => (
-  <Tooltip position={tooltipPosition} content={content}>
-    <span className={`${className} pf-v5-c-truncate`} {...props}>
+}: TruncateProps) => {
+  const [isOverflowing, setIsOverflowing] = React.useState(false)
+  const containerRef = React.useRef<HTMLSpanElement>(null)
+
+  // Check if content is actually overflowing
+  const checkOverflow = React.useCallback(() => {
+    if (containerRef.current && (content || children)) {
+      const containerElement = containerRef.current
+      const textContent = content || containerElement.textContent || ''
+
+      if (!textContent.trim()) {
+        setIsOverflowing(false)
+        return
+      }
+
+      const truncatedElement = containerElement.querySelector('.pf-v5-c-truncate__start, .pf-v5-c-truncate__end')
+
+      if (truncatedElement && truncatedElement.scrollWidth > 0) {
+        const isOverflowing = truncatedElement.scrollWidth > truncatedElement.clientWidth
+        setIsOverflowing(isOverflowing)
+      } else {
+        // In cases where the truncated element is not yet available (first render), we need to measure the text width ahead of time
+        // We create a hidden span element and measure its width
+        const measureSpan = document.createElement('span')
+        measureSpan.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap;top:-9999px;'
+        measureSpan.textContent = textContent
+
+        const computedStyle = window.getComputedStyle(containerElement)
+        measureSpan.style.fontSize = computedStyle.fontSize
+        measureSpan.style.fontFamily = computedStyle.fontFamily
+        measureSpan.style.fontWeight = computedStyle.fontWeight
+
+        document.body.appendChild(measureSpan)
+        const textWidth = measureSpan.offsetWidth
+        document.body.removeChild(measureSpan)
+
+        const containerWidth = containerElement.clientWidth
+        setIsOverflowing(textWidth > containerWidth)
+      }
+    } else {
+      setIsOverflowing(false)
+    }
+  }, [content, children])
+
+  // Check overflow when content or children change, and on initial render
+  React.useLayoutEffect(() => {
+    // Immediate check for content changes
+    checkOverflow()
+
+    // Additional check after paint for initial render accuracy
+    const checkAfterRender = () => {
+      if (containerRef.current && containerRef.current.offsetWidth > 0) {
+        // Element is ready, check overflow
+        checkOverflow()
+      } else {
+        // Element not ready yet, try again after next frame
+        requestAnimationFrame(checkAfterRender)
+      }
+    }
+
+    requestAnimationFrame(checkAfterRender)
+  }, [content, children, checkOverflow])
+
+  // Check overflow when container size changes (with requestAnimationFrame for layout stability)
+  useResizeObserver(
+    containerRef,
+    React.useCallback(() => {
+      // Use requestAnimationFrame to ensure measurement happens after layout
+      requestAnimationFrame(checkOverflow)
+    }, [checkOverflow])
+  )
+
+  // Also listen to window resize as backup
+  React.useEffect(() => {
+    const handleWindowResize = () => {
+      requestAnimationFrame(checkOverflow)
+    }
+
+    window.addEventListener('resize', handleWindowResize)
+    return () => window.removeEventListener('resize', handleWindowResize)
+  }, [checkOverflow])
+
+  // When children are provided (highlighted content), use PatternFly truncation with children
+  if (children) {
+    const truncateContent = (
+      <span ref={containerRef} className={`${className || ''} pf-v5-c-truncate`} {...props}>
+        <span className="pf-v5-c-truncate__start">{children}</span>
+      </span>
+    )
+
+    const tooltipContent = createTooltipContent(children, content, isLink)
+
+    return isOverflowing ? (
+      <Tooltip position={tooltipPosition} content={tooltipContent}>
+        {truncateContent}
+      </Tooltip>
+    ) : (
+      truncateContent
+    )
+  }
+
+  // Original truncation logic for plain text
+  const plainTextContent = (
+    <span ref={containerRef} className={`${className || ''} pf-v5-c-truncate`} {...props}>
       {(position === TruncatePosition.end || position === TruncatePosition.start) && (
         <span className={truncateStyles[position]}>
           {content}
@@ -72,6 +263,14 @@ export const Truncate: React.FunctionComponent<TruncateProps> = ({
         content.slice(0, content.length - trailingNumChars).length <= minWidthCharacters &&
         content}
     </span>
-  </Tooltip>
-)
+  )
+
+  return isOverflowing ? (
+    <Tooltip position={tooltipPosition} content={content}>
+      {plainTextContent}
+    </Tooltip>
+  ) : (
+    plainTextContent
+  )
+}
 Truncate.displayName = 'Truncate'

--- a/frontend/src/lib/test-util.ts
+++ b/frontend/src/lib/test-util.ts
@@ -10,6 +10,24 @@ const waitForOptions = { timeout: waitTimeout }
 
 // By Text
 
+/**
+ * Returns a text matcher function that can find fragmented text across multiple elements.
+ * This extracts the exact pattern used in tests for components like HighlightSearchText and Truncate.
+ *
+ * @param text - The text to search for
+ * @returns A matcher function for use with screen.getAllByText() or screen.getByText()
+ */
+export function getFragmentedTextMatcher(text: string) {
+  return (_: string, element: Element | null) => {
+    const hasText = (node: Element | null) => {
+      if (!node) return false
+      const textContent = node.textContent || ''
+      return textContent.includes(text)
+    }
+    return hasText(element)
+  }
+}
+
 export async function waitForText(text: string, multipleAllowed?: boolean) {
   if (multipleAllowed) {
     await waitFor(() => expect(screen.queryAllByText(text).length).toBeGreaterThan(0), waitForOptions)

--- a/frontend/src/routes/Applications/Overview.test.tsx
+++ b/frontend/src/routes/Applications/Overview.test.tsx
@@ -13,7 +13,7 @@ import {
   nockSearch,
 } from '../../lib/nock-util'
 import { defaultPlugin, PluginContext } from '../../lib/PluginContext'
-import { getCSVDownloadLink, getCSVExportSpies, waitForText } from '../../lib/test-util'
+import { getCSVDownloadLink, getCSVExportSpies, waitForText, getFragmentedTextMatcher } from '../../lib/test-util'
 import {
   ApplicationKind,
   ApplicationSetKind,
@@ -144,7 +144,7 @@ describe('Applications Page', () => {
     expect(screen.getByText(mockApplication0.metadata.namespace!)).toBeTruthy()
     expect(screen.getAllByText('Local')).toBeTruthy()
     expect(screen.getAllByText('Git')).toBeTruthy()
-    expect(screen.getByText('Feb 20, 2024, 3:30 PM')).toBeInTheDocument()
+    expect(screen.getAllByText(getFragmentedTextMatcher('Feb 20, 2024, 3:30 PM'))[0]).toBeInTheDocument()
 
     // appset
     expect(screen.getByText(mockApplicationSet0.metadata.name!)).toBeTruthy()

--- a/frontend/src/routes/Applications/Overview.tsx
+++ b/frontend/src/routes/Applications/Overview.tsx
@@ -146,7 +146,7 @@ export function getApplicationName(application: IApplicationResource, search: st
           search: `?apiVersion=${apiVersion}${clusterQuery}`,
         }}
       >
-        <HighlightSearchText text={application.metadata?.name} searchText={search} isTruncate />
+        <HighlightSearchText text={application.metadata?.name} searchText={search} isLink useFuzzyHighlighting />
       </Link>
     </span>
   )
@@ -155,7 +155,7 @@ export function getApplicationName(application: IApplicationResource, search: st
 export function getApplicationNamespace(resource: IApplicationResource, search: string) {
   return (
     <span style={{ whiteSpace: 'nowrap' }}>
-      <HighlightSearchText text={getAppNamespace(resource)} searchText={search} isTruncate />
+      <HighlightSearchText text={getAppNamespace(resource)} searchText={search} useFuzzyHighlighting />
     </span>
   )
 }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ManagedClusters.tsx
@@ -684,7 +684,7 @@ export function useClusterNameColumn(): IAcmTableColumn<Cluster> {
       <>
         <span style={{ whiteSpace: 'nowrap' }}>
           <Link to={getClusterNavPath(NavigationPath.clusterDetails, cluster)}>
-            <HighlightSearchText text={cluster.displayName} searchText={search} isTruncate />
+            <HighlightSearchText text={cluster.displayName} searchText={search} isLink useFuzzyHighlighting />
           </Link>
         </span>
         {cluster.hive.clusterClaimName && (
@@ -750,7 +750,7 @@ export function useClusterNamespaceColumn(): IAcmTableColumn<Cluster> {
     search: 'namespace',
     cell: (cluster, search) => (
       <span style={{ whiteSpace: 'nowrap' }}>
-        <HighlightSearchText text={cluster.namespace ?? '-'} searchText={search} isTruncate />
+        <HighlightSearchText text={cluster.namespace ?? '-'} searchText={search} useFuzzyHighlighting />
       </span>
     ),
     exportContent: (cluster) => cluster.namespace,

--- a/frontend/src/routes/UserManagement/Identities/Groups/GroupsTableHelper.tsx
+++ b/frontend/src/routes/UserManagement/Identities/Groups/GroupsTableHelper.tsx
@@ -46,7 +46,7 @@ const COLUMN_CELLS = {
   NAME: (group: RbacGroup, search: string) => (
     <span style={{ whiteSpace: 'nowrap' }}>
       <Link to={generatePath(NavigationPath.identitiesGroupsDetails, { id: group.metadata.uid ?? '' })}>
-        <HighlightSearchText text={group.metadata.name ?? ''} searchText={search} isTruncate />
+        <HighlightSearchText text={group.metadata.name ?? ''} searchText={search} />
       </Link>
     </span>
   ),

--- a/frontend/src/routes/UserManagement/Identities/Users/UsersTableHelper.tsx
+++ b/frontend/src/routes/UserManagement/Identities/Users/UsersTableHelper.tsx
@@ -46,7 +46,7 @@ const COLUMN_CELLS = {
   NAME: (user: RbacUser, search: string) => (
     <span style={{ whiteSpace: 'nowrap' }}>
       <Link to={generatePath(NavigationPath.identitiesUsersDetails, { id: user.metadata.uid ?? '' })}>
-        <HighlightSearchText text={user.metadata.name ?? ''} searchText={search} isTruncate />
+        <HighlightSearchText text={user.metadata.name ?? ''} searchText={search} useFuzzyHighlighting />
       </Link>
     </span>
   ),


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
[ACM-21111](https://issues.redhat.com/browse/ACM-21111) (AcmTable truncate should be responsive to column size)
Also regarding: [ACM-22427](https://issues.redhat.com/browse/ACM-22427) (AcmTable HighlightSearchText can truncate text too many times.)

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [x] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ **Notes for Reviewers**
<!-- Optional: anything reviewers should know, special context, etc. -->

* **To test,** use the table search toolbar where HighlightSearchText is active (Managed Clusters, Applications)
* Note that when truncation occurs, you should be able to wave over the truncated text to render a popover with the full text. 
* Highlighting also appears in the popover.

**Questions to reviewers:**
1. Does blue text on a black popover create an accessibility violation. It can be a bit hard to read at times.

<img width="565" height="204" alt="Screenshot 2025-07-15 at 6 55 06 PM" src="https://github.com/user-attachments/assets/cdbf8408-782b-4d3c-ae3f-1090751f6da1" />

<img width="616" height="269" alt="Screenshot 2025-07-15 at 6 55 11 PM" src="https://github.com/user-attachments/assets/16094c4a-63ec-4fcb-8629-e4a8ed1cd2e8" />
<br/>
<br/>

2. I've added a condition within the renderCell method of the AcmTable that will hand off string/number type cells into our HighlightSearchText component by default, however there are still cases in which the cell passed to the table is a reactNode/object, and if we want all the objects that could be transitioned to use this component to be migrated, I think it might be best to take that on in a separate PR. You will notice certain cells (**Links/buttons mostly**) that do not already include the HighlightSearchText component in their template will not share the behavior of those targeted by this PR. This is expected.


