### PR TITLE
Trim Renovate config: drop release-2.12, scope GHA to main, skip node pins

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
     "release-2.15",
     "release-2.14",
     "release-2.13",
-    "release-2.12",
     "release-2.11"
   ],
   "schedule": ["every weekend"],
@@ -33,6 +32,19 @@
       "description": "Restrict npm updates to main branch only",
       "matchManagers": ["npm"],
       "matchBaseBranches": ["!/^main$/"],
+      "enabled": false
+    },
+    {
+      "description": "Restrict GitHub Actions updates to main branch only",
+      "matchManagers": ["github-actions"],
+      "matchBaseBranches": ["!/^main$/"],
+      "enabled": false
+    },
+    {
+      "description": "Only allow major Node.js version updates in GitHub Actions — major version is sufficient",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["node"],
+      "matchUpdateTypes": ["minor", "patch"],
       "enabled": false
     },
     {


### PR DESCRIPTION
## Summary
- Remove `release-2.12` from `baseBranchPatterns` — the branch is out of service
- Add a rule to restrict GitHub Actions updates to the `main` branch only
- Add a rule to disable exact Node.js version updates in GitHub Actions — a major version is sufficient and GitHub resolves the latest available

## Test plan
- [ ] Verify Renovate no longer opens PRs against `release-2.12`
- [ ] Verify GitHub Actions update PRs are only created for `main`
- [ ] Verify no PRs are opened for Node.js version pinning in workflow files


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings for improved branch targeting.
  * Limited GitHub Actions updates to the main branch.
  * Disabled updates that only change exact Node.js versions in GitHub Actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->