### PR TITLE
ACM-23394 add all sub rows instead of only the first

### DIFF
--- a/frontend/src/ui-components/AcmTable/AcmTable.stories.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.stories.tsx
@@ -128,6 +128,15 @@ export function TableExpandable(args: Record<string, unknown>) {
                             <Text component={TextVariants.h3}>Favorite Colors</Text>
                           </TextContent>
                           <AcmTable<IExampleSubData>
+                            resultView={{
+                              loading: false,
+                              page: 1,
+                              refresh: () => {},
+                              items: [],
+                              emptyResult: false,
+                              isPreProcessed: false,
+                              processedItemCount: 0,
+                            }}
                             noBorders
                             emptyState={
                               <AcmEmptyState
@@ -240,13 +249,15 @@ export function TableEmpty(args: Record<string, unknown>) {
 
 function TableEmptyStory(args: Record<string, unknown>) {
   const [items, setItems] = useState<IExampleData[]>()
+  const props = commonProperties(args, setItems, items)
   return (
     <AcmTable<IExampleData>
       emptyState={<TableEmptyState {...args} />}
       items={[]}
       columns={columns}
       keyFn={(item: IExampleData) => item.uid.toString()}
-      {...commonProperties(args, setItems, items)}
+      {...props}
+      resultView={{ ...props.resultView, page: 0, emptyResult: true }}
     />
   )
 }
@@ -265,13 +276,15 @@ export function TableLoading(args: Record<string, unknown>) {
 
 function TableLoadingStory(args: Record<string, unknown>) {
   const [items, setItems] = useState<IExampleData[]>()
+  const props = commonProperties(args, setItems, items)
   return (
     <AcmTable<IExampleData>
       emptyState={<TableEmptyState {...args} />}
       items={undefined}
       columns={columns}
       keyFn={(item: IExampleData) => item.uid.toString()}
-      {...commonProperties(args, setItems, items)}
+      {...props}
+      resultView={{ ...props.resultView, page: 0, loading: true }}
     />
   )
 }
@@ -282,6 +295,15 @@ function commonProperties(
   items: IExampleData[] | undefined
 ) {
   return {
+    resultView: {
+      loading: false,
+      page: 1,
+      refresh: () => {},
+      items: [],
+      emptyResult: false,
+      isPreProcessed: false,
+      processedItemCount: 0,
+    },
     plural: args.plural as string,
     searchPlaceholder: args.searchPlaceholder as string,
     noBorders: args.noBorders as boolean,
@@ -524,6 +546,13 @@ export const exampleSubData: IExampleSubData[] = [
     firstName: 'Kurt',
     lastName: 'Daley',
     color: 'pink',
+  },
+  {
+    uid: 50,
+    suid: '2',
+    firstName: 'Erik',
+    lastName: 'Erikson',
+    color: 'white',
   },
 ]
 

--- a/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
@@ -940,6 +940,24 @@ describe('AcmTable', () => {
     expect(container.querySelectorAll('.pf-v5-c-chip-group__list-item')).toHaveLength(0)
   })
 
+  test('render table with multiple sub rows', async () => {
+    const { getAllByText } = render(
+      <Table
+        addSubRows={() => {
+          return [
+            {
+              cells: [{ title: 'Sub row 1' }],
+            },
+            {
+              cells: [{ title: 'Sub row 2' }],
+            },
+          ]
+        }}
+      />
+    )
+    expect(getAllByText('Sub row 2').length).toBeGreaterThan(0)
+  })
+
   test('renders with filtering and successfully deletes selected filters', async () => {
     const { container, getAllByText, getByText, getByTestId, getAllByLabelText, getByLabelText } = render(
       <Table


### PR DESCRIPTION
fixes: ACM-23394
Signed-off-by: Erik Jan de Wit <erikjan.dewit@gmail.com>

# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
[MCE UI] - 'Clusters' expandable row gets replaced by 'Pending cluster claims' in 2.9 hub

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-23394

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->
