### PR TITLE
Use OCP branding for "npm run plugins"

### DIFF
--- a/start-ocp-console.sh
+++ b/start-ocp-console.sh
@@ -18,6 +18,7 @@ echo "Starting local OpenShift console..."
 
 BRIDGE_BASE_ADDRESS="http://localhost:${CONSOLE_PORT}"
 
+BRIDGE_BRANDING="openshift"
 BRIDGE_USER_AUTH="openshift"
 BRIDGE_K8S_MODE="off-cluster"
 BRIDGE_CA_FILE="/tmp/ca.crt"


### PR DESCRIPTION
Change to OCP branding to fix issues with CNV preview flag enablement as per https://redhat-internal.slack.com/archives/C08P42DCKNH/p1754527406513969