### PR TITLE
ACM-40386 Fix AppSet destination namespace overwrite during edit

### DIFF
--- a/frontend/src/wizards/Argo/MultipleGeneratorSelector.test.tsx
+++ b/frontend/src/wizards/Argo/MultipleGeneratorSelector.test.tsx
@@ -1,6 +1,9 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { Specifications } from './MultipleGeneratorSelector'
+import { render, waitFor } from '@testing-library/react'
+import { createRef } from 'react'
+import { CrossGeneratorSync, PrevGenState, Specifications } from './MultipleGeneratorSelector'
+import { ItemContext, EditMode, EditModeContext, DataContext } from '@patternfly-labs/react-form-wizard'
 import { klona } from 'klona/json'
 
 // Mock dependencies
@@ -17,6 +20,22 @@ jest.mock('../../lib/acm-i18next', () => ({
 
 jest.mock('./common/GitRevisionSelect', () => ({
   GitRevisionSelect: () => null,
+}))
+
+jest.mock('../Placement/PlacementMatchFooter', () => ({
+  PlacementMatchFooter: () => null,
+}))
+
+jest.mock('../Placement/MatchedClustersModal', () => ({
+  MatchedClustersModal: () => null,
+}))
+
+jest.mock('../Placement/usePlacementDebug', () => ({
+  usePlacementDebug: () => ({ isReady: false, matched: [], notMatched: [], totalClusters: 0 }),
+}))
+
+jest.mock('../../hooks/useValidation', () => ({
+  useValidation: () => ({ validateName: () => undefined }),
 }))
 
 describe('Specifications', () => {
@@ -689,6 +708,242 @@ describe('Destination namespace update logic', () => {
     const namespace = hasGitGen ? pathBasename : ''
 
     expect(namespace).toBe('')
+  })
+})
+
+describe('CrossGeneratorSync - destination namespace preservation in edit mode', () => {
+  function renderCrossGeneratorSync(opts: {
+    editMode: EditMode
+    resources: any[]
+    prevGenState?: Partial<PrevGenState>
+  }) {
+    const prevGenState = { current: { hasCDRGen: true, ...opts.prevGenState } as PrevGenState }
+    const generatorPath = createRef<string>() as React.MutableRefObject<string>
+    generatorPath.current = 'spec.generators'
+    const mockUpdate = jest.fn()
+    const onGeneratorStateChange = jest.fn()
+
+    render(
+      <DataContext.Provider value={{ update: mockUpdate }}>
+        <EditModeContext.Provider value={opts.editMode}>
+          <ItemContext.Provider value={opts.resources}>
+            <CrossGeneratorSync
+              prevGenState={prevGenState}
+              onGeneratorStateChange={onGeneratorStateChange}
+              defaultData={opts.resources}
+              generatorPath={generatorPath}
+            />
+          </ItemContext.Provider>
+        </EditModeContext.Provider>
+      </DataContext.Provider>
+    )
+
+    return { prevGenState, mockUpdate, resources: opts.resources }
+  }
+
+  test('should preserve destination namespace in edit mode on initial sync', async () => {
+    const appSet: any = {
+      kind: 'ApplicationSet',
+      metadata: { name: 'my-app', namespace: 'openshift-gitops' },
+      spec: {
+        generators: [
+          {
+            clusterDecisionResource: {
+              configMapRef: 'acm-placement',
+              labelSelector: { matchLabels: {} },
+              requeueAfterSeconds: 180,
+            },
+          },
+        ],
+        template: {
+          metadata: { name: 'my-app-{{name}}' },
+          spec: {
+            destination: { namespace: 'custom-namespace', server: '{{server}}' },
+            project: 'default',
+          },
+        },
+      },
+    }
+    const resources = [
+      appSet,
+      { kind: 'Placement', metadata: { name: 'my-app-placement', namespace: 'openshift-gitops' } },
+    ]
+
+    const { prevGenState } = renderCrossGeneratorSync({
+      editMode: EditMode.Edit,
+      resources,
+    })
+
+    await waitFor(() => {
+      expect(appSet.spec.template.spec.destination.namespace).toBe('custom-namespace')
+      expect(prevGenState.current.lastSetDestinationNamespace).toBe('custom-namespace')
+    })
+  })
+
+  test('should set destination namespace to appName in create mode on initial sync', async () => {
+    const appSet: any = {
+      kind: 'ApplicationSet',
+      metadata: { name: 'my-app', namespace: 'openshift-gitops' },
+      spec: {
+        generators: [
+          {
+            clusterDecisionResource: {
+              configMapRef: 'acm-placement',
+              labelSelector: { matchLabels: {} },
+              requeueAfterSeconds: 180,
+            },
+          },
+        ],
+        template: {
+          metadata: { name: 'my-app-{{name}}' },
+          spec: {
+            destination: { namespace: '', server: '{{server}}' },
+            project: 'default',
+          },
+        },
+      },
+    }
+    const resources = [
+      appSet,
+      { kind: 'Placement', metadata: { name: 'my-app-placement', namespace: 'openshift-gitops' } },
+    ]
+
+    renderCrossGeneratorSync({
+      editMode: EditMode.Create,
+      resources,
+    })
+
+    await waitFor(() => {
+      expect(appSet.spec.template.spec.destination.namespace).toBe('my-app')
+    })
+  })
+
+  test('should preserve destination namespace in edit mode with git generator', async () => {
+    const appSet: any = {
+      kind: 'ApplicationSet',
+      metadata: { name: 'my-app', namespace: 'openshift-gitops' },
+      spec: {
+        generators: [
+          {
+            git: {
+              repoURL: 'https://github.com/test/repo',
+              revision: 'main',
+              directories: [{ path: 'apps' }],
+            },
+          },
+        ],
+        template: {
+          metadata: { name: 'my-app-old' },
+          spec: {
+            destination: { namespace: 'my-custom-ns', server: '{{server}}' },
+            project: 'default',
+          },
+        },
+      },
+    }
+    const resources = [
+      appSet,
+      { kind: 'Placement', metadata: { name: 'my-app-placement', namespace: 'openshift-gitops' } },
+    ]
+
+    renderCrossGeneratorSync({
+      editMode: EditMode.Edit,
+      resources,
+    })
+
+    await waitFor(() => {
+      expect(appSet.spec.template.metadata.name).toBe('my-app-{{name}}-{{path.basename}}')
+      expect(appSet.spec.template.spec.destination.namespace).toBe('my-custom-ns')
+    })
+  })
+
+  test('should not overwrite namespace when user has manually changed it after initial sync', async () => {
+    const appSet: any = {
+      kind: 'ApplicationSet',
+      metadata: { name: 'my-app', namespace: 'openshift-gitops' },
+      spec: {
+        generators: [
+          {
+            clusterDecisionResource: {
+              configMapRef: 'acm-placement',
+              labelSelector: { matchLabels: {} },
+              requeueAfterSeconds: 180,
+            },
+          },
+        ],
+        template: {
+          metadata: { name: 'my-app-{{name}}' },
+          spec: {
+            destination: { namespace: 'user-entered-ns', server: '{{server}}' },
+            project: 'default',
+          },
+        },
+      },
+    }
+    const resources = [
+      appSet,
+      { kind: 'Placement', metadata: { name: 'my-app-placement', namespace: 'openshift-gitops' } },
+    ]
+
+    renderCrossGeneratorSync({
+      editMode: EditMode.Edit,
+      resources,
+      prevGenState: {
+        hasGitGen: false,
+        hasListGen: false,
+        hasCDRGen: true,
+        lastSetDestinationNamespace: 'old-value',
+      },
+    })
+
+    await waitFor(() => {
+      expect(appSet.spec.template.spec.destination.namespace).toBe('user-entered-ns')
+    })
+  })
+
+  test('should preserve helm destination namespace on subsequent renders in edit mode', async () => {
+    const appSet: any = {
+      kind: 'ApplicationSet',
+      metadata: { name: 'my-app', namespace: 'openshift-gitops' },
+      spec: {
+        generators: [
+          {
+            clusterDecisionResource: {
+              configMapRef: 'acm-placement',
+              labelSelector: { matchLabels: {} },
+              requeueAfterSeconds: 300,
+            },
+          },
+        ],
+        template: {
+          metadata: { name: 'my-app-{{name}}' },
+          spec: {
+            destination: { namespace: 'helm-deploy-ns', server: '{{server}}' },
+            project: 'default',
+            sources: [{ chart: 'my-chart', repoURL: 'https://charts.example.com', targetRevision: '1.0.0' }],
+          },
+        },
+      },
+    }
+    const resources = [
+      appSet,
+      { kind: 'Placement', metadata: { name: 'my-app-placement', namespace: 'openshift-gitops' } },
+    ]
+
+    renderCrossGeneratorSync({
+      editMode: EditMode.Edit,
+      resources,
+      prevGenState: {
+        hasGitGen: false,
+        hasListGen: false,
+        hasCDRGen: true,
+        lastSetDestinationNamespace: 'helm-deploy-ns',
+      },
+    })
+
+    await waitFor(() => {
+      expect(appSet.spec.template.spec.destination.namespace).toBe('helm-deploy-ns')
+    })
   })
 })
 

--- a/frontend/src/wizards/Argo/MultipleGeneratorSelector.tsx
+++ b/frontend/src/wizards/Argo/MultipleGeneratorSelector.tsx
@@ -484,15 +484,25 @@ export function CrossGeneratorSync(props: CrossGeneratorSyncProps) {
     // fixup destination namespace with current appName unless the user has changed
     // it since the last sync
     const currentDestNamespace = get(appSet, DESTINATION_NAME_PATH_NAMESPACE)
-    const shouldFixDestNamespace =
-      !!appName &&
-      appName !== currentDestNamespace &&
-      (currentDestNamespace === prevGenState.current.lastSetDestinationNamespace ||
-        currentDestNamespace === '' ||
-        !prevGenState.current.lastSetDestinationNamespace)
-    if (shouldFixDestNamespace) {
-      fix(appSet, DESTINATION_NAME_PATH_NAMESPACE, appName)
-      prevGenState.current.lastSetDestinationNamespace = appName
+
+    // In edit mode, preserve the user's existing destination namespace — the
+    // general fixup only applies to create mode. In edit mode, namespace changes
+    // are driven exclusively by generator-type-change logic below.
+    if (editMode === EditMode.Edit) {
+      if (isInitialSync) {
+        prevGenState.current.lastSetDestinationNamespace = currentDestNamespace
+      }
+    } else {
+      const shouldFixDestNamespace =
+        !!appName &&
+        appName !== currentDestNamespace &&
+        (currentDestNamespace === prevGenState.current.lastSetDestinationNamespace ||
+          currentDestNamespace === '' ||
+          !prevGenState.current.lastSetDestinationNamespace)
+      if (shouldFixDestNamespace) {
+        fix(appSet, DESTINATION_NAME_PATH_NAMESPACE, appName)
+        prevGenState.current.lastSetDestinationNamespace = appName
+      }
     }
 
     // Handle git generator
@@ -503,11 +513,15 @@ export function CrossGeneratorSync(props: CrossGeneratorSyncProps) {
         !templateName.includes(PATH_BASENAME)
       ) {
         fix(appSet, TEMPLATE_NAME_PATH, `${appName}-{{name}}-${PATH_BASENAME}`)
-        fix(appSet, DESTINATION_NAME_PATH_NAMESPACE, `${PATH_BASENAME}`)
+        if (editMode !== EditMode.Edit) {
+          fix(appSet, DESTINATION_NAME_PATH_NAMESPACE, `${PATH_BASENAME}`)
+        }
       }
     } else if (!isInitialSync && prevGenState.current.hasGitGen !== hasGitGen) {
-      fix(appSet, DESTINATION_NAME_PATH_NAMESPACE, appName)
-      prevGenState.current.lastSetDestinationNamespace = appName
+      if (editMode !== EditMode.Edit) {
+        fix(appSet, DESTINATION_NAME_PATH_NAMESPACE, appName)
+        prevGenState.current.lastSetDestinationNamespace = appName
+      }
     }
 
     // Handle list generator


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
ApplicationSet wizard overwrites destination namespace with ApplicationSet name on edit

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-40386

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
Fixed the AppSet wizard to not change the destination namespace at all when in edit mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing destination namespaces when editing applications.
  * Prevented automatic namespace changes during edit mode.
  * Improved namespace synchronization when creating applications, including Git generator and template changes.
* **Tests**
  * Added coverage for namespace behavior across create and edit workflows, manual changes, Git generators, and Helm configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->