### PR TITLE
[ACM-23433] Resource details action buttons not visible

### DIFF
--- a/frontend/src/routes/Search/Details/YAMLPage.tsx
+++ b/frontend/src/routes/Search/Details/YAMLPage.tsx
@@ -363,7 +363,7 @@ export default function YAMLPage() {
   const [userCanEdit, setUserCanEdit] = useState<boolean>(false)
   const [resourceYaml, setResourceYaml] = useState<string>('')
   const [defaultScrollToLine, setDefaultScrollToLine] = useState<number | undefined>()
-  const [editorHeight, setEditorHeight] = useState(window.innerHeight - 370)
+  const [editorHeight, setEditorHeight] = useState(getEditorHeight())
   const location: {
     pathname: string
     state: {
@@ -385,17 +385,20 @@ export default function YAMLPage() {
     }
   }, [resource])
 
-  function handleResize() {
-    let editorHeight = window.innerHeight - 260
-    const editorHeaderHeight = document.getElementById('yaml-editor-header-wrapper')?.offsetHeight ?? 53
-    const editorActionBarHeight = document.getElementById('yaml-editor-action-wrapper')?.offsetHeight ?? 53
-    editorHeight = editorHeight - editorHeaderHeight - editorActionBarHeight
+  function getEditorHeight() {
+    const pageContentHeight = document.getElementsByClassName('pf-v5-c-page__main')[0]?.clientHeight
+    const pageSectionHeader = document.getElementsByClassName('pf-v5-c-page__main-group')[0]?.clientHeight ?? 0
+    let editorHeight = pageContentHeight - pageSectionHeader - 53 - 54 - 48 // 53px editor header height, 54px editor actions height, 48px content padding
     const globalHeader = document.getElementsByClassName('co-global-notification')
     /* istanbul ignore if */
     if (globalHeader.length > 0) {
       editorHeight = editorHeight - globalHeader.length * 33
     }
-    setEditorHeight(editorHeight)
+    return editorHeight
+  }
+
+  function handleResize() {
+    setEditorHeight(getEditorHeight())
   }
 
   useEffect(() => {

--- a/frontend/src/routes/Search/Details/YAMLPage.tsx
+++ b/frontend/src/routes/Search/Details/YAMLPage.tsx
@@ -4,7 +4,7 @@ import { ActionList, ActionListGroup, ActionListItem, Alert, Button, PageSection
 import { DownloadIcon } from '@patternfly/react-icons'
 import { saveAs } from 'file-saver'
 import jsYaml from 'js-yaml'
-import { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat'
 import YamlEditor from '../../../components/YamlEditor'
 import { useTranslation } from '../../../lib/acm-i18next'
@@ -397,15 +397,15 @@ export default function YAMLPage() {
     return editorHeight
   }
 
-  function handleResize() {
+  const handleResize = useCallback(() => {
     setEditorHeight(getEditorHeight())
-  }
+  }, [])
 
   useEffect(() => {
     handleResize()
     window.addEventListener('resize', handleResize)
     return () => window.removeEventListener('resize', handleResize)
-  }, [])
+  }, [handleResize])
 
   useEffect(() => {
     if (!resourceYaml) {

--- a/frontend/src/routes/Search/components/SavedSearchQueries.tsx
+++ b/frontend/src/routes/Search/components/SavedSearchQueries.tsx
@@ -124,7 +124,7 @@ export default function SavedSearchQueries(props: {
     [searchDefinitions, toast, t]
   )
 
-  if (loading) {
+  if (isUserPreferenceLoading || loading) {
     return (
       <PageSection>
         <AcmExpandableWrapper id={'loading-wrapper'} withCount={false} expandable={false}>


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
In OCP 4.19, the action buttons are off screen and need scrolling to find. This change improves the calculation of the required editor height, ensuring buttons are always visible at the bottom of the screen across OCP versions.

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-23433

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->