### PR TITLE
ACM-36697 [Backport release-2.13] Preserve newlines in CSV export to match console rendering

### DIFF
--- a/frontend/src/resources/utils/utils.ts
+++ b/frontend/src/resources/utils/utils.ts
@@ -54,9 +54,14 @@ export function exportObjectString(object: Record<string, string>) {
   return keyValueMap.toString()
 }
 
-export function returnCSVSafeString(exportValue: string | ReactNode) {
-  // extract newlines
-  return `"${typeof exportValue === 'string' ? exportValue.split('\n').join(' ').replace(/"/g, '""') : exportValue}"`
+export function returnCSVSafeString(exportValue: string | number | ReactNode) {
+  if (typeof exportValue === 'number') {
+    return `"${exportValue}"`
+  }
+  if (typeof exportValue !== 'string') {
+    return '"-"'
+  }
+  return `"${exportValue.replaceAll('"', '""')}"`
 }
 
 export const getISOStringTimestamp = (timestamp: string) => {

--- a/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
+++ b/frontend/src/ui-components/AcmTable/AcmTable.test.tsx
@@ -1108,10 +1108,10 @@ describe('AcmTable', () => {
 })
 
 describe('returnCSVSafeString', () => {
-  test('returns a csv safe string replacing new line with space', () => {
+  test('returns a csv safe string preserving newlines', () => {
     const content = 'testing for multiline\ndescription'
     const exportContent = returnCSVSafeString(content)
-    expect(exportContent).toEqual('"testing for multiline description"')
+    expect(exportContent).toEqual('"testing for multiline\ndescription"')
   })
 
   test('returns a csv safe string escaping double quotes', () => {


### PR DESCRIPTION
## Summary
- Backport of #6081 (ACM-32500) to `release-2.13`
- Fixes `returnCSVSafeString` to preserve newlines in CSV export instead of replacing them with spaces, so the exported CSV matches the console UI rendering of policy descriptions
- Adds `number` type support and a safe fallback for non-string/non-number ReactNode values

## Test plan
- [x] `returnCSVSafeString` unit tests pass (preserves newlines, escapes double quotes)
- [ ] Export a policy table as CSV and verify multiline descriptions retain their newlines
- [ ] Confirm the CSV output matches the UI rendering of policy descriptions

Signed-off-by: Randy Bruno Piverger <21374229+Randy424@users.noreply.github.com>