### PR TITLE
ACM-23393 Policy overview flashing

### DIFF
--- a/frontend/src/components/AcmMasonry.test.tsx
+++ b/frontend/src/components/AcmMasonry.test.tsx
@@ -3,22 +3,31 @@
 import { render, screen } from '@testing-library/react'
 import { AcmMasonry } from './AcmMasonry'
 
-jest.mock('@react-hook/resize-observer', () => {
-  return jest.fn((target, callback) => {
-    if (callback && target.current) {
-      setTimeout(() => {
-        callback({
-          contentRect: { width: 800, height: 100 },
-        })
-      }, 0)
-    }
-  })
-})
+// mock the resize observer callback
+const mockResizeCallback = jest.fn()
+
+// mock useResizeObserver to control the resize behavior in tests
+jest.mock('@react-hook/resize-observer')
+
+// get the mocked function after the mock is set up
+import useResizeObserver from '@react-hook/resize-observer'
+const mockUseResizeObserver = jest.mocked(useResizeObserver)
 
 describe('AcmMasonry', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // setup default mock implementation
+    mockUseResizeObserver.mockImplementation((_target, callback) => {
+      mockResizeCallback.mockImplementation(callback)
+      // return a mock ResizeObserver
+      return {} as ResizeObserver
+    })
+  })
+
   it('renders with no children', () => {
     const { container } = render(<AcmMasonry minSize={200} />)
-    expect(container.firstChild).toBeInTheDocument()
+    // check that the component renders a div with a grid inside
+    expect(container.querySelector('.pf-v5-l-grid')).toBeInTheDocument()
   })
 
   it('renders children in masonry layout', () => {
@@ -64,5 +73,315 @@ describe('AcmMasonry', () => {
     )
 
     expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('handles children changes correctly', () => {
+    const { container, rerender } = render(
+      <AcmMasonry minSize={200}>
+        <div key="item1">Item 1</div>
+        <div key="item2">Item 2</div>
+      </AcmMasonry>
+    )
+
+    // initially should be hidden until measurements complete
+    let grid = container.querySelector('[class*="pf-v5-l-grid"]')
+    expect(grid).toHaveStyle('visibility: hidden')
+
+    // change children (simulate search filtering with new items)
+    rerender(
+      <AcmMasonry minSize={200}>
+        <div key="item3">Item 3</div>
+        <div key="item4">Item 4</div>
+      </AcmMasonry>
+    )
+
+    // should still be hidden as new measurements need to complete
+    grid = container.querySelector('[class*="pf-v5-l-grid"]')
+    expect(grid).toHaveStyle('visibility: hidden')
+  })
+
+  it('preserves measurements when same children are reordered', () => {
+    const { container, rerender } = render(
+      <AcmMasonry minSize={200}>
+        <div key="item1">Item 1</div>
+        <div key="item2">Item 2</div>
+      </AcmMasonry>
+    )
+
+    // reorder the same children (simulate pagination or sorting)
+    rerender(
+      <AcmMasonry minSize={200}>
+        <div key="item2">Item 2</div>
+        <div key="item1">Item 1</div>
+      </AcmMasonry>
+    )
+
+    // component should handle reordering gracefully
+    const grid = container.querySelector('[class*="pf-v5-l-grid"]')
+    expect(grid).toBeInTheDocument()
+  })
+
+  it('handles responsive resizing for different column counts', () => {
+    const { rerender, container } = render(
+      <AcmMasonry minSize={200}>
+        <div>Test Item 1</div>
+        <div>Test Item 2</div>
+        <div>Test Item 3</div>
+      </AcmMasonry>
+    )
+
+    // test 1 column (width < minSize)
+    mockResizeCallback({ contentRect: { width: 150 } })
+    rerender(
+      <AcmMasonry minSize={200}>
+        <div>Test Item 1</div>
+        <div>Test Item 2</div>
+        <div>Test Item 3</div>
+      </AcmMasonry>
+    )
+    expect(container.querySelector('.pf-v5-l-grid')).toBeInTheDocument()
+
+    // test 2 columns
+    mockResizeCallback({ contentRect: { width: 450 } })
+    rerender(
+      <AcmMasonry minSize={200}>
+        <div>Test Item 1</div>
+        <div>Test Item 2</div>
+        <div>Test Item 3</div>
+      </AcmMasonry>
+    )
+    expect(container.querySelector('.pf-v5-l-grid')).toBeInTheDocument()
+
+    // test 5 columns (edge case)
+    mockResizeCallback({ contentRect: { width: 1050 } })
+    rerender(
+      <AcmMasonry minSize={200}>
+        <div>Test Item 1</div>
+        <div>Test Item 2</div>
+        <div>Test Item 3</div>
+      </AcmMasonry>
+    )
+    expect(container.querySelector('.pf-v5-l-grid')).toBeInTheDocument()
+
+    // test default case (>6 columns)
+    mockResizeCallback({ contentRect: { width: 1500 } })
+    rerender(
+      <AcmMasonry minSize={200}>
+        <div>Test Item 1</div>
+        <div>Test Item 2</div>
+        <div>Test Item 3</div>
+      </AcmMasonry>
+    )
+    expect(container.querySelector('.pf-v5-l-grid')).toBeInTheDocument()
+  })
+
+  it('respects maxColumns prop', () => {
+    const { rerender, container } = render(
+      <AcmMasonry minSize={100} maxColumns={3}>
+        <div>Test Item 1</div>
+        <div>Test Item 2</div>
+        <div>Test Item 3</div>
+        <div>Test Item 4</div>
+      </AcmMasonry>
+    )
+
+    // simulate resize observer callback with width that would result in more than 3 columns without maxColumns
+    mockResizeCallback({ contentRect: { width: 1000 } })
+
+    rerender(
+      <AcmMasonry minSize={100} maxColumns={3}>
+        <div>Test Item 1</div>
+        <div>Test Item 2</div>
+        <div>Test Item 3</div>
+        <div>Test Item 4</div>
+      </AcmMasonry>
+    )
+
+    expect(container.querySelector('.pf-v5-l-grid')).toBeInTheDocument()
+  })
+
+  it('handles children without explicit keys', () => {
+    render(
+      <AcmMasonry minSize={200}>
+        <div>Item without key 1</div>
+        <div>Item without key 2</div>
+        <div>Item without key 3</div>
+      </AcmMasonry>
+    )
+
+    expect(screen.getByText('Item without key 1')).toBeInTheDocument()
+    expect(screen.getByText('Item without key 2')).toBeInTheDocument()
+    expect(screen.getByText('Item without key 3')).toBeInTheDocument()
+  })
+
+  it('handles mixed children with and without keys', () => {
+    render(
+      <AcmMasonry minSize={200}>
+        <div key="explicit-key">Item with key</div>
+        <div>Item without key</div>
+        <div key="another-key">Another item with key</div>
+      </AcmMasonry>
+    )
+
+    expect(screen.getByText('Item with key')).toBeInTheDocument()
+    expect(screen.getByText('Item without key')).toBeInTheDocument()
+    expect(screen.getByText('Another item with key')).toBeInTheDocument()
+  })
+
+  it('updates isReady state when measurements complete', () => {
+    const { container, rerender } = render(
+      <AcmMasonry minSize={200}>
+        <div key="item1">Item 1</div>
+        <div key="item2">Item 2</div>
+      </AcmMasonry>
+    )
+
+    // initially should be hidden
+    const grid = container.querySelector('[class*="pf-v5-l-grid"]')
+    expect(grid).toHaveStyle('visibility: hidden')
+
+    // simulate measurements completing by triggering resize callback
+    mockResizeCallback({ contentRect: { width: 400, height: 100 } })
+
+    rerender(
+      <AcmMasonry minSize={200}>
+        <div key="item1">Item 1</div>
+        <div key="item2">Item 2</div>
+      </AcmMasonry>
+    )
+
+    // grid should still be in the document
+    expect(grid).toBeInTheDocument()
+  })
+
+  it('handles partial children changes (some same, some new)', () => {
+    const { rerender } = render(
+      <AcmMasonry minSize={200}>
+        <div key="item1">Item 1</div>
+        <div key="item2">Item 2</div>
+        <div key="item3">Item 3</div>
+      </AcmMasonry>
+    )
+
+    // change to have some same children and some new ones
+    rerender(
+      <AcmMasonry minSize={200}>
+        <div key="item1">Item 1</div>
+        <div key="item4">Item 4</div>
+        <div key="item5">Item 5</div>
+      </AcmMasonry>
+    )
+
+    expect(screen.getByText('Item 1')).toBeInTheDocument()
+    expect(screen.getByText('Item 4')).toBeInTheDocument()
+    expect(screen.getByText('Item 5')).toBeInTheDocument()
+  })
+
+  it('handles null and undefined children gracefully', () => {
+    render(
+      <AcmMasonry minSize={200}>
+        <div>Test Item 1</div>
+        {null}
+        {undefined}
+        <div>Test Item 2</div>
+        {false && <div>Should not render</div>}
+      </AcmMasonry>
+    )
+
+    expect(screen.getByText('Test Item 1')).toBeInTheDocument()
+    expect(screen.getByText('Test Item 2')).toBeInTheDocument()
+    expect(screen.queryByText('Should not render')).not.toBeInTheDocument()
+  })
+
+  it('distributes children across columns based on height', () => {
+    const { container } = render(
+      <AcmMasonry minSize={100} maxColumns={2}>
+        <div key="short" style={{ height: '50px' }}>
+          Short item
+        </div>
+        <div key="tall" style={{ height: '200px' }}>
+          Tall item
+        </div>
+        <div key="medium" style={{ height: '100px' }}>
+          Medium item
+        </div>
+      </AcmMasonry>
+    )
+
+    // all items should be rendered
+    expect(screen.getByText('Short item')).toBeInTheDocument()
+    expect(screen.getByText('Tall item')).toBeInTheDocument()
+    expect(screen.getByText('Medium item')).toBeInTheDocument()
+
+    // should have proper grid structure
+    const gridItems = container.querySelectorAll('[class*="pf-v5-l-grid__item"]')
+    expect(gridItems.length).toBeGreaterThan(0)
+  })
+
+  it('shows AcmLoadingPage when not ready', () => {
+    render(
+      <AcmMasonry minSize={200}>
+        <div key="item1">Item 1</div>
+      </AcmMasonry>
+    )
+
+    // should show loading initially
+    expect(screen.getByText('Loading')).toBeInTheDocument()
+  })
+
+  it('properly sets up resize observer on mount', () => {
+    render(
+      <AcmMasonry minSize={200}>
+        <div>Test Item</div>
+      </AcmMasonry>
+    )
+
+    // verify that useResizeObserver was called
+    expect(mockUseResizeObserver).toHaveBeenCalled()
+
+    // get the callback passed to useResizeObserver
+    const callback = mockUseResizeObserver.mock.calls[0][1]
+    expect(typeof callback).toBe('function')
+  })
+
+  it('handles minimum width constraints', () => {
+    const { rerender, container } = render(
+      <AcmMasonry minSize={500}>
+        <div>Test Item 1</div>
+        <div>Test Item 2</div>
+      </AcmMasonry>
+    )
+
+    // simulate resize observer callback with width smaller than minSize
+    mockResizeCallback({ contentRect: { width: 300 } })
+
+    rerender(
+      <AcmMasonry minSize={500}>
+        <div>Test Item 1</div>
+        <div>Test Item 2</div>
+      </AcmMasonry>
+    )
+
+    expect(container.querySelector('.pf-v5-l-grid')).toBeInTheDocument()
+  })
+
+  it('handles edge case with very wide container', () => {
+    const { rerender, container } = render(
+      <AcmMasonry minSize={50}>
+        <div>Test Item</div>
+      </AcmMasonry>
+    )
+
+    // simulate a very wide container
+    mockResizeCallback({ contentRect: { width: 5000 } })
+
+    rerender(
+      <AcmMasonry minSize={50}>
+        <div>Test Item</div>
+      </AcmMasonry>
+    )
+
+    expect(screen.getByText('Test Item')).toBeInTheDocument()
+    expect(container.querySelector('.pf-v5-l-grid')).toBeInTheDocument()
   })
 })

--- a/frontend/src/routes/Governance/policy-sets/PolicySets.test.tsx
+++ b/frontend/src/routes/Governance/policy-sets/PolicySets.test.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { render, screen, within } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom-v5-compat'
 import { RecoilRoot } from 'recoil'
 import { policySetsState } from '../../../atoms'
@@ -14,7 +14,7 @@ describe('PolicySets Page', () => {
     nockIgnoreRBAC()
     nockIgnoreApiPaths()
   })
-  test('Should render empty PolicySet page correctly', async () => {
+  test('shows empty page when no policy sets', async () => {
     render(
       <RecoilRoot
         initializeState={(snapshot) => {
@@ -30,7 +30,7 @@ describe('PolicySets Page', () => {
     await waitForText("You don't have any policy sets")
   })
 
-  test('Should render PolicySet page correctly', async () => {
+  test('renders page with filters and policy sets', async () => {
     render(
       <RecoilRoot
         initializeState={(snapshot) => {
@@ -43,31 +43,27 @@ describe('PolicySets Page', () => {
       </RecoilRoot>
     )
 
+    // should show all items initially
+    expect(screen.getAllByText('policy-set-with-1-placement')).toHaveLength(3)
+
     screen
       .getByRole('combobox', {
         name: 'Select filter options',
       })
       .click()
 
-    // filter title and a selection
-    expect(screen.getAllByText('Violations')).toHaveLength(2)
-    expect(screen.getAllByText('No violations')).toBeTruthy()
-    expect(screen.getAllByText('No status')).toBeTruthy()
+    // check filter dropdown options
+    expect(screen.getByText('Violations')).toBeInTheDocument()
+    expect(screen.getByText('Violations (0)')).toBeInTheDocument()
+    expect(screen.getByText('No violations (2)')).toBeInTheDocument()
+    expect(screen.getByText('No status (1)')).toBeInTheDocument()
 
-    expect(within(screen.getAllByText('Violations')[1]).getByText('0')).toBeInTheDocument()
-    expect(within(screen.getAllByText('No violations')[0]).getByText('2')).toBeInTheDocument()
-    expect(within(screen.getAllByText('No status')[0]).getByText('1')).toBeInTheDocument()
-
-    screen.getAllByText('No status')[0].click()
+    // filter by no status
+    screen.getAllByText('No status (1)')[0].click()
     expect(screen.getAllByText('policy-set-with-1-placement')).toHaveLength(1)
-
-    // un-select No status
-    screen.getAllByText('No status')[0].click()
-    screen.getAllByText('Violations')[1].click()
-    expect(screen.queryByText('policy-set-with-1-placement')).not.toBeInTheDocument()
   })
 
-  test('Should filter no-violation correctly with url-filter', async () => {
+  test('filters by no violations from url params', async () => {
     render(
       <RecoilRoot
         initializeState={(snapshot) => {
@@ -80,7 +76,7 @@ describe('PolicySets Page', () => {
       </RecoilRoot>
     )
 
-    // filter title and a selection
+    // should only show no violations filter
     expect(screen.queryByText('Violations')).not.toBeInTheDocument()
     expect(screen.getAllByText('No violations')).toBeTruthy()
     expect(screen.queryByText('No status')).not.toBeInTheDocument()

--- a/frontend/src/routes/Governance/policy-sets/components/CardViewToolbarFilter.tsx
+++ b/frontend/src/routes/Governance/policy-sets/components/CardViewToolbarFilter.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { Badge, SelectOption, SelectGroup } from '@patternfly/react-core'
+import { SelectOption, SelectGroup } from '@patternfly/react-core'
 import { AcmSelectBase, SelectVariant } from '../../../../components/AcmSelectBase'
 import { FilterIcon } from '@patternfly/react-icons'
 import { useCallback, useMemo, useState } from 'react'
@@ -8,7 +8,6 @@ import { useRecoilValue, useSharedAtoms } from '../../../../shared-recoil'
 import { NavigationPath } from '../../../../NavigationPath'
 import { PolicySet } from '../../../../resources/policy-set'
 import { useTranslation } from '../../../../lib/acm-i18next'
-import { filterOption, filterOptionBadge } from '../../../../ui-components/AcmTable/filterStyles'
 
 export default function CardViewToolbarFilter(props: {
   preSelectedFilters: string[]
@@ -60,16 +59,16 @@ export default function CardViewToolbarFilter(props: {
             label: t('No status'),
             complianceValue: undefined,
           },
-        ].map(({ key, label, complianceValue }) => (
-          <SelectOption key={key} value={key}>
-            <div className={filterOption}>
-              {label}
-              <Badge className={filterOptionBadge} key={`${key}-count`} isRead>
-                {policySets.filter((policySet: PolicySet) => policySet?.status?.compliant === complianceValue).length}
-              </Badge>
-            </div>
-          </SelectOption>
-        ))}
+        ].map(({ key, label, complianceValue }) => {
+          const count = policySets.filter(
+            (policySet: PolicySet) => policySet?.status?.compliant === complianceValue
+          ).length
+          return (
+            <SelectOption key={key} value={key}>
+              {`${label} (${count})`}
+            </SelectOption>
+          )
+        })}
       </SelectGroup>,
     ],
     [policySets, t]


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
**Fix AcmMasonry loading state and PolicySets filter display issues**

Changes:
AcmMasonry: Replace index-based with key-based measurement tracking to prevent loading spinner during PolicySets search
PolicySets Filter: Simplify SelectOption content to fix [object Object] display issue

Reasoning:
Key-based tracking preserves measurements across children changes (search/pagination) while still preventing the Overview page from flashing
Complex JSX structures in SelectOption cause rendering issues in AcmSelectBase - simple text format resolves display problems

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-23393

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [X] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [X] Code builds and runs locally without errors
- [X] No console logs, commented-out code, or unnecessary files
- [X] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->