### PR TITLE
ACM-22766: Polling for feature flag hook

### DIFF
--- a/frontend/src/utils/flags/useFeatureFlags.test.ts
+++ b/frontend/src/utils/flags/useFeatureFlags.test.ts
@@ -1,16 +1,28 @@
 /* Copyright Contributors to the Open Cluster Management project */
+import { renderHook, act } from '@testing-library/react-hooks'
 import { getRequest } from '../../resources/utils'
 import { FEATURE_FLAGS } from './consts'
 import useFeatureFlags from './useFeatureFlags'
 
 jest.mock('../../resources/utils')
 
+// Mock timers for polling tests
+jest.useFakeTimers()
+
 describe('useFeatureFlags', () => {
   const setFeatureFlagMock = jest.fn()
   const getRequestMock = getRequest as jest.Mock
+  const abortMock = jest.fn()
 
   beforeEach(() => {
     jest.resetAllMocks()
+    jest.clearAllTimers()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+    jest.useFakeTimers()
   })
 
   it.each([
@@ -18,33 +30,178 @@ describe('useFeatureFlags', () => {
     ['no flags exist at multiclusterhub', []],
   ])('%s', async (_title: string, components: any[] | undefined) => {
     // Arrange
-    getRequestMock.mockReturnValueOnce({
-      promise: new Promise((resolve) => resolve(components)),
+    getRequestMock.mockReturnValue({
+      promise: Promise.resolve(components),
+      abort: abortMock,
     })
 
     // Act
-    await useFeatureFlags(setFeatureFlagMock)
+    const { unmount } = renderHook(() => useFeatureFlags(setFeatureFlagMock, 0)) // Disable polling for this test
+
+    // Use act with async Promise.resolve() to ensure React state updates complete
+    // The Promise.resolve() gives the event loop a chance to process the hook's async operations.
+    await act(async () => {
+      await Promise.resolve()
+    })
 
     // Assert
-    expect(setFeatureFlagMock).toHaveBeenCalledTimes(Object.entries(FEATURE_FLAGS).length)
+    expect(setFeatureFlagMock).toHaveBeenCalledTimes(Object.entries(FEATURE_FLAGS).length + 1)
+    expect(setFeatureFlagMock).toHaveBeenCalledWith('MULTICLUSTER_SDK_PROVIDER_1', true)
     Object.keys(FEATURE_FLAGS).forEach((featureFlag) =>
       expect(setFeatureFlagMock).toHaveBeenCalledWith(featureFlag, false)
     )
+
+    unmount()
   })
 
   it.each([[true], [false]])('all flags exist at multiclusterhub and enabled: %s', async (enabled: boolean) => {
     // Arrange
-    getRequestMock.mockReturnValueOnce({
-      promise: new Promise((resolve) => resolve(Object.values(FEATURE_FLAGS).map((e) => ({ name: e, enabled })))),
+    getRequestMock.mockReturnValue({
+      promise: Promise.resolve(Object.values(FEATURE_FLAGS).map((e) => ({ name: e, enabled }))),
+      abort: abortMock,
     })
 
     // Act
-    await useFeatureFlags(setFeatureFlagMock)
+    const { unmount } = renderHook(() => useFeatureFlags(setFeatureFlagMock, 0)) // Disable polling for this test
+
+    // Wait for the promise to resolve
+    await act(async () => {
+      await Promise.resolve()
+    })
 
     // Assert
-    expect(setFeatureFlagMock).toHaveBeenCalledTimes(Object.entries(FEATURE_FLAGS).length)
+    expect(setFeatureFlagMock).toHaveBeenCalledTimes(Object.entries(FEATURE_FLAGS).length + 1)
+    expect(setFeatureFlagMock).toHaveBeenCalledWith('MULTICLUSTER_SDK_PROVIDER_1', true)
     Object.keys(FEATURE_FLAGS).forEach((featureFlag) =>
       expect(setFeatureFlagMock).toHaveBeenCalledWith(featureFlag, enabled)
     )
+
+    unmount()
+  })
+
+  it('should poll at specified intervals', async () => {
+    // Arrange
+    const pollingInterval = 5000
+    getRequestMock.mockReturnValue({
+      promise: Promise.resolve([]),
+      abort: abortMock,
+    })
+
+    // Act
+    const { unmount } = renderHook(() => useFeatureFlags(setFeatureFlagMock, pollingInterval))
+
+    // Wait for initial call
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(getRequestMock).toHaveBeenCalledTimes(1)
+
+    // Use act when advancing fake timers that trigger React updates
+    // WHY: jest.advanceTimersByTime() will cause the hook's polling timer to fire,
+    // which triggers a new API call and state updates. Without act, React would warn
+    // about state updates outside of act, and the updates might not be flushed
+    // before the next assertion.
+    act(() => {
+      jest.advanceTimersByTime(pollingInterval)
+    })
+
+    // Wait for the second call
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(getRequestMock).toHaveBeenCalledTimes(2)
+
+    // repeat for third call
+    act(() => {
+      jest.advanceTimersByTime(pollingInterval)
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(getRequestMock).toHaveBeenCalledTimes(3)
+
+    unmount()
+  })
+
+  it('should abort previous requests when making new ones', async () => {
+    // Arrange
+    const pollingInterval = 1000
+    getRequestMock.mockReturnValue({
+      promise: Promise.resolve([]),
+      abort: abortMock,
+    })
+
+    // Act
+    const { unmount } = renderHook(() => useFeatureFlags(setFeatureFlagMock, pollingInterval))
+
+    // Wait for initial call
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Fast-forward to trigger second call
+    act(() => {
+      jest.advanceTimersByTime(pollingInterval)
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Assert that abort was called on the previous request
+    expect(abortMock).toHaveBeenCalledTimes(1)
+
+    unmount()
+  })
+
+  it('should clean up on unmount', async () => {
+    // Arrange
+    const pollingInterval = 1000
+    getRequestMock.mockReturnValue({
+      promise: Promise.resolve([]),
+      abort: abortMock,
+    })
+
+    // Act
+    const { unmount } = renderHook(() => useFeatureFlags(setFeatureFlagMock, pollingInterval))
+
+    // Wait for initial call
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Unmount the hook
+    unmount()
+
+    // Assert that abort was called during cleanup
+    expect(abortMock).toHaveBeenCalled()
+  })
+
+  it('should handle request errors gracefully', async () => {
+    // Arrange
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
+    getRequestMock.mockReturnValue({
+      promise: Promise.reject(new Error('Network error')),
+      abort: abortMock,
+    })
+
+    // Act
+    const { unmount } = renderHook(() => useFeatureFlags(setFeatureFlagMock, 0))
+
+    // Wait for the promise to reject
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Assert
+    expect(consoleSpy).toHaveBeenCalledWith('Failed to fetch feature flags:', expect.any(Error))
+    expect(setFeatureFlagMock).toHaveBeenCalledWith('MULTICLUSTER_SDK_PROVIDER_1', true) // Should still set the required flag
+
+    consoleSpy.mockRestore()
+    unmount()
   })
 })

--- a/frontend/src/utils/flags/useFeatureFlags.ts
+++ b/frontend/src/utils/flags/useFeatureFlags.ts
@@ -1,20 +1,68 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { SetFeatureFlag } from '@openshift-console/dynamic-plugin-sdk'
-
+import { useCallback, useEffect, useRef } from 'react'
 import { MultiClusterHubComponent } from '../../resources/multi-cluster-hub-component'
 import { getBackendUrl, getRequest } from '../../resources/utils'
 import { FEATURE_FLAGS } from './consts'
 
-const useFeatureFlags = (setFeatureFlag: SetFeatureFlag) => {
-  const multiClusterHubComponentsRequest = getRequest<MultiClusterHubComponent[] | undefined>(
-    getBackendUrl() + '/multiclusterhub/components'
-  )
+const REQUIRED_PROVIDER_FLAG = 'MULTICLUSTER_SDK_PROVIDER_1'
 
-  multiClusterHubComponentsRequest.promise.then((response) =>
-    Object.entries(FEATURE_FLAGS).forEach(([featureFlag, componentName]) =>
-      setFeatureFlag(featureFlag, response?.find((e) => e.name === componentName)?.enabled || false)
+const useFeatureFlags = (setFeatureFlag: SetFeatureFlag, pollingInterval: number = 30000) => {
+  const requestRef = useRef<ReturnType<typeof getRequest<MultiClusterHubComponent[] | undefined>> | null>(null)
+  const intervalRef = useRef<NodeJS.Timeout | null>(null)
+
+  // useCallback to prevent re-rendering when the function is called
+  const fetchFeatureFlags = useCallback(() => {
+    // Abort any existing request to prevent race conditions
+    if (requestRef.current) {
+      requestRef.current.abort()
+    }
+
+    // Create new request
+    requestRef.current = getRequest<MultiClusterHubComponent[] | undefined>(
+      getBackendUrl() + '/multiclusterhub/components'
     )
-  )
+
+    requestRef.current.promise
+      .then((response) => {
+        Object.entries(FEATURE_FLAGS).forEach(([featureFlag, componentName]) =>
+          setFeatureFlag(featureFlag, response?.find((e) => e.name === componentName)?.enabled || false)
+        )
+      })
+      .catch((error) => {
+        // Handle errors gracefully - log but don't throw
+        console.warn('Failed to fetch feature flags:', error)
+      })
+  }, [setFeatureFlag])
+
+  useEffect(() => {
+    // Fetch immediately on mount
+    fetchFeatureFlags()
+
+    // Set up polling if interval is provided and > 0
+    if (pollingInterval > 0) {
+      intervalRef.current = setInterval(fetchFeatureFlags, pollingInterval)
+    }
+
+    // Cleanup function
+    return () => {
+      // Clear interval
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+      // Abort any pending request
+      if (requestRef.current) {
+        requestRef.current.abort()
+        requestRef.current = null
+      }
+    }
+  }, [fetchFeatureFlags, pollingInterval])
+
+  // Set the required provider flag once
+  useEffect(() => {
+    setFeatureFlag(REQUIRED_PROVIDER_FLAG, true)
+  }, [setFeatureFlag])
 }
 
 export default useFeatureFlags


### PR DESCRIPTION
# 📝 Summary

Multiple calls for the /multicloud/multiclusterhub/components.
Added a useCallback hook and polling implementation to prevent fetching on render but continue with occasional updates. 

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->