### PR TITLE
fix(clusters): hide console link and action for hub cluster (ACM-38829)

### DIFF
--- a/frontend/src/components/Clusters/ClustersTableHelper.test.tsx
+++ b/frontend/src/components/Clusters/ClustersTableHelper.test.tsx
@@ -362,6 +362,24 @@ describe('ClustersTableHelper', () => {
       expect(screen.queryByRole('link', { name: 'cluster.openConsole' })).not.toBeInTheDocument()
     })
 
+    it('should not render console URL launch icon for hub cluster even when consoleURL is set', () => {
+      const hubCluster = { ...mockCluster, name: 'local-cluster', consoleURL: 'https://console.example.com' }
+      const column = useClusterNameColumn(true, 'local-cluster')
+      renderWithProviders(<TestColumnComponent column={column} cluster={hubCluster} />)
+
+      expect(screen.queryByRole('link', { name: 'cluster.openConsole' })).not.toBeInTheDocument()
+    })
+
+    it('should render console URL launch icon for non-hub cluster when localHubName is provided', () => {
+      const managedCluster = { ...mockCluster, consoleURL: 'https://console.example.com' }
+      const column = useClusterNameColumn(true, 'local-cluster')
+      renderWithProviders(<TestColumnComponent column={column} cluster={managedCluster} />)
+
+      const consoleLink = screen.getByRole('link', { name: 'cluster.openConsole' })
+      expect(consoleLink).toBeInTheDocument()
+      expect(consoleLink).toHaveAttribute('href', 'https://console.example.com')
+    })
+
     it('should render cluster status column', () => {
       const column = useClusterStatusColumn()
       renderWithProviders(<TestColumnComponent column={column} cluster={mockCluster} />)

--- a/frontend/src/components/Clusters/ClustersTableHelper.tsx
+++ b/frontend/src/components/Clusters/ClustersTableHelper.tsx
@@ -81,7 +81,10 @@ const patchClusterPowerState = (cluster: Cluster, powerState: 'Hibernating' | 'R
     [{ op: 'replace', path: '/spec/powerState', value: powerState }]
   )
 
-export function useClusterNameColumn(areLinksDisplayed: boolean = true): IAcmTableColumn<Cluster> {
+export function useClusterNameColumn(
+  areLinksDisplayed: boolean = true,
+  localHubName?: string
+): IAcmTableColumn<Cluster> {
   const { t } = useTranslation()
   return {
     header: t('table.name'),
@@ -98,7 +101,7 @@ export function useClusterNameColumn(areLinksDisplayed: boolean = true): IAcmTab
           ) : (
             <HighlightSearchText text={cluster.displayName} searchText={search} useFuzzyHighlighting />
           )}
-          {cluster.consoleURL && (
+          {cluster.consoleURL && cluster.name !== localHubName && (
             <Tooltip content={t('cluster.openConsole')}>
               <a
                 href={cluster.consoleURL}
@@ -928,7 +931,7 @@ export function useTableColumns({
 }: UseTableColumnsParams) {
   const { useIsObservabilityInstalled } = useSharedAtoms()
   const isObservabilityInstalled = useIsObservabilityInstalled()
-  const clusterNameColumn = useClusterNameColumn(areLinksDisplayed)
+  const clusterNameColumn = useClusterNameColumn(areLinksDisplayed, localHubName)
   const clusterNameColumnModal = useClusterNameColumnModal(areLinksDisplayed)
   const clusterNamespaceColumn = useClusterNamespaceColumn()
   const clusterStatusColumn = useClusterStatusColumn()

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.test.tsx
@@ -456,6 +456,13 @@ describe('ClusterActionDropdown', () => {
     await clickByLabel('Actions')
     await waitForNotText('Open cluster console')
   })
+
+  test('Open cluster console action is not shown for hub cluster even when consoleURL is set', async () => {
+    const cluster: Cluster = { ...mockCluster, name: 'local-cluster', consoleURL: 'https://console.example.com' }
+    render(<Component cluster={cluster} />)
+    await clickByLabel('Actions')
+    await waitForNotText('Open cluster console')
+  })
 })
 
 describe('ClusterActionDropdown', () => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
@@ -488,7 +488,13 @@ export function ClusterActionDropdown(props: { cluster: Cluster; isKebab: boolea
           rbac: destroyRbac,
         },
       ].filter((action) =>
-        clusterSupportsAction(cluster, action.id, isHypershiftUpdateAvailable, isHypershiftChannelSelectable)
+        clusterSupportsAction(
+          cluster,
+          action.id,
+          isHypershiftUpdateAvailable,
+          isHypershiftChannelSelectable,
+          localHubName
+        )
       ),
     [
       t,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.test.tsx
@@ -312,4 +312,14 @@ describe('clusterSupportsAction - OpenConsole', () => {
     const cluster: Cluster = { ...baseCluster, consoleURL: undefined }
     expect(clusterSupportsAction(cluster, ClusterAction.OpenConsole)).toBe(false)
   })
+
+  test('returns false for hub cluster even when consoleURL is set', () => {
+    const cluster: Cluster = { ...baseCluster, name: 'local-cluster', consoleURL: 'https://console.example.com' }
+    expect(clusterSupportsAction(cluster, ClusterAction.OpenConsole, undefined, undefined, 'local-cluster')).toBe(false)
+  })
+
+  test('returns true for non-hub cluster with consoleURL when localHubName is provided', () => {
+    const cluster: Cluster = { ...baseCluster, consoleURL: 'https://console.example.com' }
+    expect(clusterSupportsAction(cluster, ClusterAction.OpenConsole, undefined, undefined, 'local-cluster')).toBe(true)
+  })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.ts
@@ -55,7 +55,8 @@ export function clusterSupportsAction(
   cluster: Cluster,
   clusterAction: ClusterAction,
   isHypershiftUpdatesReady?: boolean,
-  isHypershiftChannelSelectable?: boolean
+  isHypershiftChannelSelectable?: boolean,
+  localHubName?: string
 ): boolean {
   if (!isHypershiftUpdatesReady) {
     isHypershiftUpdatesReady = false
@@ -128,7 +129,7 @@ export function clusterSupportsAction(
     case ClusterAction.RemoveAutomationTemplate:
       return cluster.hasAutomationTemplate && !cluster.distribution?.upgradeInfo?.isUpgrading // is not currently upgrading
     case ClusterAction.OpenConsole:
-      return !!cluster.consoleURL
+      return !!cluster.consoleURL && cluster.name !== localHubName
     default:
       return false
   }


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**
Open cluster console action and link should not appear for hub cluster

**Ticket Link:**
https://redhat.atlassian.net/browse/ACM-38829

**Type of Change:**
- [x] 🐞 Bug Fix

---

## Root Cause

The feature added in ACM-36253 (console links for managed clusters) did not exclude the hub cluster (`local-cluster`). Two places were affected:

1. **Name column icon** (`frontend/src/components/Clusters/ClustersTableHelper.tsx:101`) — `useClusterNameColumn` only checked `cluster.consoleURL`, not whether the cluster was the hub.
2. **"Open cluster console" row action** (`frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.ts:131`) — `clusterSupportsAction` for `OpenConsole` only checked `!!cluster.consoleURL`.

Since the hub cluster has a real `consoleURL`, both the link icon and the action always appeared for it.

## Fix

- Added optional `localHubName?: string` parameter to `clusterSupportsAction`. The `OpenConsole` case now returns `false` when `cluster.name === localHubName`.
- `ClusterActionDropdown` passes its already-fetched `localHubName` to `clusterSupportsAction`.
- `useClusterNameColumn` accepts an optional `localHubName` parameter and skips rendering the console link icon for the hub cluster. `useTableColumns` (which already had `localHubName`) passes it down.

## How to test

1. `npm run setup` (if not already done)
2. `npm run plugins` — navigate to **Infrastructure → Clusters**
3. With a hub cluster (`local-cluster`) visible in the list:
   - **Expected:** No external link icon next to the hub cluster name
   - **Expected:** No "Open cluster console" option in the hub cluster's actions kebab menu
4. Verify the link icon and action still appear for non-hub managed clusters with a console URL

## ✅ Checklist

### General

- [x] PR title follows the convention
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
After:

<img width="1262" height="593" alt="Снимок экрана — 2026-08-13 в 10 10 47 AM" src="https://github.com/user-attachments/assets/094528fb-47bf-44e2-a78c-f2e4679588a2" />

Three minimal changes across two source files. The `localHubName` is already available in both call sites (`ClusterActionDropdown` fetches it via `useLocalHubName()`; `useTableColumns` already received it as a prop). No new state or hooks were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented the “Open cluster console” link and action from appearing for the local hub cluster.
  - Continued displaying console access for eligible non-hub clusters with a configured console URL.

- **Tests**
  - Added coverage confirming correct console-action visibility for hub and non-hub clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->