### PR TITLE
ACM-23403: useFleetClusterNames filtering unavailable managedClusters

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38392,6 +38392,7 @@
         "react-virtualized": "^9.22.6"
       },
       "devDependencies": {
+        "@kubernetes/client-node": "^1.3.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^12.1.5",
         "@testing-library/react-hooks": "^8.0.1",
@@ -47944,6 +47945,7 @@
       "version": "file:packages/multicluster-sdk",
       "requires": {
         "@apollo/client": "3.10.8",
+        "@kubernetes/client-node": "^1.3.0",
         "@patternfly/react-component-groups": "^6.2.1",
         "@patternfly/react-core": "^6.2.2",
         "@patternfly/react-styles": "^6.2.2",

--- a/frontend/packages/multicluster-sdk/README.md
+++ b/frontend/packages/multicluster-sdk/README.md
@@ -277,7 +277,7 @@ Returns:
 A promise that resolves to the response of the resource updated.
 In case of failure promise gets rejected with HTTP error response.
 
-[:link: Source](https://github.com/stolostron/console/blob/main/frontend/packages/multicluster-sdk/tree/../src/api/fleetK8sUpdate.ts#L30)
+[:link: Source](https://github.com/stolostron/console/blob/main/frontend/packages/multicluster-sdk/tree/../src/api/fleetK8sUpdate.ts#L29)
 
 ### :gear: FleetResourceEventStream
 
@@ -389,11 +389,63 @@ Array with `isAllowed` and `loading` values.
 
 ### :gear: useFleetClusterNames
 
+Hook that returns names of managed clusters with optional filtering by cluster proxy addon and availability status.
+
+This hook watches ManagedCluster resources and by default filters them to only include clusters
+that have both the label `feature.open-cluster-management.io/addon-cluster-proxy: available` AND
+the condition `ManagedClusterConditionAvailable` with status `True`.
+
 | Function | Type |
 | ---------- | ---------- |
 | `useFleetClusterNames` | `UseFleetClusterNames` |
 
-[:link: Source](https://github.com/stolostron/console/blob/main/frontend/packages/multicluster-sdk/tree/../src/api/useFleetClusterNames.ts#L6)
+Parameters:
+
+* `returnAllClusters`: - Optional boolean to return all cluster names regardless of labels and conditions.
+Defaults to false. When false (default), only returns clusters with the
+'feature.open-cluster-management.io/addon-cluster-proxy: available' label AND
+'ManagedClusterConditionAvailable' status: 'True'.
+When true, returns all cluster names regardless of labels and conditions.
+
+
+Returns:
+
+A tuple containing:
+- clusterNames: Array of cluster names (filtered by default, or all clusters if specified)
+- loaded: Boolean indicating if the resource watch has loaded
+- error: Any error that occurred during the watch operation
+
+Examples:
+
+```tsx
+// Get only clusters with cluster proxy addon available AND ManagedClusterConditionAvailable: 'True' (default behavior)
+const [availableClusterNames, loaded, error] = useFleetClusterNames()
+
+// Get all cluster names regardless of labels and conditions
+const [allClusterNames, loaded, error] = useFleetClusterNames(true)
+
+// Explicitly filter by cluster proxy addon and availability (same as default)
+const [filteredClusterNames, loaded, error] = useFleetClusterNames(false)
+
+if (!loaded) {
+  return <Loading />
+}
+
+if (error) {
+  return <ErrorState error={error} />
+}
+
+return (
+  <div>
+    {availableClusterNames.map(name => (
+      <div key={name}>{name}</div>
+    ))}
+  </div>
+)
+```
+
+
+[:link: Source](https://github.com/stolostron/console/blob/main/frontend/packages/multicluster-sdk/tree/../src/api/useFleetClusterNames.ts#L57)
 
 ### :gear: useFleetK8sAPIPath
 
@@ -535,7 +587,7 @@ const [services, loaded, error] = useFleetSearchPoll({
 ```
 
 
-[:link: Source](https://github.com/stolostron/console/blob/main/frontend/packages/multicluster-sdk/tree/../src/api/useFleetSearchPoll.ts#L79)
+[:link: Source](https://github.com/stolostron/console/blob/main/frontend/packages/multicluster-sdk/tree/../src/api/useFleetSearchPoll.ts#L92)
 
 ### :gear: useHubClusterName
 
@@ -720,7 +772,7 @@ Array with `isObservabilityInstalled`, `loaded` and `error` values.
 
 | Type | Type |
 | ---------- | ---------- |
-| `UseFleetClusterNames` | `() => [string[], boolean, any]` |
+| `UseFleetClusterNames` | `(returnAllClusters?: boolean) => [string[], boolean, any]` |
 
 [:link: Source](https://github.com/stolostron/console/blob/main/frontend/packages/multicluster-sdk/tree/../src/types/fleet.ts#L28)
 

--- a/frontend/packages/multicluster-sdk/package.json
+++ b/frontend/packages/multicluster-sdk/package.json
@@ -39,6 +39,7 @@
     "@openshift-console/dynamic-plugin-sdk": ">=1.0.0 || >=4.19.0-prerelease"
   },
   "devDependencies": {
+    "@kubernetes/client-node": "^1.3.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/react-hooks": "^8.0.1",

--- a/frontend/packages/multicluster-sdk/src/api/useFleetClusterNames.test.ts
+++ b/frontend/packages/multicluster-sdk/src/api/useFleetClusterNames.test.ts
@@ -1,0 +1,626 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+jest.mock('@openshift-console/dynamic-plugin-sdk', () => ({
+  useK8sWatchResource: jest.fn(),
+}))
+
+import { renderHook } from '@testing-library/react-hooks'
+import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk'
+import { useFleetClusterNames } from './useFleetClusterNames'
+import { ManagedClusterListGroupVersionKind } from '../internal/models'
+
+const mockUseK8sWatchResource = useK8sWatchResource as jest.MockedFunction<typeof useK8sWatchResource>
+
+describe('useFleetClusterNames', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('when returnAllClusters is false (default)', () => {
+    it('should return empty array when no clusters are loaded', () => {
+      mockUseK8sWatchResource.mockReturnValue([[], false, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([[], false, undefined])
+      expect(mockUseK8sWatchResource).toHaveBeenCalledWith({
+        groupVersionKind: ManagedClusterListGroupVersionKind,
+        isList: true,
+      })
+    })
+
+    it('should return empty array when no clusters are loaded (explicit false)', () => {
+      mockUseK8sWatchResource.mockReturnValue([[], false, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames(false))
+
+      expect(result.current).toEqual([[], false, undefined])
+      expect(mockUseK8sWatchResource).toHaveBeenCalledWith({
+        groupVersionKind: ManagedClusterListGroupVersionKind,
+        isList: true,
+      })
+    })
+
+    it('should return cluster names only for clusters with cluster proxy addon available and ManagedClusterConditionAvailable: True', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-with-proxy-and-available',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-without-proxy',
+            labels: {
+              'some.other.label': 'value',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-with-wrong-proxy-value',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'unavailable',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-with-proxy-but-unavailable',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'False',
+              },
+            ],
+          },
+        },
+      ] as any[]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([['cluster-with-proxy-and-available'], true, undefined])
+    })
+
+    it('should handle clusters without metadata', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-with-proxy-and-available',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          // Cluster without metadata
+        },
+        {
+          metadata: {
+            // Cluster without name
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([['cluster-with-proxy-and-available'], true, undefined])
+    })
+
+    it('should handle clusters without labels', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-with-proxy-and-available',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-without-labels',
+            // No labels property
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([['cluster-with-proxy-and-available'], true, undefined])
+    })
+
+    it('should return multiple cluster names when multiple clusters have the required label and available condition', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-1',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-2',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-3',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'unavailable',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([['cluster-1', 'cluster-2'], true, undefined])
+    })
+
+    it('should forward loading state from useK8sWatchResource', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-1',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, false, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([['cluster-1'], false, undefined])
+    })
+
+    it('should forward error from useK8sWatchResource', () => {
+      const mockError = new Error('Failed to load clusters')
+      mockUseK8sWatchResource.mockReturnValue([[], false, mockError])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([[], false, mockError])
+    })
+
+    it('should handle empty clusters array', () => {
+      mockUseK8sWatchResource.mockReturnValue([[], true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([[], true, undefined])
+    })
+
+    it('should be case-sensitive for label values', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-with-correct-case',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-with-wrong-case',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'Available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([['cluster-with-correct-case'], true, undefined])
+    })
+
+    it('should handle clusters missing status conditions', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-with-proxy-no-status',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          // No status property
+        },
+        {
+          metadata: {
+            name: 'cluster-with-proxy-empty-conditions',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-with-proxy-and-available',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([['cluster-with-proxy-and-available'], true, undefined])
+    })
+
+    it('should handle clusters with different condition types', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-with-different-condition',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'SomeOtherCondition',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-with-available-condition',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([['cluster-with-available-condition'], true, undefined])
+    })
+
+    it('should be case-sensitive for condition status values', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-with-lowercase-true',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'true',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-with-uppercase-true',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames())
+
+      expect(result.current).toEqual([['cluster-with-uppercase-true'], true, undefined])
+    })
+  })
+
+  describe('when returnAllClusters is true', () => {
+    it('should return all cluster names regardless of labels and conditions', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-with-proxy-and-available',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-without-proxy-but-available',
+            labels: {
+              'some.other.label': 'value',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'True',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-with-proxy-but-unavailable',
+            labels: {
+              'feature.open-cluster-management.io/addon-cluster-proxy': 'available',
+            },
+          },
+          status: {
+            conditions: [
+              {
+                type: 'ManagedClusterConditionAvailable',
+                status: 'False',
+              },
+            ],
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-without-labels-or-status',
+          },
+        },
+      ] as any[]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames(true))
+
+      expect(result.current).toEqual([
+        [
+          'cluster-with-proxy-and-available',
+          'cluster-without-proxy-but-available',
+          'cluster-with-proxy-but-unavailable',
+          'cluster-without-labels-or-status',
+        ],
+        true,
+        undefined,
+      ])
+    })
+
+    it('should still filter out clusters without names', () => {
+      const mockClusters = [
+        {
+          metadata: {
+            name: 'cluster-1',
+            labels: {
+              'some.label': 'value',
+            },
+          },
+        },
+        {
+          // Cluster without metadata
+        },
+        {
+          metadata: {
+            // Cluster without name
+            labels: {
+              'some.label': 'value',
+            },
+          },
+        },
+        {
+          metadata: {
+            name: 'cluster-2',
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames(true))
+
+      expect(result.current).toEqual([['cluster-1', 'cluster-2'], true, undefined])
+    })
+
+    it('should return empty array when no clusters have names', () => {
+      const mockClusters = [
+        {
+          // Cluster without metadata
+        },
+        {
+          metadata: {
+            // Cluster without name
+            labels: {
+              'some.label': 'value',
+            },
+          },
+        },
+      ]
+
+      mockUseK8sWatchResource.mockReturnValue([mockClusters, true, undefined])
+
+      const { result } = renderHook(() => useFleetClusterNames(true))
+
+      expect(result.current).toEqual([[], true, undefined])
+    })
+
+    it('should forward loading and error states correctly', () => {
+      const mockError = new Error('Failed to load clusters')
+      mockUseK8sWatchResource.mockReturnValue([[], false, mockError])
+
+      const { result } = renderHook(() => useFleetClusterNames(true))
+
+      expect(result.current).toEqual([[], false, mockError])
+    })
+  })
+})

--- a/frontend/packages/multicluster-sdk/src/api/useFleetClusterNames.ts
+++ b/frontend/packages/multicluster-sdk/src/api/useFleetClusterNames.ts
@@ -1,14 +1,82 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { K8sResourceCommon, useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk'
+import { V1CustomResourceDefinitionCondition } from '@kubernetes/client-node'
 import { UseFleetClusterNames } from '../types/fleet'
 import { ManagedClusterListGroupVersionKind } from '../internal/models'
 
-export const useFleetClusterNames: UseFleetClusterNames = () => {
+// Helper function to check for condition - similar to checkForCondition from status-conditions.ts
+const checkForCondition = (condition: string, conditions: V1CustomResourceDefinitionCondition[], status?: string) =>
+  conditions?.find((c) => c.type === condition)?.status === (status ?? 'True')
+
+/**
+ * Hook that returns names of managed clusters with optional filtering by cluster proxy addon and availability status.
+ *
+ * This hook watches ManagedCluster resources and by default filters them to only include clusters
+ * that have both the label `feature.open-cluster-management.io/addon-cluster-proxy: available` AND
+ * the condition `ManagedClusterConditionAvailable` with status `True`.
+ *
+ * @param returnAllClusters - Optional boolean to return all cluster names regardless of labels and conditions.
+ *   Defaults to false. When false (default), only returns clusters with the
+ *   'feature.open-cluster-management.io/addon-cluster-proxy: available' label AND
+ *   'ManagedClusterConditionAvailable' status: 'True'.
+ *   When true, returns all cluster names regardless of labels and conditions.
+ *
+ * @returns A tuple containing:
+ *   - clusterNames: Array of cluster names (filtered by default, or all clusters if specified)
+ *   - loaded: Boolean indicating if the resource watch has loaded
+ *   - error: Any error that occurred during the watch operation
+ *
+ * @example
+ * ```tsx
+ * // Get only clusters with cluster proxy addon available AND ManagedClusterConditionAvailable: 'True' (default behavior)
+ * const [availableClusterNames, loaded, error] = useFleetClusterNames()
+ *
+ * // Get all cluster names regardless of labels and conditions
+ * const [allClusterNames, loaded, error] = useFleetClusterNames(true)
+ *
+ * // Explicitly filter by cluster proxy addon and availability (same as default)
+ * const [filteredClusterNames, loaded, error] = useFleetClusterNames(false)
+ *
+ * if (!loaded) {
+ *   return <Loading />
+ * }
+ *
+ * if (error) {
+ *   return <ErrorState error={error} />
+ * }
+ *
+ * return (
+ *   <div>
+ *     {availableClusterNames.map(name => (
+ *       <div key={name}>{name}</div>
+ *     ))}
+ *   </div>
+ * )
+ * ```
+ */
+export const useFleetClusterNames: UseFleetClusterNames = (returnAllClusters = false) => {
   const [clusters, loaded, error] = useK8sWatchResource<K8sResourceCommon[]>({
     groupVersionKind: ManagedClusterListGroupVersionKind,
     isList: true,
   })
-  const clusterNames = clusters.flatMap((cluster) => (cluster.metadata?.name ? [cluster.metadata.name] : []))
+  const clusterNames = clusters.flatMap((cluster) => {
+    if (!cluster.metadata?.name) {
+      return []
+    }
+
+    if (returnAllClusters) {
+      return [cluster.metadata.name]
+    }
+
+    const hasClusterProxyLabel =
+      cluster.metadata?.labels?.['feature.open-cluster-management.io/addon-cluster-proxy'] === 'available'
+
+    // Check if cluster has ManagedClusterConditionAvailable status: 'True'
+    const conditions = (cluster as any)?.status?.conditions || []
+    const isClusterAvailable = checkForCondition('ManagedClusterConditionAvailable', conditions)
+
+    return hasClusterProxyLabel && isClusterAvailable ? [cluster.metadata.name] : []
+  })
 
   return [clusterNames, loaded, error]
 }

--- a/frontend/packages/multicluster-sdk/src/types/fleet.ts
+++ b/frontend/packages/multicluster-sdk/src/types/fleet.ts
@@ -25,7 +25,7 @@ export type FleetResourceLinkProps = Fleet<ResourceLinkProps>
 export type UseFleetK8sWatchResource = <R extends FleetK8sResourceCommon | FleetK8sResourceCommon[]>(
   initResource: FleetWatchK8sResource | null
 ) => WatchK8sResult<R> | [undefined, boolean, any]
-export type UseFleetClusterNames = () => [string[], boolean, any]
+export type UseFleetClusterNames = (returnAllClusters?: boolean) => [string[], boolean, any]
 
 /** Signature of the `useIsFleetAvailable` hook */
 export type UseIsFleetAvailable = () => boolean


### PR DESCRIPTION

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
In CNV fleet view, we are currently showing all clusters, even if they are not available or if the cluster-proxy addon is not enabled. This leads to errors when trying to use these clusters.

Also! The API useFleetClusterNames has no ts docs, we should add some!

# 📝 Summary
**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-23403

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [x] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->