### PR TITLE
ACM-22793: Adding backend path for hypershift status, addon, and multiClusterEngine access

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -31,6 +31,7 @@ import { username } from './routes/username'
 import { userpreference } from './routes/userpreference'
 import { virtualMachineGETProxy, virtualMachineProxy, vmResourceUsageProxy } from './routes/virtualMachineProxy'
 import { managedClusterProxy } from './routes/managedClusterProxy'
+import { hypershiftStatus } from './routes/hypershift-status'
 
 const isProduction = process.env.NODE_ENV === 'production'
 const isDevelopment = process.env.NODE_ENV === 'development'
@@ -69,6 +70,7 @@ router.get('/username', username)
 router.all('/userpreference', userpreference)
 router.all('/metrics', metrics)
 router.get('/hub', hub)
+router.get('/hypershift-status', hypershiftStatus)
 router.post('/upgrade-risks-prediction', upgradeRiskPredictions)
 router.post('/aggregate/*', aggregate)
 router.get('/virtualmachines/get/*', virtualMachineGETProxy)

--- a/backend/src/lib/managed-cluster-addon.ts
+++ b/backend/src/lib/managed-cluster-addon.ts
@@ -1,0 +1,67 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { jsonRequest } from './json-request'
+import { logger } from './logger'
+import { getServiceAccountToken } from './serviceAccountToken'
+
+export interface ManagedClusterAddOn {
+  metadata: {
+    name: string
+  }
+  status?: {
+    conditions?: Array<{
+      reason: string
+      status: string
+    }>
+  }
+}
+
+interface ManagedClusterAddOnList {
+  items: ManagedClusterAddOn[]
+}
+
+export async function getManagedClusterAddOns(
+  namespace: string,
+  throwErrors?: boolean
+): Promise<ManagedClusterAddOn[]> {
+  const serviceAccountToken = getServiceAccountToken()
+
+  try {
+    const response = await jsonRequest<ManagedClusterAddOnList>(
+      process.env.CLUSTER_API_URL +
+        `/apis/addon.open-cluster-management.io/v1alpha1/namespaces/${namespace}/managedclusteraddons`,
+      serviceAccountToken
+    )
+    return response.items || []
+  } catch (err) {
+    if (throwErrors) {
+      throw err
+    }
+    logger.error({
+      msg: 'Error getting ManagedClusterAddOns',
+      namespace,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return []
+  }
+}
+
+export async function getManagedClusterAddOn(
+  namespace: string,
+  name: string,
+  throwErrors?: boolean
+): Promise<ManagedClusterAddOn | undefined> {
+  const addons = await getManagedClusterAddOns(namespace, throwErrors)
+  return addons.find((addon) => addon.metadata.name === name)
+}
+
+export function isAddOnHealthy(addon: ManagedClusterAddOn): boolean {
+  if (!addon.status?.conditions) {
+    return false
+  }
+
+  return (
+    addon.status.conditions.find((condition) => condition.reason === 'ManagedClusterAddOnLeaseUpdated')?.status ===
+    'True'
+  )
+}

--- a/backend/src/routes/hypershift-status.ts
+++ b/backend/src/routes/hypershift-status.ts
@@ -1,0 +1,71 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { Http2ServerRequest, Http2ServerResponse } from 'http2'
+import { logger } from '../lib/logger'
+import { respondInternalServerError } from '../lib/respond'
+import { getAuthenticatedToken } from '../lib/token'
+import { getMultiClusterEngineComponents, MultiClusterEngineComponent } from '../lib/multi-cluster-engine'
+import { getManagedClusterAddOn, isAddOnHealthy, ManagedClusterAddOn } from '../lib/managed-cluster-addon'
+
+function processHypershiftStatus(
+  components: MultiClusterEngineComponent[] | undefined,
+  hypershiftAddon: ManagedClusterAddOn | undefined
+): boolean {
+  try {
+    // Check if we have components
+    if (!components) {
+      return false
+    }
+
+    // Check if hypershift components are enabled
+    const hypershift = components.find((component) => component.name === 'hypershift')
+    const hypershiftLocalHosting = components.find((component) => component.name === 'hypershift-local-hosting')
+
+    if (!hypershift?.enabled || !hypershiftLocalHosting?.enabled) {
+      return false
+    }
+
+    // Check if the hypershift addon exists and is healthy
+    if (!hypershiftAddon) {
+      return false
+    }
+
+    return isAddOnHealthy(hypershiftAddon)
+  } catch (error) {
+    logger.error('Error processing hypershift status:', error)
+    return false
+  }
+}
+
+export async function hypershiftStatus(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void> {
+  const token = await getAuthenticatedToken(req, res)
+  if (!token) {
+    return // getAuthenticatedToken already handles the response
+  }
+
+  try {
+    // Get the local hub name from query parameter or default to 'local-cluster'
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    const localHubName = url.searchParams.get('hubName') || 'local-cluster'
+
+    // Fetch MultiClusterEngine components (no cache for fresh data, throw errors)
+    const components = await getMultiClusterEngineComponents(true, true)
+
+    // Fetch the hypershift-addon for the local hub (throw errors)
+    const hypershiftAddon = await getManagedClusterAddOn(localHubName, 'hypershift-addon', true)
+
+    // Process the results to determine if hypershift is enabled
+    const isHypershiftEnabled = processHypershiftStatus(components, hypershiftAddon)
+
+    const responsePayload = {
+      statusCode: 200,
+      body: { isHypershiftEnabled },
+    }
+
+    res.setHeader('Content-Type', 'application/json')
+    res.end(JSON.stringify(responsePayload))
+  } catch (err) {
+    logger.error('Error fetching hypershift status:', err)
+    respondInternalServerError(req, res)
+  }
+}

--- a/backend/test/routes/hypershift-status.test.ts
+++ b/backend/test/routes/hypershift-status.test.ts
@@ -1,0 +1,81 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { request } from '../mock-request'
+import { parseResponseJsonBody } from '../../src/lib/body-parser'
+import nock from 'nock'
+
+describe('hypershift-status Route', function () {
+  const mockAuth = () => nock(process.env.CLUSTER_API_URL).get('/apis').reply(200, { status: 200 })
+
+  const mockMCE = (hypershiftEnabled = true, localHostingEnabled = true) =>
+    nock(process.env.CLUSTER_API_URL)
+      .get('/apis/multicluster.openshift.io/v1/multiclusterengines')
+      .reply(200, {
+        items: [
+          {
+            spec: {
+              overrides: {
+                components: [
+                  { name: 'hypershift', enabled: hypershiftEnabled },
+                  { name: 'hypershift-local-hosting', enabled: localHostingEnabled },
+                ],
+              },
+            },
+          },
+        ],
+      })
+
+  const mockAddons = (addonStatus = 'True') =>
+    nock(process.env.CLUSTER_API_URL)
+      .get('/apis/addon.open-cluster-management.io/v1alpha1/namespaces/local-cluster/managedclusteraddons')
+      .reply(200, {
+        items: [
+          {
+            metadata: { name: 'hypershift-addon' },
+            status: { conditions: [{ reason: 'ManagedClusterAddOnLeaseUpdated', status: addonStatus }] },
+          },
+        ],
+      })
+
+  it('should return hypershift enabled when all conditions are met', async function () {
+    mockAuth()
+    mockMCE(true, true)
+    mockAddons('True')
+
+    const res = await request('GET', '/hypershift-status?hubName=local-cluster')
+    expect(res.statusCode).toEqual(200)
+    const { body } = await parseResponseJsonBody(res)
+    expect(body).toEqual({ isHypershiftEnabled: true })
+  })
+
+  it('should return hypershift disabled when components are disabled', async function () {
+    mockAuth()
+    mockMCE(false, true)
+    mockAddons('True')
+
+    const res = await request('GET', '/hypershift-status?hubName=local-cluster')
+    expect(res.statusCode).toEqual(200)
+    const { body } = await parseResponseJsonBody(res)
+    expect(body).toEqual({ isHypershiftEnabled: false })
+  })
+
+  it('should return hypershift disabled when addon is unhealthy', async function () {
+    mockAuth()
+    mockMCE(true, true)
+    mockAddons('False')
+
+    const res = await request('GET', '/hypershift-status?hubName=local-cluster')
+    expect(res.statusCode).toEqual(200)
+    const { body } = await parseResponseJsonBody(res)
+    expect(body).toEqual({ isHypershiftEnabled: false })
+  })
+
+  it('should handle API errors gracefully', async function () {
+    mockAuth()
+    nock(process.env.CLUSTER_API_URL)
+      .get('/apis/multicluster.openshift.io/v1/multiclusterengines')
+      .replyWithError('API server error')
+
+    const res = await request('GET', '/hypershift-status?hubName=local-cluster')
+    expect(res.statusCode).toEqual(500)
+  })
+})

--- a/frontend/src/lib/nock-hypershift-status.ts
+++ b/frontend/src/lib/nock-hypershift-status.ts
@@ -1,0 +1,25 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import nock from 'nock'
+
+/**
+ * Mock the hypershift-status backend endpoint for testing
+ */
+export function nockHypershiftStatus(isEnabled: boolean, statusCode = 200) {
+  return nock(process.env.JEST_DEFAULT_HOST as string)
+    .persist()
+    .get('/hypershift-status')
+    .query(true) // Accept any query parameters
+    .reply(
+      statusCode,
+      {
+        statusCode: 200,
+        body: { isHypershiftEnabled: isEnabled },
+      },
+      {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, OPTIONS',
+        'Access-Control-Allow-Credentials': 'true',
+      }
+    )
+}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAWSControlPlane.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAWSControlPlane.test.tsx
@@ -2,10 +2,11 @@
 import { render } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat'
 import { RecoilRoot } from 'recoil'
-import { clickByTestId, isCardEnabled } from '../../../../../lib/test-util'
+import { clickByTestId, isCardEnabled, waitForNocks } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { CreateAWSControlPlane } from './CreateAWSControlPlane'
 import { nockIgnoreApiPaths } from '../../../../../lib/nock-util'
+import { nockHypershiftStatus } from '../../../../../lib/nock-hypershift-status'
 import { managedClusterAddonsState, multiClusterEnginesState } from '../../../../../atoms'
 import {
   mockManagedClusterAddOn,
@@ -38,18 +39,30 @@ describe('CreateAWSControlPlane', () => {
   }
 
   test('Hosted should be enabled when hypershift is enabled', async () => {
+    const hypershiftStatusNock = nockHypershiftStatus(true)
+
     const { getByTestId } = render(<Component />)
+    await waitForNocks([hypershiftStatusNock])
+
     expect(isCardEnabled(getByTestId('hosted'))).toBe(true)
   })
 
   test('Hosted should be disabled when hypershift is disabled', async () => {
+    const hypershiftStatusNock = nockHypershiftStatus(false)
+
     const { getByTestId } = render(<Component enableHypershift={false} />)
+    await waitForNocks([hypershiftStatusNock])
+
     expect(isCardEnabled(getByTestId('hosted'))).toBe(false)
     await clickByTestId('hosted')
   })
 
   test('can click standalone', async () => {
+    const hypershiftStatusNock = nockHypershiftStatus(true)
+
     render(<Component />)
+    await waitForNocks([hypershiftStatusNock])
+
     await clickByTestId('standalone')
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAWSControlPlane.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateAWSControlPlane.tsx
@@ -23,7 +23,7 @@ export function CreateAWSControlPlane() {
   const { nextStep, back, cancel } = useBackCancelNavigation()
   const [isDiagramExpanded, setIsDiagramExpanded] = useState(true)
   const [isMouseOverControlPlaneLink, setIsMouseOverControlPlaneLink] = useState(false)
-  const isHypershiftEnabled = useIsHypershiftEnabled()
+  const [isHypershiftEnabled, loaded] = useIsHypershiftEnabled()
 
   const onDiagramToggle = (isExpanded: boolean) => {
     if (!isMouseOverControlPlaneLink) {
@@ -59,15 +59,19 @@ export function CreateAWSControlPlane() {
           },
         ],
         onClick: isHypershiftEnabled ? nextStep(NavigationPath.createAWSCLI) : undefined,
-        alertTitle: isHypershiftEnabled
-          ? undefined
-          : t('Hosted control plane operator must be enabled in order to continue'),
+        alertTitle: (() => {
+          if (!loaded || isHypershiftEnabled) return undefined
+          return t('Hosted control plane operator must be enabled in order to continue')
+        })(),
         alertVariant: 'info',
-        alertContent: (
-          <a href={DOC_LINKS.HOSTED_ENABLE_FEATURE_AWS} target="_blank" rel="noopener noreferrer">
-            {t('View documentation')} <ExternalLinkAltIcon />
-          </a>
-        ),
+        alertContent: (() => {
+          if (!loaded || isHypershiftEnabled) return undefined
+          return (
+            <a href={DOC_LINKS.HOSTED_ENABLE_FEATURE_AWS} target="_blank" rel="noopener noreferrer">
+              {t('View documentation')} <ExternalLinkAltIcon />
+            </a>
+          )
+        })(),
         badgeList: [
           {
             badge: t('CLI-based'),
@@ -108,7 +112,7 @@ export function CreateAWSControlPlane() {
       },
     ]
     return newCards
-  }, [nextStep, t, isHypershiftEnabled])
+  }, [nextStep, t, isHypershiftEnabled, loaded])
 
   const keyFn = useCallback((card: ICatalogCard) => card.id, [])
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateControlPlane.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateControlPlane.tsx
@@ -19,7 +19,7 @@ export function CreateControlPlane() {
   const [isDiagramExpanded, setIsDiagramExpanded] = useState(true)
   const [isMouseOverControlPlaneLink, setIsMouseOverControlPlaneLink] = useState(false)
 
-  const isHypershiftEnabled = useIsHypershiftEnabled()
+  const [isHypershiftEnabled, loaded] = useIsHypershiftEnabled()
   const noAvailableHostsAlert = useNoAvailableHostsAlert('hosted')
 
   const onDiagramToggle = (isExpanded: boolean) => {
@@ -60,16 +60,22 @@ export function CreateControlPlane() {
           isHypershiftEnabled && !noAvailableHostsAlert
             ? nextStep(getTypedCreateClusterPath(HostInventoryInfrastructureType.CIMHypershift))
             : undefined,
-        alertTitle: !isHypershiftEnabled
-          ? t('Hosted control plane operator must be enabled in order to continue')
-          : noAvailableHostsAlert?.title,
-        alertContent: !isHypershiftEnabled ? (
-          <a href={DOC_LINKS.HOSTED_ENABLE_FEATURE_AWS} target="_blank" rel="noopener noreferrer">
-            {t('View documentation')} <ExternalLinkAltIcon />
-          </a>
-        ) : (
-          noAvailableHostsAlert?.content
-        ),
+        alertTitle: (() => {
+          if (!loaded) return undefined
+          if (!isHypershiftEnabled) return t('Hosted control plane operator must be enabled in order to continue')
+          return noAvailableHostsAlert?.title
+        })(),
+        alertContent: (() => {
+          if (!loaded) return undefined
+          if (!isHypershiftEnabled) {
+            return (
+              <a href={DOC_LINKS.HOSTED_ENABLE_FEATURE_AWS} target="_blank" rel="noopener noreferrer">
+                {t('View documentation')} <ExternalLinkAltIcon />
+              </a>
+            )
+          }
+          return noAvailableHostsAlert?.content
+        })(),
         alertVariant: 'info',
       },
       {
@@ -105,7 +111,7 @@ export function CreateControlPlane() {
       },
     ]
     return newCards
-  }, [nextStep, t, isHypershiftEnabled, noAvailableHostsAlert])
+  }, [nextStep, t, isHypershiftEnabled, loaded, noAvailableHostsAlert])
 
   return (
     <GetControlPlane

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateKubeVirtControlPlane.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateKubeVirtControlPlane.test.tsx
@@ -4,7 +4,8 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom-v5-compat'
 import { RecoilRoot } from 'recoil'
 import { managedClusterAddonsState, multiClusterEnginesState } from '../../../../../atoms'
 import { nockIgnoreApiPaths } from '../../../../../lib/nock-util'
-import { clickByTestId, isCardEnabled } from '../../../../../lib/test-util'
+import { nockHypershiftStatus } from '../../../../../lib/nock-hypershift-status'
+import { clickByTestId, isCardEnabled, waitForNocks } from '../../../../../lib/test-util'
 import { NavigationPath } from '../../../../../NavigationPath'
 import { CreateKubeVirtControlPlane } from './CreateKubeVirtControlPlane'
 import {
@@ -37,12 +38,20 @@ describe('CreateKubeVirtControlPlane', () => {
   }
 
   test('Hosted should be enabled when hypershift is enabled', async () => {
+    const hypershiftStatusNock = nockHypershiftStatus(true)
+
     const { getByTestId } = render(<Component />)
+    await waitForNocks([hypershiftStatusNock])
+
     expect(isCardEnabled(getByTestId('hosted'))).toBe(true)
   })
 
   test('Hosted should be disabled when hypershift is disabled', async () => {
+    const hypershiftStatusNock = nockHypershiftStatus(false)
+
     const { getByTestId } = render(<Component enableHypershift={false} />)
+    await waitForNocks([hypershiftStatusNock])
+
     expect(isCardEnabled(getByTestId('hosted'))).toBe(false)
     await clickByTestId('hosted')
   })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateKubeVirtControlPlane.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateClusterCatalog/CreateKubeVirtControlPlane.tsx
@@ -13,7 +13,7 @@ import GetHostedCard from './common/GetHostedCard'
 export function CreateKubeVirtControlPlane() {
   const [t] = useTranslation()
   const { nextStep, back, cancel } = useBackCancelNavigation()
-  const isHypershiftEnabled = useIsHypershiftEnabled()
+  const [isHypershiftEnabled] = useIsHypershiftEnabled()
 
   const cards = useMemo(
     () => [GetHostedCard(nextStep(getTypedCreateClusterPath(Provider.kubevirt)), t, isHypershiftEnabled)],


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

When the UI determines if the hosted control plane feature is enabled for displaying the hosted control plane creation wizard, it requires the user to have access to the following resources.

MultiClusterEngine CR
ManagedClusterAddOn CRs
 
If the user does not have access to these resources, the UI displays this even though the hosted control plane features are enabled in MCE.

We used the backend's service account on behalf of the user to check these required resources so that we can avoid having to give the non-admin user explicit access to MCE resources.

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-22793

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [x] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->