### PR TITLE
ACM-40763: Fix whitespace-only cluster description rendering blank instead of dash

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.test.tsx
@@ -1003,3 +1003,103 @@ describe('ClusterOverview hypershift hook status', () => {
     await waitForText('View template')
   })
 })
+
+describe('ClusterOverview description display', () => {
+  beforeEach(() => {
+    nockIgnoreRBAC()
+    nockIgnoreApiPaths()
+  })
+
+  it('should display "-" when description annotation is whitespace-only', async () => {
+    nockAggegateRequest('statuses', { clusters: ['test-cluster'] }, { itemCount: 0, filterCounts: undefined })
+    const clusterWithWhitespaceDescription = {
+      ...mockCluster,
+      annotations: {
+        'console.open-cluster-management.io/description': '   ',
+      },
+    }
+    const context: Partial<ClusterDetailsContext> = {
+      cluster: clusterWithWhitespaceDescription,
+      canGetSecret: true,
+    }
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policyreportState, [])
+          snapshot.set(managedClustersState, [])
+          snapshot.set(clusterDeploymentsState, [])
+          snapshot.set(managedClusterInfosState, [])
+          snapshot.set(certificateSigningRequestsState, [])
+          snapshot.set(managedClusterAddonsState, {})
+          snapshot.set(clusterManagementAddonsState, [])
+          snapshot.set(clusterClaimsState, [])
+          snapshot.set(clusterCuratorsState, [])
+          snapshot.set(agentClusterInstallsState, [])
+          snapshot.set(agentsState, [])
+          snapshot.set(infraEnvironmentsState, [])
+          snapshot.set(hostedClustersState, [])
+          snapshot.set(nodePoolsState, [])
+        }}
+      >
+        <MemoryRouter>
+          <Routes>
+            <Route element={<Outlet context={context} />}>
+              <Route path="*" element={<ClusterOverviewPageContent />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForText(clusterWithWhitespaceDescription.name)
+    const descriptionLabel = screen.getByText('Description')
+    const descriptionRow = descriptionLabel.closest('[class*="description-list"]') || descriptionLabel.parentElement
+    expect(descriptionRow).toBeInTheDocument()
+    await waitForText('-', true)
+  })
+
+  it('should render description when annotation has non-whitespace content', async () => {
+    nockAggegateRequest('statuses', { clusters: ['test-cluster'] }, { itemCount: 0, filterCounts: undefined })
+    const clusterWithDescription = {
+      ...mockCluster,
+      annotations: {
+        'console.open-cluster-management.io/description': 'Production cluster',
+      },
+    }
+    const context: Partial<ClusterDetailsContext> = {
+      cluster: clusterWithDescription,
+      canGetSecret: true,
+    }
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(policyreportState, [])
+          snapshot.set(managedClustersState, [])
+          snapshot.set(clusterDeploymentsState, [])
+          snapshot.set(managedClusterInfosState, [])
+          snapshot.set(certificateSigningRequestsState, [])
+          snapshot.set(managedClusterAddonsState, {})
+          snapshot.set(clusterManagementAddonsState, [])
+          snapshot.set(clusterClaimsState, [])
+          snapshot.set(clusterCuratorsState, [])
+          snapshot.set(agentClusterInstallsState, [])
+          snapshot.set(agentsState, [])
+          snapshot.set(infraEnvironmentsState, [])
+          snapshot.set(hostedClustersState, [])
+          snapshot.set(nodePoolsState, [])
+        }}
+      >
+        <MemoryRouter>
+          <Routes>
+            <Route element={<Outlet context={context} />}>
+              <Route path="*" element={<ClusterOverviewPageContent />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+
+    await waitForText(clusterWithDescription.name)
+    await waitForText('Production cluster')
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.test.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Outlet, Route, Routes } from 'react-router'
 import { RecoilRoot } from 'recoil'
 import {
@@ -46,6 +46,7 @@ import { ClusterOverviewPageContent } from './ClusterOverview'
 import { HostedClusterK8sResource } from '@openshift-assisted/ui-lib/cim'
 import userEvent from '@testing-library/user-event'
 import { AcmToastGroup, AcmToastProvider } from '../../../../../../ui-components'
+import { axe } from 'jest-axe'
 import { ClusterDetailsContext } from '../ClusterDetails'
 
 const kubeConfigSecret: Secret = {
@@ -1022,7 +1023,7 @@ describe('ClusterOverview description display', () => {
       cluster: clusterWithWhitespaceDescription,
       canGetSecret: true,
     }
-    render(
+    const { container } = render(
       <RecoilRoot
         initializeState={(snapshot) => {
           snapshot.set(policyreportState, [])
@@ -1053,9 +1054,17 @@ describe('ClusterOverview description display', () => {
 
     await waitForText(clusterWithWhitespaceDescription.name)
     const descriptionLabel = screen.getByText('Description')
-    const descriptionRow = descriptionLabel.closest('[class*="description-list"]') || descriptionLabel.parentElement
-    expect(descriptionRow).toBeInTheDocument()
-    await waitForText('-', true)
+    const descriptionGroup = descriptionLabel.closest('[class*="description-list__group"]')
+    expect(descriptionGroup).toBeInTheDocument()
+    expect(within(descriptionGroup as HTMLElement).getByText('-')).toBeInTheDocument()
+    expect(
+      await axe(container, {
+        rules: {
+          'button-name': { enabled: false },
+          'duplicate-id-active': { enabled: false },
+        },
+      })
+    ).toHaveNoViolations()
   })
 
   it('should render description when annotation has non-whitespace content', async () => {
@@ -1070,7 +1079,7 @@ describe('ClusterOverview description display', () => {
       cluster: clusterWithDescription,
       canGetSecret: true,
     }
-    render(
+    const { container } = render(
       <RecoilRoot
         initializeState={(snapshot) => {
           snapshot.set(policyreportState, [])
@@ -1101,5 +1110,13 @@ describe('ClusterOverview description display', () => {
 
     await waitForText(clusterWithDescription.name)
     await waitForText('Production cluster')
+    expect(
+      await axe(container, {
+        rules: {
+          'button-name': { enabled: false },
+          'duplicate-id-active': { enabled: false },
+        },
+      })
+    ).toHaveNoViolations()
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterOverview/ClusterOverview.tsx
@@ -343,7 +343,7 @@ export function ClusterOverviewPageContent() {
     },
     description: {
       key: t('Description'),
-      value: cluster?.annotations?.[clusterDescriptionAnnotation] ? (
+      value: cluster?.annotations?.[clusterDescriptionAnnotation]?.trim() ? (
         <div style={{ whiteSpace: 'pre-wrap' }}>
           <Markdown template={cluster.annotations[clusterDescriptionAnnotation]} />
         </div>


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Whitespace-only cluster description annotation renders blank instead of dash

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-40763

**Type of Change:**  
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

When the `console.open-cluster-management.io/description` annotation is set to a whitespace-only value via CLI (e.g. `oc annotate managedcluster <name> --overwrite 'console.open-cluster-management.io/description=   '`), the Cluster Overview page renders a blank space instead of the expected `-` placeholder.

**Root cause:** JavaScript evaluates `"   "` as truthy, so the existing check `cluster?.annotations?.[clusterDescriptionAnnotation]` passes and the Markdown renderer receives whitespace — rendering nothing visible.

**Fix:** Add `.trim()` to the truthiness check so whitespace-only values fall through to the `-` fallback. The `EditDescription` modal already trims on save and sends `null` for empty input, so this only affects annotations set directly via CLI.

**Tests added:**
- Whitespace-only description renders `-`
- Non-whitespace description renders correctly

Full test suite passes (16/16).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster descriptions containing only whitespace now display as “-” instead of blank content.
  * Valid descriptions continue to display correctly with Markdown formatting.
  * Improved handling ensures cluster overview information remains clear and consistent when descriptions are missing or empty.

* **Tests**
  * Added coverage for whitespace-only and non-empty cluster descriptions.
  * Added accessibility checks for the updated description display scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->