### PR TITLE
ACM-24965 Enable connection pooling for better backend performance

### DIFF
--- a/backend/src/lib/agent.ts
+++ b/backend/src/lib/agent.ts
@@ -2,11 +2,21 @@
 import { Agent } from 'https'
 import { getCACertificate, getServiceCACertificate } from './serviceAccountToken'
 import { HttpsProxyAgent } from 'https-proxy-agent'
+import { AgentOptions } from 'http'
+
+const COMMON_AGENT_OPTIONS: Partial<AgentOptions> = {
+  keepAlive: true, // Reuse connections
+  keepAliveMsecs: 30000, // 30 seconds keep alive
+  timeout: 30000, // 30 second socket timeout
+}
 
 let defaultAgent: Agent
 export function getDefaultAgent() {
   if (!defaultAgent) {
-    defaultAgent = new Agent({ ca: getCACertificate() })
+    defaultAgent = new Agent({
+      ca: getCACertificate(),
+      ...COMMON_AGENT_OPTIONS,
+    })
   }
   return defaultAgent
 }
@@ -14,7 +24,7 @@ export function getDefaultAgent() {
 let serviceAgent: Agent
 export function getServiceAgent() {
   if (!serviceAgent) {
-    serviceAgent = new Agent({ ca: getServiceCACertificate() })
+    serviceAgent = new Agent({ ca: getServiceCACertificate(), ...COMMON_AGENT_OPTIONS })
   }
   return serviceAgent
 }
@@ -22,7 +32,7 @@ export function getServiceAgent() {
 let proxyAgent: HttpsProxyAgent<string>
 export function getProxyAgent() {
   if (!proxyAgent && process.env.HTTPS_PROXY) {
-    proxyAgent = new HttpsProxyAgent(process.env.HTTPS_PROXY)
+    proxyAgent = new HttpsProxyAgent(process.env.HTTPS_PROXY, COMMON_AGENT_OPTIONS)
   }
   return proxyAgent
 }

--- a/backend/src/lib/search.ts
+++ b/backend/src/lib/search.ts
@@ -3,9 +3,10 @@ import { OutgoingHttpHeaders } from 'http2'
 import { RequestOptions, request } from 'https'
 import { URL } from 'url'
 import { getMultiClusterHub } from '../lib/multi-cluster-hub'
-import { getNamespace, getServiceAccountToken, getServiceCACertificate } from '../lib/serviceAccountToken'
+import { getNamespace, getServiceAccountToken } from '../lib/serviceAccountToken'
 import { logger } from './logger'
 import { IQuery } from '../routes/aggregators/applications'
+import { getServiceAgent } from './agent'
 
 export type ISearchResult = {
   data: {
@@ -51,7 +52,7 @@ export async function getSearchRequestOptions(headers: OutgoingHttpHeaders): Pro
     path: url.pathname,
     method: 'POST',
     headers,
-    ca: getServiceCACertificate(),
+    agent: getServiceAgent(),
   }
   return options
 }

--- a/backend/src/lib/search.ts
+++ b/backend/src/lib/search.ts
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { OutgoingHttpHeaders } from 'http2'
-import { RequestOptions, request } from 'https'
-import { URL } from 'url'
+import { OutgoingHttpHeaders } from 'node:http2'
+import { RequestOptions, request } from 'node:https'
+import { URL } from 'node:url'
 import { getMultiClusterHub } from '../lib/multi-cluster-hub'
 import { getNamespace, getServiceAccountToken } from '../lib/serviceAccountToken'
 import { logger } from './logger'
@@ -64,7 +64,7 @@ export async function getSearchResults(query: IQuery) {
     let body = ''
     const id = setTimeout(() => {
       logger.error(`getSearchResults request timeout`)
-      reject(Error('request timeout'))
+      reject(new Error('request timeout'))
     }, requestTimeout)
     const req = request(options, (res) => {
       res.on('data', (data) => {
@@ -76,7 +76,7 @@ export async function getSearchResults(query: IQuery) {
           const message = typeof result === 'string' ? result : result.message
           if (message) {
             logger.error(`getSearchResults return error ${message}`)
-            reject(Error(result.message))
+            reject(new Error(result.message))
           }
           resolve(result)
         } catch (e) {
@@ -84,7 +84,7 @@ export async function getSearchResults(query: IQuery) {
           // pause before next request
           logger.error(`getSearchResults parse error ${e} ${body}`)
           setTimeout(() => {
-            reject(Error(body))
+            reject(new Error(body))
           }, requestTimeout)
         }
         clearTimeout(id)
@@ -128,7 +128,7 @@ export async function pingSearchAPI() {
     const id = setTimeout(
       () => {
         logger.error(`ping searchAPI timeout`)
-        reject(Error('request timeout'))
+        reject(new Error('request timeout'))
       },
       4 * 60 * 1000
     )

--- a/backend/src/routes/managedClusterProxy.ts
+++ b/backend/src/routes/managedClusterProxy.ts
@@ -3,10 +3,10 @@ import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
 import { logger } from '../lib/logger'
 import { respondInternalServerError } from '../lib/respond'
 import { getAuthenticatedToken, isHttp2ServerResponse } from '../lib/token'
-import { getServiceCACertificate } from '../lib/serviceAccountToken'
 import { getMultiClusterEngine } from '../lib/multi-cluster-engine'
 import proxy from 'http2-proxy'
 import { TLSSocket } from 'tls'
+import { getServiceAgent } from '../lib/agent'
 
 export async function managedClusterProxy(req: Http2ServerRequest, res: Http2ServerResponse): Promise<void>
 export async function managedClusterProxy(req: Http2ServerRequest, socket: TLSSocket, head: Buffer): Promise<void>
@@ -40,7 +40,7 @@ export async function managedClusterProxy(
       protocol: 'https',
       hostname: proxyHost,
       port: proxyPort,
-      ca: getServiceCACertificate(),
+      agent: getServiceAgent(),
     } as const
 
     const proxyHandler = (err: Error) => {

--- a/backend/src/routes/managedClusterProxy.ts
+++ b/backend/src/routes/managedClusterProxy.ts
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
+import { constants, Http2ServerRequest, Http2ServerResponse } from 'node:http2'
 import { logger } from '../lib/logger'
 import { respondInternalServerError } from '../lib/respond'
 import { getAuthenticatedToken, isHttp2ServerResponse } from '../lib/token'

--- a/backend/src/routes/metricsProxy.ts
+++ b/backend/src/routes/metricsProxy.ts
@@ -1,8 +1,8 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { constants, Http2ServerRequest, Http2ServerResponse, OutgoingHttpHeaders } from 'http2'
-import { request, RequestOptions } from 'https'
-import { pipeline } from 'stream'
-import { URL } from 'url'
+import { constants, Http2ServerRequest, Http2ServerResponse, OutgoingHttpHeaders } from 'node:http2'
+import { request, RequestOptions } from 'node:https'
+import { pipeline } from 'node:stream'
+import { URL } from 'node:url'
 import { getServiceAgent } from '../lib/agent'
 import { logger } from '../lib/logger'
 import { notFound, respondInternalServerError, unauthorized } from '../lib/respond'

--- a/backend/src/routes/virtualMachineProxy.ts
+++ b/backend/src/routes/virtualMachineProxy.ts
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { constants, Http2ServerRequest, Http2ServerResponse } from 'http2'
+import { constants, Http2ServerRequest, Http2ServerResponse } from 'node:http2'
 import { HeadersInit } from 'node-fetch'
 import { getServiceAgent } from '../lib/agent'
 import { fetchRetry } from '../lib/fetch-retry'
@@ -431,18 +431,18 @@ async function calculateSingleVmiUsage(
   // --- Calculate CPU and Memory Usage ---
   let podRequestedCPU = 0
   let podRequestedMemory = 0
-  pod.spec.containers.forEach((c) => {
+  for (const c of pod.spec.containers) {
     // Assuming these helper functions handle undefined/null inputs gracefully (e.g., return 0)
     podRequestedCPU += toMillicores(c.resources?.requests?.cpu)
     podRequestedMemory += toMebibytes(c.resources?.requests?.memory)
-  })
+  }
 
   let podCpuUsage = 0
   let podMemoryUsage = 0
-  metric.containers.forEach((container) => {
+  for (const container of metric.containers) {
     podCpuUsage += convertNanocoresToMillicores(container.usage.cpu)
     podMemoryUsage += convertKibibytesToMebibytes(container.usage.memory)
-  })
+  }
 
   // --- Fetch and Calculate Storage Usage ---
   const { proxyURL, clusterName, namespace, token } = context
@@ -452,11 +452,11 @@ async function calculateSingleVmiUsage(
   let podStorageUsage = 0
   let podStorageTotal = 0
   if (filesystem?.items) {
-    filesystem.items.forEach((item) => {
+    for (const item of filesystem.items) {
       // Assuming these helpers convert bytes to GiB as in the original code
       podStorageUsage += convertBytesToGibibytes(item.usedBytes)
       podStorageTotal += convertBytesToGibibytes(item.totalBytes)
-    })
+    }
   }
 
   // --- Assemble final VMI usage object ---

--- a/backend/src/routes/virtualMachineProxy.ts
+++ b/backend/src/routes/virtualMachineProxy.ts
@@ -76,9 +76,7 @@ export async function virtualMachineGETProxy(req: Http2ServerRequest, res: Http2
   const token = await getAuthenticatedToken(req, res)
   if (token) {
     try {
-      const mce = await getMultiClusterEngine()
-      const proxyService = `https://cluster-proxy-addon-user.${mce?.spec?.targetNamespace || 'multicluster-engine'}.svc.cluster.local:9092`
-      const proxyURL = process.env.CLUSTER_PROXY_ADDON_USER_ROUTE || proxyService
+      const proxyURL = await getProxyUrl()
       const urlSplit = req.url.split('/')
       // vm get requests have url /virtualmachines/get/<managedCluster>/<name>/<namespace>
       const managedCluster = urlSplit[3]
@@ -121,9 +119,7 @@ export async function virtualMachineProxy(req: Http2ServerRequest, res: Http2Ser
         mch?.spec?.overrides?.components?.find(
           (e: { enabled: boolean; name: string }) => e.name === 'fine-grained-rbac-preview'
         )?.enabled ?? false
-      const mce = await getMultiClusterEngine()
-      const proxyService = `https://cluster-proxy-addon-user.${mce?.spec?.targetNamespace || 'multicluster-engine'}.svc.cluster.local:9092`
-      const proxyURL = process.env.CLUSTER_PROXY_ADDON_USER_ROUTE || proxyService
+      const proxyURL = await getProxyUrl()
 
       const chucks: string[] = []
       req.on('data', (chuck: string) => {

--- a/backend/test/routes/proxy.test.ts
+++ b/backend/test/routes/proxy.test.ts
@@ -1,0 +1,296 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { constants } from 'http2'
+import { jest } from '@jest/globals'
+import { pipeline } from 'stream'
+import { request } from 'https'
+import { proxy } from '../../src/routes/proxy'
+import { getToken } from '../../src/lib/token'
+import { getDefaultAgent } from '../../src/lib/agent'
+// import { logger } from '../../src/lib/logger'
+import { unauthorized } from '../../src/lib/respond'
+
+// Mock dependencies
+jest.mock('../../src/lib/token', () => ({
+  getToken: jest.fn(),
+}))
+
+jest.mock('../../src/lib/agent', () => ({
+  getDefaultAgent: jest.fn(() => ({})),
+}))
+
+jest.mock('../../src/lib/logger', () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}))
+
+jest.mock('../../src/lib/respond', () => ({
+  notFound: jest.fn(),
+  unauthorized: jest.fn(),
+}))
+
+jest.mock('https', () => ({
+  request: jest.fn((_options: unknown, callback: unknown) => {
+    // Return a mock stream and call the callback with a mock response
+    const mockStream = {} as NodeJS.ReadableStream
+    const mockResponse = {
+      headers: {},
+      statusCode: 200,
+    }
+    if (callback && typeof callback === 'function') {
+      process.nextTick(() => (callback as (response: unknown) => void)(mockResponse))
+    }
+    return mockStream
+  }),
+}))
+
+jest.mock('stream', () => ({
+  pipeline: jest.fn((_req: unknown, _request: unknown, callback: unknown) => {
+    // Simulate the pipeline behavior - just call the error callback
+    if (callback && typeof callback === 'function') {
+      process.nextTick(() => (callback as (error: Error | null) => void)(null))
+    }
+  }),
+}))
+
+// Import mocked modules
+const mockGetToken = getToken as jest.MockedFunction<typeof getToken>
+const mockGetDefaultAgent = getDefaultAgent as jest.MockedFunction<typeof getDefaultAgent>
+const mockUnauthorized = unauthorized as jest.MockedFunction<typeof unauthorized>
+const mockPipeline = jest.mocked(pipeline)
+const mockRequest = jest.mocked(request)
+
+describe('Proxy Route Tests', () => {
+  let mockReq: Partial<import('http2').Http2ServerRequest>
+  let mockRes: Partial<import('http2').Http2ServerResponse>
+  let originalClusterUrl: string | undefined
+
+  beforeEach(() => {
+    // Store original environment variable
+    originalClusterUrl = process.env.CLUSTER_API_URL
+
+    // Set up test environment
+    process.env.CLUSTER_API_URL = 'https://test-cluster.example.com:6443'
+
+    // Reset all mocks
+    jest.clearAllMocks()
+
+    // Create mock request and response objects
+    mockReq = {
+      url: '/api/v1/namespaces',
+      method: 'GET',
+      headers: {
+        [constants.HTTP2_HEADER_ACCEPT]: 'application/json',
+        [constants.HTTP2_HEADER_CONTENT_TYPE]: 'application/json',
+        [constants.HTTP2_HEADER_AUTHORIZATION]: 'Bearer test-token',
+      },
+    } as Partial<import('http2').Http2ServerRequest>
+
+    mockRes = {
+      writeHead: jest.fn(),
+    } as Partial<import('http2').Http2ServerResponse>
+
+    // Don't reset modules to avoid issues with mocks
+  })
+
+  afterEach(() => {
+    // Restore original environment variable
+    if (originalClusterUrl !== undefined) {
+      process.env.CLUSTER_API_URL = originalClusterUrl
+    } else {
+      delete process.env.CLUSTER_API_URL
+    }
+  })
+
+  describe('getClusterUrl function', () => {
+    it('should parse and cache cluster URL from environment variable', async () => {
+      // Re-import the module to test getClusterUrl
+      const { proxy: proxyFunction } = await import('../../src/routes/proxy')
+
+      // Call proxy to trigger getClusterUrl
+      mockGetToken.mockReturnValue('test-token')
+
+      proxyFunction(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+      // Verify that the URL was parsed correctly
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          protocol: 'https:',
+          hostname: 'test-cluster.example.com',
+          port: '6443',
+        }),
+        expect.any(Function)
+      )
+    })
+
+    it('should reuse cached URL on subsequent calls', async () => {
+      const { proxy: proxyFunction } = await import('../../src/routes/proxy')
+
+      mockGetToken.mockReturnValue('test-token')
+
+      // Call proxy multiple times
+      proxyFunction(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+      proxyFunction(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+      // Should only parse URL once (cached)
+      expect(mockRequest).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('proxy function', () => {
+    it('should return unauthorized when no token is provided', () => {
+      mockGetToken.mockReturnValue(null)
+
+      proxy(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+      expect(mockUnauthorized).toHaveBeenCalledWith(mockReq, mockRes)
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+
+    it('should return unauthorized when token is empty string', () => {
+      mockGetToken.mockReturnValue('')
+
+      proxy(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+      expect(mockUnauthorized).toHaveBeenCalledWith(mockReq, mockRes)
+      expect(mockRequest).not.toHaveBeenCalled()
+    })
+
+    it('should make HTTPS request with correct options when token is provided', () => {
+      mockGetToken.mockReturnValue('test-token')
+
+      proxy(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          protocol: 'https:',
+          hostname: 'test-cluster.example.com',
+          port: '6443',
+          path: '/api/v1/namespaces',
+          method: 'GET',
+          headers: expect.objectContaining({
+            authorization: 'Bearer test-token',
+            accept: 'application/json',
+            'content-type': 'application/json',
+          }) as Record<string, unknown>,
+          agent: {},
+        }),
+        expect.any(Function)
+      )
+    })
+
+    it('should forward proxy headers from request', () => {
+      mockGetToken.mockReturnValue('test-token')
+
+      // Add more headers to test forwarding
+      Object.assign(
+        mockReq as Record<string, unknown>,
+        {
+          headers: {
+            [constants.HTTP2_HEADER_ACCEPT]: 'application/json',
+            [constants.HTTP2_HEADER_ACCEPT_ENCODING]: 'gzip',
+            [constants.HTTP2_HEADER_CONTENT_ENCODING]: 'gzip',
+            [constants.HTTP2_HEADER_CONTENT_LENGTH]: '100',
+            [constants.HTTP2_HEADER_CONTENT_TYPE]: 'application/json',
+            [constants.HTTP2_HEADER_AUTHORIZATION]: 'Bearer test-token',
+            // This header should not be forwarded
+            'x-custom-header': 'should-not-be-forwarded',
+          },
+        } as Partial<import('http2').Http2ServerRequest>
+      )
+
+      proxy(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            authorization: 'Bearer test-token',
+            accept: 'application/json',
+            'accept-encoding': 'gzip',
+            'content-encoding': 'gzip',
+            'content-length': '100',
+            'content-type': 'application/json',
+          }) as Record<string, unknown>,
+        }),
+        expect.any(Function)
+      )
+
+      // Verify custom header is not forwarded
+      const callArgs = mockRequest.mock.calls[0]?.[0] as unknown as { headers: Record<string, unknown> }
+      expect(callArgs?.headers).not.toHaveProperty('x-custom-header')
+    })
+
+    it('should use getDefaultAgent for HTTPS requests', () => {
+      const mockAgent = { name: 'test-agent' } as unknown as import('https').Agent
+      mockGetDefaultAgent.mockReturnValue(mockAgent)
+      mockGetToken.mockReturnValue('test-token')
+
+      proxy(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+      expect(mockGetDefaultAgent).toHaveBeenCalled()
+      expect(mockRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agent: mockAgent,
+        }),
+        expect.any(Function)
+      )
+    })
+
+    it('should handle different HTTP methods', () => {
+      mockGetToken.mockReturnValue('test-token')
+
+      const methods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH']
+
+      methods.forEach((method) => {
+        Object.assign(mockReq as Record<string, unknown>, { method } as Record<string, unknown>)
+        proxy(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+        expect(mockRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            method: method,
+          }),
+          expect.any(Function)
+        )
+      })
+    })
+
+    it('should handle different URL paths', () => {
+      mockGetToken.mockReturnValue('test-token')
+
+      const paths = ['/api/v1/namespaces', '/apis/apps/v1/deployments', '/api/v1/pods']
+
+      paths.forEach((path) => {
+        Object.assign(mockReq as Record<string, unknown>, { url: path } as Record<string, unknown>)
+        proxy(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+        expect(mockRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            path: path,
+          }),
+          expect.any(Function)
+        )
+      })
+    })
+
+    it('should call pipeline with correct arguments', () => {
+      mockGetToken.mockReturnValue('test-token')
+
+      proxy(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+      expect(mockPipeline).toHaveBeenCalledWith(
+        mockReq,
+        expect.any(Object), // The result of request(options, callback)
+        expect.any(Function) // Error callback
+      )
+    })
+
+    it('should handle pipeline errors', () => {
+      mockGetToken.mockReturnValue('test-token')
+
+      // Test that pipeline is called with correct arguments
+      proxy(mockReq as import('http2').Http2ServerRequest, mockRes as import('http2').Http2ServerResponse)
+
+      expect(mockPipeline).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
console-mce pod CrashLoopBackOff due to probe failure

**Ticket Link:**  
https://issues.redhat.com/browse/ACM-24965

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [x] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

---

### 🗒️ Notes for Reviewers
This PR updates code paths to use shared Agents for https connections. This avoids re-reading certificates on every connection and enables connection pooling for lower overall response times. For example, the apiPaths API that aggregates data from several k8s API calls runs in about 500ms after this change, compared to about 2s before.

Note that this is just part of the fix for the linked issue. The problem occurs when certain users access the UI, so I believe the RBAC checks may be slowing down overall response times from the console backend. I will also increase the liveness/readiness probe timeouts to 10s, which also resolved the issue in practice.