### PR TITLE
ACM-39124: fix(clusters): guard UpdateAutomationModal alert against undefined nonUpdatableCount

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.tsx
@@ -249,7 +249,7 @@ export function UpdateAutomationModal(props: {
     >
       <AcmForm>
         <Stack hasGutter>
-          {nonUpdatableCount !== 0 && (
+          {!!nonUpdatableCount && (
             <StackItem>
               <AcmAlert
                 variant="warning"


### PR DESCRIPTION
## Summary

- **Jira:** [ACM-39124](https://redhat.atlassian.net/browse/ACM-39124)
- **Root cause:** `ClustersTable.tsx` unconditionally mounts `UpdateAutomationModal` with `clusters={undefined}` on page load. Inside the modal, the guard `nonUpdatableCount !== 0` evaluates to `true` when `nonUpdatableCount` is `undefined` (because `undefined !== 0` is `true` in JavaScript), causing `t('{{count}} cluster cannot be edited', { count: undefined })` to be called on every render. i18next cannot resolve a plural form for `undefined`, so it logs `Missing i18n key "{{count}} cluster cannot be edited" in namespace "plugin__mce"` — approximately 4 times per page load (once per Recoil atom subscription settling).
- **Fix:** Change `nonUpdatableCount !== 0` → `!!nonUpdatableCount` at line 252 of `UpdateAutomationModal.tsx`. `!!undefined` is `false`, silencing the spurious errors while preserving all existing behavior for numeric values.

## Pages affected

- `/multicloud/infrastructure/clusters/managed`
- `/multicloud/infrastructure/clusters/sets/details/*/clusters`

## Test plan

- [ ] Navigate to `/multicloud/infrastructure/clusters/managed` with DevTools Console open (filter to Errors) — confirm no `Missing i18n key "{{count}} cluster cannot be edited"` errors on page load
- [ ] Repeat on `/multicloud/infrastructure/clusters/sets/details/default/clusters`
- [ ] Select clusters that include non-updatable ones and trigger **Update Automation Template** — confirm the warning alert still renders with the correct singular/plural message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ACM-39124]: https://redhat.atlassian.net/browse/ACM-39124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an incorrect warning message that could appear when no non-editable clusters were identified.
  * The warning now displays only when at least one cluster cannot be updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->