### PR TITLE
fix: update ip-address / CIDR deps to fix CVE-2026-69192 [mce-2.9]

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -39,7 +39,7 @@ const config: Config.InitialOptions = {
     '\\.(css|less|scss)$': '<rootDir>/jest-raw-loader.js',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!d3*|internmap|robust-predicates|react-monaco-editor|@openshift-assisted|lodash-es|@patternfly/react-tokens|@patternfly/react-icons|@patternfly/react-user-feedback|@patternfly/react-icons|@patternfly-labs/react-form-wizard|@juggle/resize-observer|@react-hook/*|uuid|@openshift-console/dynamic-plugin-sdk*|screenfull)',
+    'node_modules/(?!d3*|internmap|robust-predicates|react-monaco-editor|@openshift-assisted|lodash-es|@patternfly/react-tokens|@patternfly/react-icons|@patternfly/react-user-feedback|@patternfly/react-icons|@patternfly-labs/react-form-wizard|@juggle/resize-observer|@react-hook/*|uuid|@openshift-console/dynamic-plugin-sdk*|screenfull|cidr-tools|cidr-regex|is-cidr|ip-bigint)',
   ],
   modulePathIgnorePatterns: ['<rootDir>/plugins'],
   ci: true,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,7 +42,7 @@
         "@tanstack/react-query": "^4.36.1",
         "ajv": "8.11.0",
         "axios": "^0.32.0",
-        "cidr-tools": "4.3.0",
+        "cidr-tools": "^12.1.3",
         "debounce": "1.2.1",
         "deep-diff": "1.0.2",
         "diff": "5.1.0",
@@ -57,7 +57,8 @@
         "i18next": "21.7.1",
         "i18next-browser-languagedetector": "6.1.4",
         "i18next-http-backend": "1.4.0",
-        "ip-cidr": "2.1.5",
+        "ip-address": "^10.5.0",
+        "is-cidr": "^7.0.1",
         "js-yaml": "^4.3.0",
         "lodash": "^4.17.23",
         "monaco-editor": "^0.34.1",
@@ -5925,6 +5926,74 @@
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@openshift-assisted/ui-lib/node_modules/cidr-regex": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-3.1.1.tgz",
+      "integrity": "sha512-RBqYd32aDwbCMFJRL6wHOlDNYJsPNTt8vC82ErHF5vKt8QQzxm1FrkW8s/R5pVrXMf17sba09Uoy91PKiddAsw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@openshift-assisted/ui-lib/node_modules/cidr-tools": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cidr-tools/-/cidr-tools-4.3.0.tgz",
+      "integrity": "sha512-Conidfn8svry8txRhW63SkaRMYJWJSvCT5kRCovIzlD0A3wzaV3gVFNxmAFJo5rxx3KHeYnJxCe7bUKFr1wxHA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "ip-address": "^8.1.0",
+        "ip-cidr": "^3.0.4",
+        "ipv6-normalize": "^1.0.1",
+        "is-cidr": "^4.0.2",
+        "is-ip": "^3.1.0",
+        "jsbn": "^1.1.0",
+        "string-natural-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@openshift-assisted/ui-lib/node_modules/cidr-tools/node_modules/ip-address": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-8.1.0.tgz",
+      "integrity": "sha512-Wz91gZKpNKoXtqvY8ScarKYwhXoK4r/b5QuT+uywe/azv0/nUCo7Bh0IRRI7F9DHR06kJNWtzMGLIbXavngbKA==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@openshift-assisted/ui-lib/node_modules/ip-address": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
+      "integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@openshift-assisted/ui-lib/node_modules/is-cidr": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-4.0.2.tgz",
+      "integrity": "sha512-z4a1ENUajDbEl/Q6/pVBpTR1nBjjEE1X7qb7bmWYanNnPoKAvUCPFKeXV6Fe4mgTkWKBqiHIcwsI3SndiO5FeA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "cidr-regex": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@openshift-assisted/ui-lib/node_modules/swr": {
@@ -13727,67 +13796,25 @@
       "dev": true
     },
     "node_modules/cidr-regex": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-3.1.1.tgz",
-      "integrity": "sha512-RBqYd32aDwbCMFJRL6wHOlDNYJsPNTt8vC82ErHF5vKt8QQzxm1FrkW8s/R5pVrXMf17sba09Uoy91PKiddAsw==",
-      "dependencies": {
-        "ip-regex": "^4.1.0"
-      },
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cidr-regex/-/cidr-regex-7.0.1.tgz",
+      "integrity": "sha512-5gppzHz6kQy4wob+bAyk5FsqF7irqxi7V6o2qO/iL1pWbwxL4uTNZ9IHk/X4MKdDegjjWIz8uERyX5nIFITT4g==",
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=22"
       }
     },
     "node_modules/cidr-tools": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cidr-tools/-/cidr-tools-4.3.0.tgz",
-      "integrity": "sha512-Conidfn8svry8txRhW63SkaRMYJWJSvCT5kRCovIzlD0A3wzaV3gVFNxmAFJo5rxx3KHeYnJxCe7bUKFr1wxHA==",
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/cidr-tools/-/cidr-tools-12.1.3.tgz",
+      "integrity": "sha512-nrz3c8ARh18FGrDZG4O6DffMcsOeh/Sw4hsMLSxAxxcCl3OfE2aGinplB1URIE2LSkrSQltL/eYweqw1E9FBuQ==",
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "ip-address": "^8.1.0",
-        "ip-cidr": "^3.0.4",
-        "ipv6-normalize": "^1.0.1",
-        "is-cidr": "^4.0.2",
-        "is-ip": "^3.1.0",
-        "jsbn": "^1.1.0",
-        "string-natural-compare": "^3.0.1"
+        "ip-bigint": "^9.0.7"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cidr-tools/node_modules/ip-address": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-8.1.0.tgz",
-      "integrity": "sha512-Wz91gZKpNKoXtqvY8ScarKYwhXoK4r/b5QuT+uywe/azv0/nUCo7Bh0IRRI7F9DHR06kJNWtzMGLIbXavngbKA==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/cidr-tools/node_modules/ip-cidr": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/ip-cidr/-/ip-cidr-3.0.7.tgz",
-      "integrity": "sha512-0cBBICDnmmpAdULMbMVdi4f0mSG+VWY/QBPL/OIIjuom14x7Y63VhpS/uSAOycasXOeGXah5y0eu//PDU51aNw==",
-      "dependencies": {
-        "ip-address": "^7.1.0",
-        "jsbn": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/cidr-tools/node_modules/ip-cidr/node_modules/ip-address": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
-      "integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 10"
+        "bun": "*",
+        "node": ">=22"
       }
     },
     "node_modules/citty": {
@@ -20130,6 +20157,38 @@
       "dev": true
     },
     "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-bigint": {
+      "version": "9.0.8",
+      "resolved": "https://registry.npmjs.org/ip-bigint/-/ip-bigint-9.0.8.tgz",
+      "integrity": "sha512-DxVFaACbpbgORsUxhcfD7TOsUgeNmKUcoJDXps/Y3CjTJpfcVfFwNu6sXIL4Y1iI8SqiCOAEKvCtIUWFZx8Qvw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "bun": "*",
+        "node": ">=22"
+      }
+    },
+    "node_modules/ip-cidr": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ip-cidr/-/ip-cidr-3.1.0.tgz",
+      "integrity": "sha512-HUCn4snshEX1P8cja/IyU3qk8FVDW8T5zZcegDFbu4w7NojmAhk5NcOgj3M8+0fmumo1afJTPDtJlzsxLdOjtg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^7.1.0",
+        "jsbn": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ip-cidr/node_modules/ip-address": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
       "integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
@@ -20142,39 +20201,11 @@
         "node": ">= 10"
       }
     },
-    "node_modules/ip-cidr": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/ip-cidr/-/ip-cidr-2.1.5.tgz",
-      "integrity": "sha512-Ms60rCkjP5cwZCgUu1JtJ6NFU1uL25SmOQHPfwMdw3LvNgY7gWz4cUou1+6Udp/vXo3eAf83XwhUpC0iZMSYkw==",
-      "dependencies": {
-        "ip-address": "^6.3.0",
-        "jsbn": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=5.0.0"
-      }
-    },
-    "node_modules/ip-cidr/node_modules/ip-address": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.4.0.tgz",
-      "integrity": "sha512-c5uxc2WUTuRBVHT/6r4m7HIr/DfV0bF6DvLH3iZGSK8wp8iMwwZSgIq2do0asFf8q9ECug0SE+6+1ACMe4sorA==",
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "lodash.find": "4.6.0",
-        "lodash.max": "4.0.1",
-        "lodash.merge": "4.6.2",
-        "lodash.padstart": "4.6.1",
-        "lodash.repeat": "4.1.0",
-        "sprintf-js": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/ip-regex": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
       "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -20191,7 +20222,8 @@
     "node_modules/ipv6-normalize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ipv6-normalize/-/ipv6-normalize-1.0.1.tgz",
-      "integrity": "sha1-GzJYKQ02X6gyOeiZB93kWS52IKg="
+      "integrity": "sha512-Bm6H79i01DjgGTCWjUuCjJ6QDo1HB96PT/xCYuyJUP9WFbVDrLSbG4EZCvOCun2rNswZb0c3e4Jt/ws795esHA==",
+      "license": "MIT"
     },
     "node_modules/is-absolute": {
       "version": "1.0.0",
@@ -20341,14 +20373,15 @@
       }
     },
     "node_modules/is-cidr": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-4.0.2.tgz",
-      "integrity": "sha512-z4a1ENUajDbEl/Q6/pVBpTR1nBjjEE1X7qb7bmWYanNnPoKAvUCPFKeXV6Fe4mgTkWKBqiHIcwsI3SndiO5FeA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/is-cidr/-/is-cidr-7.0.1.tgz",
+      "integrity": "sha512-/0uDsu4koT4rXUFGl9VUnHmT1GjfB698aY8fjwRmJiqh514Y//AhNh3n7KYCVZaY2lFtxPU6R1scH8GwxfPZLA==",
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^3.1.1"
+        "cidr-regex": "^7.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=22"
       }
     },
     "node_modules/is-core-module": {
@@ -20526,6 +20559,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
       "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
+      "license": "MIT",
       "dependencies": {
         "ip-regex": "^4.0.0"
       },
@@ -25938,16 +25972,6 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
-    "node_modules/lodash.find": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg=="
-    },
-    "node_modules/lodash.max": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
-      "integrity": "sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ=="
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -25957,17 +25981,8 @@
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/lodash.padstart": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw=="
-    },
-    "node_modules/lodash.repeat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
-      "integrity": "sha512-eWsgQW89IewS95ZOcr15HHCX6FVDxq3f2PNUIng3fyzsPev9imFQxIYdFZ6crl8L56UR6ZlGDLcEb3RZsCSSqw=="
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
@@ -30764,16 +30779,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/socks/node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/sort-keys": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.0.0.tgz",
@@ -31126,7 +31131,8 @@
     "node_modules/string-natural-compare": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/string-natural-compare/-/string-natural-compare-3.0.1.tgz",
-      "integrity": "sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw=="
+      "integrity": "sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==",
+      "license": "MIT"
     },
     "node_modules/string-similarity": {
       "version": "4.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -72,7 +72,7 @@
     "@tanstack/react-query": "^4.36.1",
     "ajv": "8.11.0",
     "axios": "^0.32.0",
-    "cidr-tools": "4.3.0",
+    "cidr-tools": "^12.1.3",
     "debounce": "1.2.1",
     "deep-diff": "1.0.2",
     "diff": "5.1.0",
@@ -87,7 +87,6 @@
     "i18next": "21.7.1",
     "i18next-browser-languagedetector": "6.1.4",
     "i18next-http-backend": "1.4.0",
-    "ip-cidr": "2.1.5",
     "js-yaml": "^4.3.0",
     "lodash": "^4.17.23",
     "monaco-editor": "^0.34.1",
@@ -102,7 +101,9 @@
     "svg.js": "2.7.1",
     "validator": "13.7.0",
     "yaml": "1.10.2",
-    "yup": "0.32.11"
+    "yup": "0.32.11",
+    "is-cidr": "^7.0.1",
+    "ip-address": "^10.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.24.5",

--- a/frontend/src/components/TemplateEditor/utils/validation-types.ts
+++ b/frontend/src/components/TemplateEditor/utils/validation-types.ts
@@ -1,11 +1,12 @@
 /* Copyright Contributors to the Open Cluster Management project */
 'use strict'
 
-import IPCIDR from 'ip-cidr'
 import { Address4, Address6 } from 'ip-address'
+import { containsCidr, parseCidr } from 'cidr-tools'
 import { validateHttpsURL, validateNoProxy, VALID_DNS_NAME_TESTER } from '../../../lib/validation'
 import { TFunction } from 'react-i18next'
 import { getControlByID } from '../../../lib/temptifly-utils'
+import isCidr from 'is-cidr'
 
 type Tester = {
   test: (value: string) => boolean
@@ -74,10 +75,9 @@ export const getIPValidator = (
         if (subnetControls.length) {
           const controlName = subnetControls[0].name
           const matchedSubnets = subnetControls.filter((subnetControl: any) => {
-            const cidrString = subnetControl.active || ''
-            const cidr = new IPCIDR(cidrString.toString())
+            const cidrString = (subnetControl.active || '').toString()
             // if CIDR is invalid or not yet entered, validation will catch that
-            return !cidr.isValid() || cidr.contains(active)
+            return !isCidr(cidrString) || containsCidr(cidrString, active)
           })
           if (!matchedSubnets.length) {
             return t('creation.ocp.cluster.valid.cidr.membership', {
@@ -107,9 +107,12 @@ export const getIPValidator = (
 export const getCIDRValidator = (t: TFunction): Validator => ({
   tester: {
     test: (value) => {
-      const cidr = new IPCIDR(value)
       // Ensure CIDR is valid and results in more than one address
-      return cidr.isValid() && cidr.start() !== cidr.end()
+      if (!isCidr(value)) {
+        return false
+      }
+      const cidr = parseCidr(value)
+      return cidr.start !== cidr.end
     },
   },
   notification: t('creation.ocp.cluster.valid.cidr'),


### PR DESCRIPTION
Mirrors https://github.com/stolostron/console/pull/6679 on `backplane-2.9`:

- Update `cidr-tools` to `^12.1.3`
- Replace `ip-cidr` with `is-cidr` `^7.0.1`
- Add/update `ip-address` to `^10.5.0` (>= 10.3.1) for CVE-2026-69192
- Update CIDR validation in `validation-types.ts` and jest transformIgnorePatterns

Verified: `npm run tsc` and TemplateEditor/useValidation/validation-types jest suites.

Related: ACM-39721

Made with [Cursor](https://cursor.com)