### PR TITLE
ACM-22587 OCP console unresponsive after opening ACM console Argo app

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/application.js
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/application.js
@@ -143,7 +143,9 @@ export const getApplication = async (
       isAppSetPullModel,
       relatedPlacement,
     }
-    const uidata = await fetchAggregate(SupportedAggregate.uidata, backendUrl, app)
+    const appForFetch = { ...app }
+    delete appForFetch.cluster
+    const uidata = await fetchAggregate(SupportedAggregate.uidata, backendUrl, appForFetch)
     model.clusterList = uidata?.clusterList
 
     // a short sweet ride for argo


### PR DESCRIPTION
application details uses the uidata api to get list of clusters an app has been deployed to
the api was being called with the name of the app, but it was also passing all of the details of its cluster
those details were unneeded and occasionally caused json syntax errors on the backend causing the get to fail

Signed-off-by: John Swanke <jswanke@redhat.com>

# 📝 Summary

**Ticket Summary (Title):**  
OCP console unresponsive after opening ACM console Argo app 

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-22587

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist


### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->