### PR TITLE
ACM-20341: update virtualmachine link

### DIFF
--- a/frontend/packages/multicluster-sdk/src/api/FleetResourceLink.test.tsx
+++ b/frontend/packages/multicluster-sdk/src/api/FleetResourceLink.test.tsx
@@ -33,7 +33,7 @@ describe('FleetResourceLink', () => {
     )
 
     const link = screen.getByRole('link')
-    expect(link).toHaveAttribute('href', '/multicloud/infrastructure/virtualmachines/test-cluster/default/test-vm')
+    expect(link).toHaveAttribute('href', '/k8s/cluster/test-cluster/ns/default/kubevirt.io~v1~VirtualMachine/test-vm')
     expect(link).toHaveTextContent('test-vm')
     expect(screen.getByTestId('resource-icon-mock')).toHaveTextContent('Icon: VirtualMachine')
   })

--- a/frontend/packages/multicluster-sdk/src/api/FleetResourceLink.tsx
+++ b/frontend/packages/multicluster-sdk/src/api/FleetResourceLink.tsx
@@ -32,7 +32,7 @@ export const FleetResourceLink: React.FC<FleetResourceLinkProps> = ({ cluster, .
 
     const path =
       groupVersionKind?.kind === 'VirtualMachine' && namespace
-        ? `/multicloud/infrastructure/virtualmachines/${cluster}/${namespace}/${name}`
+        ? `/k8s/cluster/${cluster}/ns/${namespace}/kubevirt.io~v1~VirtualMachine/${name}`
         : `/multicloud/search/resources${getURLSearchParam({
             cluster,
             kind: groupVersionKind?.kind,


### PR DESCRIPTION
Change the vm link from `/multicloud/infrastructure/...` to `/k8s/cluster/:cluster/ns/:ns/kubevirt.io~v1~VirtualMachine/:name`