### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for console-acm-214

### DIFF
--- a/Containerfile.acm.konflux
+++ b/Containerfile.acm.konflux
@@ -34,4 +34,5 @@ LABEL com.redhat.component="console-container" \
       io.k8s.display-name="console" \
       maintainer="['acm-component-maintainers@redhat.com']" \
       description="console" \
-      io.k8s.description="console"
+      io.k8s.description="console" \
+      cpe="cpe:/a:redhat:acm:2.14::el9"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
