### PR TITLE
ACM-39105 ACM-39113 Use an agent without rejectUnauthorized: false

### DIFF
--- a/backend/src/lib/json-request.ts
+++ b/backend/src/lib/json-request.ts
@@ -1,7 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { constants } from 'node:http2'
 import { Agent } from 'node:https'
-import { HttpsProxyAgent } from 'https-proxy-agent'
 import type { HeadersInit } from 'node-fetch'
 import { fetchRetry } from './fetch-retry'
 
@@ -28,7 +27,7 @@ export function jsonPost<T = unknown>(
   body: unknown,
   token?: string,
   userAgent?: string,
-  proxyAgent?: HttpsProxyAgent<string>
+  customAgent?: Agent
 ): Promise<PostResponse<T>> {
   const headers: HeadersInit = {
     [HTTP2_HEADER_ACCEPT]: 'application/json',
@@ -39,7 +38,7 @@ export function jsonPost<T = unknown>(
   return fetchRetry(url, {
     method: 'POST',
     headers,
-    agent: proxyAgent ? proxyAgent : agent,
+    agent: customAgent ? customAgent : agent,
     body: JSON.stringify(body),
     compress: true,
   }).then(async (response) => {

--- a/backend/src/routes/upgrade-risks-prediction.ts
+++ b/backend/src/routes/upgrade-risks-prediction.ts
@@ -8,6 +8,7 @@ import { getServiceAccountToken } from '../lib/serviceAccountToken'
 import { getAuthenticatedToken } from '../lib/token'
 import type { IResource } from '../resources/resource'
 import type { ResourceList } from '../resources/resource-list'
+import { Agent } from 'node:https'
 
 interface Credential {
   auths: {
@@ -65,6 +66,8 @@ export async function upgradeRiskPredictions(req: Http2ServerRequest, res: Http2
           proxyAgent = new HttpsProxyAgent(process.env.HTTPS_PROXY)
         }
 
+        const secureAgent = new Agent({})
+
         // create array of clusterIds with length of 100
         const clusterIds = body.clusterIds.reduce((resultArray: string[][], item, index) => {
           const chunkIndex = Math.floor(index / 100)
@@ -77,10 +80,12 @@ export async function upgradeRiskPredictions(req: Http2ServerRequest, res: Http2
 
         // Create req for each 100 id chunk
         const reqs = clusterIds.map((idChunk: string[]) => {
-          return jsonPost(insightsPath, { clusters: idChunk }, crcToken, userAgent, proxyAgent).catch((err: Error) => {
-            logger.error({ msg: 'Error getting cluster upgrade risk predictions', error: err.message })
-            return { error: err.message }
-          })
+          return jsonPost(insightsPath, { clusters: idChunk }, crcToken, userAgent, proxyAgent ?? secureAgent).catch(
+            (err: Error) => {
+              logger.error({ msg: 'Error getting cluster upgrade risk predictions', error: err.message })
+              return { error: err.message }
+            }
+          )
         })
 
         await Promise.all(reqs).then((results) => {


### PR DESCRIPTION
**Ticket Summary (Title):**  
CVE-2026-66806 rhacm2/console-rhel9: console: TLS verification disabled when sending hub pull-secret to console.redhat.com [rhacm-2.11.z]

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-39105
https://redhat.atlassian.net/browse/ACM-39113

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression
