### PR TITLE
MGMT-19746: holdInstallation=true set by the UI when there is no reason to

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/cim/EditAICluster.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useEffect, useState, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import { PathParam, generatePath, useLocation, useNavigate, useParams } from 'react-router-dom-v5-compat'
 import {
   ACM_ENABLED_FEATURES,
@@ -61,7 +61,6 @@ const EditAICluster: React.FC = () => {
   const { name = '', namespace = '' } = useParams<PathParam<NavigationPath.editCluster>>()
   const searchParams = new URLSearchParams(search)
   const { t } = useTranslation()
-  const [patchingHoldInstallation, setPatchingHoldInstallation] = useState(true)
   const navigate = useNavigate()
   const { agentsState, clusterImageSetsState, nmStateConfigsState, clusterCuratorsState, bareMetalHostsState } =
     useSharedAtoms()
@@ -129,35 +128,11 @@ const EditAICluster: React.FC = () => {
     onSetInstallationDiskId,
   }
 
-  useEffect(() => {
-    const patch = async () => {
-      if (agentClusterInstall) {
-        try {
-          if (!agentClusterInstall.spec?.holdInstallation) {
-            await patchResource(agentClusterInstall as IResource, [
-              {
-                op: agentClusterInstall.spec?.holdInstallation === false ? 'replace' : 'add',
-                path: '/spec/holdInstallation',
-                value: true,
-              },
-            ]).promise
-          }
-        } finally {
-          setPatchingHoldInstallation(false)
-        }
-      }
-    }
-    patch()
-  }, [
-    // just once but when the ACI is loaded
-    !!agentClusterInstall,
-  ])
-
   const isNutanix = agentClusterInstall?.spec?.platformType === 'Nutanix'
 
   const clusterCurator = clusterCurators.find((c) => c.metadata?.namespace === namespace)
 
-  return patchingHoldInstallation || !clusterDeployment || !agentClusterInstall ? (
+  return !clusterDeployment || !agentClusterInstall ? (
     <LoadingState />
   ) : (
     <AcmPage


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
When doing am manifest drive installation of a bare metal cluster using ACM and assisted installer, under certain circumstances the UI will putt the installation on hold, by changing this flag: `holdInstallation=true`. The UI should pause only the cluster installation created by the UI. No reasons to interfere with cluster installation create in other ways. The `managedFields` can possibly help make that distinction.

**Note:** since the clusters created via the UI already have `holdInstallation: true` specified, we can remove this patch.

**Ticket Link:**  

https://issues.redhat.com/browse/MGMT-19746

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->