### PR TITLE
ACM-23691: add indexes values in the pvc object

### DIFF
--- a/frontend/packages/multicluster-sdk/src/api/useFleetSearchPoll.test.ts
+++ b/frontend/packages/multicluster-sdk/src/api/useFleetSearchPoll.test.ts
@@ -579,6 +579,9 @@ describe('useFleetSearchPoll', () => {
         kind: 'PersistentVolumeClaim',
         requestedStorage: '1Gi',
         volumeMode: 'Filesystem',
+        storageClassName: 'gp3-csi',
+        capacity: '1Gi',
+        status: 'Bound',
       }
 
       mockUseSearchResultItemsQuery.mockReturnValue({
@@ -607,6 +610,11 @@ describe('useFleetSearchPoll', () => {
           },
         },
         volumeMode: 'Filesystem',
+        storageClassName: 'gp3-csi',
+      })
+      expect(dataArray[0].status).toEqual({
+        phase: 'Bound',
+        capacity: { storage: '1Gi' },
       })
     })
 

--- a/frontend/packages/multicluster-sdk/src/api/useFleetSearchPoll.ts
+++ b/frontend/packages/multicluster-sdk/src/api/useFleetSearchPoll.ts
@@ -242,7 +242,10 @@ export function useFleetSearchPoll<T extends K8sResourceCommon | K8sResourceComm
 
           case 'PersistentVolumeClaim':
             setIfDefined(resource, 'spec.resources.requests.storage', item.requestedStorage)
+            setIfDefined(resource, 'spec.storageClassName', item.storageClassName)
             setIfDefined(resource, 'spec.volumeMode', item.volumeMode)
+            setIfDefined(resource, 'status.phase', item.status)
+            setIfDefined(resource, 'status.capacity.storage', item.capacity)
             break
 
           case 'StorageClass.storage.k8s.io':


### PR DESCRIPTION
most important value that we need from pvc is `spec.storageClassName` that its currently indexed