### PR TITLE
ACM-24901: Unable to set the attachDefaultNetwork: false while installing HCP cluster using GUI

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
@@ -759,7 +759,7 @@ const mockNodePools = {
             size: '32Gi',
           },
         },
-        defaultPodNetwork: true,
+        attachDefaultNetwork: true,
       },
     },
     release: {
@@ -1934,7 +1934,7 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
               },
             },
             additionalNetworks: [{ name: 'ns1/name1' }, { name: 'ns2/name2' }],
-            defaultPodNetwork: false,
+            attachDefaultNetwork: false,
           },
         },
         release: {
@@ -2353,7 +2353,7 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
               size: '32Gi',
             },
           },
-          defaultPodNetwork: true,
+          attachDefaultNetwork: true,
         },
       },
       release: {
@@ -2836,7 +2836,7 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
               size: '32Gi',
             },
           },
-          defaultPodNetwork: true,
+          attachDefaultNetwork: true,
         },
       },
       release: {
@@ -3320,7 +3320,7 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
               size: '32Gi',
             },
           },
-          defaultPodNetwork: true,
+          attachDefaultNetwork: true,
         },
       },
       release: {
@@ -3829,7 +3829,7 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
             },
           },
           additionalNetworks: [{ name: 'ns1/name1' }],
-          defaultPodNetwork: true,
+          attachDefaultNetwork: true,
         },
       },
       release: {
@@ -3867,7 +3867,7 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
             },
           },
           additionalNetworks: [{ name: 'ns1/name1' }],
-          defaultPodNetwork: true,
+          attachDefaultNetwork: true,
         },
       },
       release: {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -915,19 +915,19 @@ export const updateDefaultPodNetwork = (_nameControl, globalControl) => {
 
     activeNodePools.forEach((nodepool) => {
       const additionalNetworks = nodepool.find(({ id }) => id === 'additionalNetworks')
-      const defaultPodNetwork = nodepool.find(({ id }) => id === 'defaultPodNetwork')
+      const attachDefaultNetwork = nodepool.find(({ id }) => id === 'attachDefaultNetwork')
 
-      if (additionalNetworks && defaultPodNetwork) {
+      if (additionalNetworks && attachDefaultNetwork) {
         // check if there are any networks
         const hasNetworks = additionalNetworks.active?.multitextEntries?.some((entry) => entry.trim() !== '') || false
 
         if (hasNetworks) {
           // if networks exist, enable checkbox
-          defaultPodNetwork.disabled = false
+          attachDefaultNetwork.disabled = false
         } else {
           // if no networks, force it to be checked and disabled
-          defaultPodNetwork.disabled = true
-          defaultPodNetwork.active = true
+          attachDefaultNetwork.disabled = true
+          attachDefaultNetwork.active = true
         }
       }
     })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataKubeVirt.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataKubeVirt.js
@@ -330,7 +330,7 @@ export const getControlDataKubeVirt = (
         {
           name: t('Attach default pod network'),
           tooltip: t('tooltip.creation.ocp.node.pool.default.pod.network'),
-          id: 'defaultPodNetwork',
+          id: 'attachDefaultNetwork',
           type: 'checkbox',
           active: true,
           disabled: true,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataKubeVirt.test.js.snap
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/__snapshots__/ControlDataKubeVirt.test.js.snap
@@ -348,7 +348,7 @@ exports[`Cluster creation control data for KubeVirt generates correctly 1`] = `
       {
         "active": true,
         "disabled": true,
-        "id": "defaultPodNetwork",
+        "id": "attachDefaultNetwork",
         "name": "Attach default pod network",
         "tooltip": "Check this box to attach the default pod network to nodes from this pool.",
         "type": "checkbox",
@@ -806,7 +806,7 @@ exports[`Cluster creation control data for KubeVirt generates correctly for MCE 
       {
         "active": true,
         "disabled": true,
-        "id": "defaultPodNetwork",
+        "id": "attachDefaultNetwork",
         "name": "Attach default pod network",
         "tooltip": "Check this box to attach the default pod network to nodes from this pool.",
         "type": "checkbox",

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/kubevirt-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/kubevirt-template.hbs
@@ -174,10 +174,10 @@ spec:
           {{/if}}
         {{/each}}
       {{/if}}
-      {{#if defaultPodNetwork}}
-      defaultPodNetwork: true
+      {{#if attachDefaultNetwork}}
+      attachDefaultNetwork: true
       {{else}}
-      defaultPodNetwork: false
+      attachDefaultNetwork: false
       {{/if}}
   release:
     image: {{{@root.releaseImage}}}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
ACM-24901: Unable to set the attachDefaultNetwork: false while installing HCP cluster using GUI

**Ticket Link:**  
<!-- e.g. https://issues.redhat.com/browse/ACM-12345 -->
https://issues.redhat.com/browse/ACM-24901

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->