### PR TITLE
Fix background color styling in YAML editor header

### DIFF
--- a/frontend/src/routes/Search/Details/YAMLPage.tsx
+++ b/frontend/src/routes/Search/Details/YAMLPage.tsx
@@ -1,6 +1,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { css } from '@emotion/css'
-import { ActionList, ActionListGroup, ActionListItem, Alert, Button, PageSection } from '@patternfly/react-core'
+import {
+  ActionList,
+  ActionListGroup,
+  ActionListItem,
+  Alert,
+  Button,
+  Divider,
+  PageSection,
+} from '@patternfly/react-core'
 import { DownloadIcon } from '@patternfly/react-icons'
 import { FleetK8sResourceCommon } from '@stolostron/multicluster-sdk/lib/types/fleet'
 import { saveAs } from 'file-saver'
@@ -23,25 +30,6 @@ import {
 import { useRecoilValue, useSharedAtoms } from '../../../shared-recoil'
 import { AcmLoadingPage } from '../../../ui-components'
 import { useSearchDetailsContext } from './DetailsPage'
-
-const headerContainer = css({
-  display: 'flex',
-  backgroundColor: 'var(--pf-v5-global--palette--black-850)',
-  fontSize: '14px',
-})
-const spacer = css({
-  borderRight: '1px solid var(--pf-v5-global--palette--black-700)',
-  paddingLeft: '1rem',
-})
-const textTitle = css({
-  color: 'var(--pf-v5-global--palette--black-300)',
-  padding: '1rem',
-})
-const textContent = css({
-  color: 'var(--pf-v5-global--palette--white)',
-  padding: '1rem 0',
-  fontWeight: 700,
-})
 
 /* istanbul ignore next */
 function loadResource(
@@ -204,14 +192,22 @@ export function EditorHeaderBar(props: Readonly<{ cluster: string; namespace: st
   const { t } = useTranslation()
 
   return (
-    <div id={'yaml-editor-header-wrapper'} className={headerContainer}>
+    <div
+      id={'yaml-editor-header-wrapper'}
+      style={{
+        display: 'flex',
+        fontSize: '14px',
+        backgroundColor: 'var(--pf-v5-c-page__main-section--m-light--BackgroundColor)',
+      }}
+    >
       {/* No translation - this is a kube resource field */}
-      <p className={textTitle}>{'Cluster:'}</p>
-      <p className={textContent}>{cluster}</p>
-      <div className={spacer} />
+      <p style={{ padding: '1rem' }}>{'Cluster:'}</p>
+      <p style={{ padding: '1rem 0', fontWeight: 700 }}>{cluster}</p>
       {/* No translation - this is a kube resource field */}
-      <p className={textTitle}>{'Namespace:'}</p>
-      <p className={textContent}>{namespace !== '' ? namespace : t('Resource is not namespaced')}</p>
+      <p style={{ padding: '1rem' }}>{'Namespace:'}</p>
+      <p style={{ padding: '1rem 0', fontWeight: 700 }}>
+        {namespace !== '' ? namespace : t('Resource is not namespaced')}
+      </p>
     </div>
   )
 }
@@ -516,6 +512,7 @@ export default function YAMLPage() {
       }}
     >
       <EditorHeaderBar cluster={cluster} namespace={namespace} />
+      <Divider />
       <YamlEditor
         resourceYAML={resourceYaml}
         readOnly={!userCanEdit}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Fixes the incorrect dark header styling in the Search YAML editor page when console is in light mode. 

Fixed:
<img width="1046" height="174" alt="Screenshot 2025-09-25 at 3 52 35 PM" src="https://github.com/user-attachments/assets/36477c94-e7af-491f-b623-d7a5efc6bc0e" />

Current:
<img width="990" height="189" alt="Screenshot 2025-09-25 at 3 54 31 PM" src="https://github.com/user-attachments/assets/00f2546f-ce6a-49b8-ba47-6294c0952837" />


**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->