### PR TITLE
Fix console plugin failing when hosted clusters are defined without SSH keys

### DIFF
--- a/frontend/src/resources/hosted-cluster.ts
+++ b/frontend/src/resources/hosted-cluster.ts
@@ -48,7 +48,7 @@ export interface HostedCluster extends IResource {
     pullSecret: {
       name: string
     }
-    sshKey: {
+    sshKey?: {
       name: string
     }
     networking: {

--- a/frontend/src/resources/hosted-cluster.ts
+++ b/frontend/src/resources/hosted-cluster.ts
@@ -45,7 +45,7 @@ export interface HostedCluster extends IResource {
     release: {
       image: string
     }
-    pullSecret: {
+    pullSecret?: {
       name: string
     }
     sshKey?: {

--- a/frontend/src/resources/utils/get-cluster.test.ts
+++ b/frontend/src/resources/utils/get-cluster.test.ts
@@ -5,6 +5,7 @@ import { ClusterCurator, ClusterCuratorApiVersion, ClusterCuratorKind } from '..
 import { ClusterDeployment, ClusterDeploymentApiVersion, ClusterDeploymentKind } from '../cluster-deployment'
 import {
   ClusterStatus,
+  getCluster,
   getClusterStatus,
   getDistributionInfo,
   getHCUpgradePercent,
@@ -1027,6 +1028,22 @@ const mockClusterCuratorPosthookFailed: ClusterCurator = {
     ],
   },
 }
+
+describe('getCluster', () => {
+  it('should handle a hosted cluster without an SSH key', () => {
+    const { sshKey: _sshKey, ...spec } = mockHostedCluster.spec
+    const hostedCluster = { ...mockHostedCluster, spec } as HostedClusterK8sResource
+
+    const cluster = getCluster({
+      hostedCluster,
+      managedClusterAddOns: [],
+      clusterManagementAddOns: {},
+      nodePools: [],
+    })
+
+    expect(cluster.hypershift?.secretNames).toEqual(['psecret'])
+  })
+})
 
 describe('getDistributionInfo', () => {
   it('should have correct available updates and available channels', () => {

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -615,7 +615,7 @@ export function getCluster({
       ? {
           agent: !!hostedCluster.spec.platform?.agent,
           nodePools: clusterNodePools,
-          secretNames: [hostedCluster.spec?.sshKey?.name || '', hostedCluster.spec?.pullSecret?.name || ''].filter(
+          secretNames: [hostedCluster.spec?.sshKey?.name, hostedCluster.spec?.pullSecret?.name].filter(
             (name) => !!name
           ),
           hostingNamespace: hostedCluster.metadata?.namespace || '',

--- a/frontend/src/resources/utils/get-cluster.ts
+++ b/frontend/src/resources/utils/get-cluster.ts
@@ -615,7 +615,7 @@ export function getCluster({
       ? {
           agent: !!hostedCluster.spec.platform?.agent,
           nodePools: clusterNodePools,
-          secretNames: [hostedCluster.spec?.sshKey.name || '', hostedCluster.spec?.pullSecret?.name || ''].filter(
+          secretNames: [hostedCluster.spec?.sshKey?.name || '', hostedCluster.spec?.pullSecret?.name || ''].filter(
             (name) => !!name
           ),
           hostingNamespace: hostedCluster.metadata?.namespace || '',


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Handle HostedClusters without an SSH key

**Ticket Link:**  
N/A — this fix does not have an ACM Jira ticket, and GitHub Issues are disabled for this repository.

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

HyperShift defines `HostedCluster.spec.sshKey` as optional. The cluster resource mapping guarded `spec`, but accessed `sshKey.name` without guarding the optional `sshKey`. As a result, listing a valid HostedCluster without an SSH key threw `Cannot read properties of undefined (reading 'name')` and broke the managed clusters page.

This change safely accesses the optional SSH key reference and updates the console-owned HostedCluster interface to reflect the HyperShift API contract. A regression test verifies that a HostedCluster without an SSH key is mapped successfully.

Validation:

- `npm run check` — passed
- `npm test` — 532 frontend suites and all backend tests passed; one unrelated Policy wizard test failed from a missing parallel HTTP mock
- `npm test -- --runInBand src/wizards/Governance/Policy/policyWizard.test.tsx` — passed (9/9) when rerun in isolation
- `npm test -- --runInBand src/resources/utils/get-cluster.test.ts` — passed, including the new regression case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hosted clusters can now be configured without an SSH key.
  * Cluster secret handling no longer includes empty or invalid secret names when optional credentials are missing.
  * Improved compatibility with hosted-cluster configurations where pull-secret or SSH-key details are omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->