### PR TITLE
ACM-23618 Adds resource route extensions ACM first class resource pages

### DIFF
--- a/frontend/plugins/acm/console-extensions.ts
+++ b/frontend/plugins/acm/console-extensions.ts
@@ -218,6 +218,62 @@ const identitiesRoute: EncodedExtension<RoutePage> = {
   },
 }
 
+// ACM resource route extensions - for fleetresourcelink integration
+
+// Managed cluster resource route
+const managedClusterResourceRoute: EncodedExtension = {
+  type: 'acm.resource/route',
+  properties: {
+    model: { group: 'cluster.open-cluster-management.io', kind: 'ManagedCluster', version: 'v1' },
+    handler: { $codeRef: 'resource-routes.acmResourceRouteHandler' },
+  },
+}
+
+// Cluster resource route
+const clusterResourceRoute: EncodedExtension = {
+  type: 'acm.resource/route',
+  properties: {
+    model: { kind: 'Cluster' },
+    handler: { $codeRef: 'resource-routes.acmResourceRouteHandler' },
+  },
+}
+
+// Application K8s resource route
+const applicationK8sResourceRoute: EncodedExtension = {
+  type: 'acm.resource/route',
+  properties: {
+    model: { group: 'app.k8s.io', kind: 'Application', version: 'v1beta1' },
+    handler: { $codeRef: 'resource-routes.acmResourceRouteHandler' },
+  },
+}
+
+// Application Argo resource route
+const applicationArgoResourceRoute: EncodedExtension = {
+  type: 'acm.resource/route',
+  properties: {
+    model: { group: 'argoproj.io', kind: 'Application', version: 'v1alpha1' },
+    handler: { $codeRef: 'resource-routes.acmResourceRouteHandler' },
+  },
+}
+
+// Policy resource route
+const policyResourceRoute: EncodedExtension = {
+  type: 'acm.resource/route',
+  properties: {
+    model: { group: 'policy.open-cluster-management.io', kind: 'Policy', version: 'v1' },
+    handler: { $codeRef: 'resource-routes.acmResourceRouteHandler' },
+  },
+}
+
+// Policy report resource route
+const policyReportResourceRoute: EncodedExtension = {
+  type: 'acm.resource/route',
+  properties: {
+    model: { group: 'wgpolicyk8s.io', kind: 'PolicyReport', version: 'v1alpha2' },
+    handler: { $codeRef: 'resource-routes.acmResourceRouteHandler' },
+  },
+}
+
 export const extensions: EncodedExtension[] = [
   homeSection,
   welcomeNavItem,
@@ -237,4 +293,10 @@ export const extensions: EncodedExtension[] = [
   rolesRoute,
   identitiesNavItem,
   identitiesRoute,
+  managedClusterResourceRoute,
+  clusterResourceRoute,
+  applicationK8sResourceRoute,
+  applicationArgoResourceRoute,
+  policyResourceRoute,
+  policyReportResourceRoute,
 ]

--- a/frontend/plugins/acm/console-plugin-metadata.ts
+++ b/frontend/plugins/acm/console-plugin-metadata.ts
@@ -21,6 +21,7 @@ export const pluginMetadata: ConsolePluginBuildMetadata = {
     roles: '../../src/routes/UserManagement/Roles/RolesManagementPlugin.tsx',
     identities: '../../src/routes/UserManagement/Identities/IdentitiesManagementPlugin.tsx',
     featureFlags: '../../src/utils/flags/useFeatureFlags.ts',
+    'resource-routes': './resource-routes.ts',
   },
   dependencies: {
     '@console/pluginAPI': '>=4.15.0',

--- a/frontend/plugins/acm/resource-routes.ts
+++ b/frontend/plugins/acm/resource-routes.ts
@@ -1,0 +1,63 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { generatePath } from 'react-router-dom-v5-compat'
+import queryString from 'query-string'
+import { ResourceRouteHandler } from '@stolostron/multicluster-sdk'
+
+/**
+ * ACM resource route handler for first-class resource pages.
+ * Routes resources to their dedicated ACM pages instead of generic search results.
+ */
+export const acmResourceRouteHandler: ResourceRouteHandler = ({ cluster, namespace, name, resource, model }) => {
+  const { kind, group } = model
+
+  switch (kind.toLowerCase()) {
+    case 'cluster':
+    case 'managedcluster':
+      return generatePath('/multicloud/infrastructure/clusters/details/:namespace/:name/overview', {
+        namespace: name,
+        name,
+      })
+
+    case 'application': {
+      if (group === 'app.k8s.io' || group === 'argoproj.io') {
+        const params = queryString.stringify({
+          apiVersion: `${kind}.${group}`.toLowerCase(),
+          cluster: resource._hubClusterResource ? undefined : cluster,
+          applicationset: resource.applicationSet ?? undefined,
+        })
+        const path = generatePath('/multicloud/applications/details/:namespace/:name/overview', {
+          namespace: namespace!,
+          name,
+        })
+        return `${path}?${params}`
+      }
+      break
+    }
+
+    case 'policy': {
+      if (
+        resource._hubClusterResource &&
+        group === 'policy.open-cluster-management.io' &&
+        !resource.label?.includes('policy.open-cluster-management.io/root-policy')
+      ) {
+        return generatePath('/multicloud/governance/policies/details/:namespace/:name', {
+          namespace: namespace!,
+          name,
+        })
+      }
+      break
+    }
+
+    case 'policyreport': {
+      const path = generatePath('/multicloud/infrastructure/clusters/details/:namespace/:name/overview', {
+        namespace: namespace!,
+        name: namespace!,
+      })
+      return `${path}?${encodeURIComponent('showClusterIssues=true')}`
+    }
+  }
+
+  // fall back to null if no custom route found
+  return null as any
+}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
Summary
Register `acm.resource/route` extensions for ACM first-class resources to enable proper routing when using `@stolostron/multicluster-sdk` `FleetResourceLink` components.
Details

1. Add resource route extensions for all resources currently defined in searchDefinitions.tsx that link to ACM pages instead of generic search details
2. Use kubevirt-plugin implementation as reference pattern
3. Create separate extension for each resource kind with shared handler implementation
4. No changes to existing search implementation

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-23618

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [X ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [X] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [X] Code builds and runs locally without errors
- [X] No console logs, commented-out code, or unnecessary files
- [X] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->