### PR TITLE
ACM-38692 Stored DOM XSS via unescaped pod logs in document.write

### DIFF
--- a/frontend/src/routes/Search/Details/LogsPage.test.tsx
+++ b/frontend/src/routes/Search/Details/LogsPage.test.tsx
@@ -549,8 +549,15 @@ describe('LogsPage', () => {
       setSearchedWordIndexes: () => {},
       setCurrentSearchedItemCount: () => {},
     })
-    window.open = jest.fn()
-    document.write = jest.fn()
+    const mockPre = { textContent: '' } as HTMLPreElement
+    const mockBody = { appendChild: jest.fn() }
+    const mockRawWindow = {
+      document: {
+        createElement: jest.fn().mockReturnValue(mockPre),
+        body: mockBody,
+      },
+    }
+    window.open = jest.fn().mockReturnValue(mockRawWindow)
     const Toolbar = () => {
       const [wrapLines, setWrapLines] = useState<boolean>(false)
       const [container, setContainer] = useState<string>('testContainer')
@@ -591,6 +598,9 @@ describe('LogsPage', () => {
     await waitFor(() => expect(rawBtn).toBeInTheDocument())
     userEvent.click(rawBtn)
     expect(window.open).toHaveBeenCalledWith('about:blank')
+    expect(mockRawWindow.document.createElement).toHaveBeenCalledWith('pre')
+    expect(mockPre.textContent).toBe('testLogs')
+    expect(mockBody.appendChild).toHaveBeenCalledWith(mockPre)
 
     const containerBtn = screen.getByText(/testcontainer/i)
     await waitFor(() => expect(containerBtn).toBeInTheDocument())

--- a/frontend/src/routes/Search/Details/LogsPage.tsx
+++ b/frontend/src/routes/Search/Details/LogsPage.tsx
@@ -100,7 +100,6 @@ export function LogsToolbar(props: {
 
   const openRawTab = () => {
     const rawWindow = window.open('about:blank')
-    /* istanbul ignore next */
     if (rawWindow) {
       // Pod logs are untrusted spoke-cluster output rendered in the hub admin's
       // browser; write them as a text node so they are never parsed as HTML.

--- a/frontend/src/routes/Search/Details/LogsPage.tsx
+++ b/frontend/src/routes/Search/Details/LogsPage.tsx
@@ -101,7 +101,13 @@ export function LogsToolbar(props: {
   const openRawTab = () => {
     const rawWindow = window.open('about:blank')
     /* istanbul ignore next */
-    rawWindow?.document.write(`<pre>${logs}</pre>`)
+    if (rawWindow) {
+      // Pod logs are untrusted spoke-cluster output rendered in the hub admin's
+      // browser; write them as a text node so they are never parsed as HTML.
+      const pre = rawWindow.document.createElement('pre')
+      pre.textContent = logs
+      rawWindow.document.body.appendChild(pre)
+    }
   }
 
   const { downloadUrl, downloadFilename } = useMemo(() => {


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Stored DOM XSS via unescaped pod logs in document.write

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-38692

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Raw Logs view to display pod logs safely and consistently in a new browser window.
  * Preserved log formatting by presenting content in a preformatted text view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->