### PR TITLE
ACM-39083 ACM-39086 glasswing: fix f001 — derive Ansible host/token from RBAC-checked Secret [release-2.11]

### DIFF
--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -5,13 +5,23 @@ import type { RequestOptions } from 'node:https'
 import { request } from 'node:https'
 import { pipeline } from 'node:stream'
 import { URL } from 'node:url'
+import { jsonRequest } from '../lib/json-request'
 import { logger } from '../lib/logger'
 import { catchInternalServerError, notFound, respond, respondBadRequest } from '../lib/respond'
 import { getAuthenticatedToken } from '../lib/token'
 
-interface AnsibleCredential {
-  towerHost: string
-  token: string
+interface AnsibleTowerRequest {
+  // Reference to the Ansible credential Secret. The backend reads it with the
+  // caller's bearer token so kube-apiserver enforces RBAC; the tower host and
+  // token are derived server-side and never accepted from the request body.
+  secretNamespace: string
+  secretName: string
+  // Allow-listed AAP API path (optionally with query string for pagination).
+  ansiblePath: string
+}
+
+interface AnsibleSecret {
+  data?: { host?: string; token?: string }
 }
 
 // must match ansiblePaths in frontend/src/resources/utils/resource-request.ts
@@ -19,53 +29,80 @@ export const ansiblePaths = ['/api/v2/job_templates/', '/api/v2/workflow_job_tem
 
 export function ansibleTower(req: Http2ServerRequest, res: Http2ServerResponse): void {
   getAuthenticatedToken(req, res)
-    .then(() => {
+    .then((userToken) => {
       const chucks: string[] = []
-      let ansibleCredential: AnsibleCredential
-
       req.on('data', (chuck: string) => {
         chucks.push(chuck)
       })
       req.on('end', () => {
-        const body = chucks.join()
-        ansibleCredential = JSON.parse(body) as AnsibleCredential
-        let towerUrl = null
+        let body: AnsibleTowerRequest
         try {
-          towerUrl = new URL(ansibleCredential.towerHost.toString())
+          body = JSON.parse(chucks.join('')) as AnsibleTowerRequest
         } catch (err) {
           return respondBadRequest(req, res)
         }
-
-        // allow list of apis our ui calls
-        if (!ansiblePaths.includes(towerUrl.pathname)) {
+        if (
+          typeof body.secretNamespace !== 'string' ||
+          typeof body.secretName !== 'string' ||
+          typeof body.ansiblePath !== 'string'
+        ) {
           return respondBadRequest(req, res)
         }
 
-        const options: RequestOptions = {
-          protocol: towerUrl.protocol,
-          hostname: towerUrl.hostname,
-          path: `${towerUrl.pathname}${towerUrl.search ? towerUrl.search : ''}`,
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${ansibleCredential.token}`,
-          },
-          rejectUnauthorized: false, // NOSONAR - AAP connects insecurely by default
-        }
-
-        const towerReq = request(options, (response) => {
-          if (!response) return notFound(req, res)
-          res.writeHead(response.statusCode ?? 500, response.headers)
-          pipeline(response, res as unknown as NodeJS.WritableStream, (err) => {
-            if (err) {
-              logger.error(err)
+        // Resolve the tower host + token from the credential Secret using the
+        // caller's own token. A 401/403 from kube-apiserver means the caller
+        // is not authorized for this credential; never proxy in that case.
+        const secretPath =
+          process.env.CLUSTER_API_URL +
+          `/api/v1/namespaces/${encodeURIComponent(body.secretNamespace)}/secrets/${encodeURIComponent(body.secretName)}`
+        jsonRequest<AnsibleSecret>(secretPath, userToken, 0)
+          .then((secret) => {
+            const host = secret?.data?.host ? Buffer.from(secret.data.host, 'base64').toString('utf8') : ''
+            const token = secret?.data?.token ? Buffer.from(secret.data.token, 'base64').toString('utf8') : ''
+            if (!host || !token) {
+              return respondBadRequest(req, res)
             }
+
+            let towerUrl: URL
+            try {
+              towerUrl = new URL(body.ansiblePath, host)
+            } catch (err) {
+              return respondBadRequest(req, res)
+            }
+
+            // allow list of apis our ui calls
+            if (!ansiblePaths.includes(towerUrl.pathname)) {
+              return respondBadRequest(req, res)
+            }
+
+            const options: RequestOptions = {
+              protocol: towerUrl.protocol,
+              hostname: towerUrl.hostname,
+              port: towerUrl.port,
+              path: `${towerUrl.pathname}${towerUrl.search ? towerUrl.search : ''}`,
+              method: 'GET',
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+              rejectUnauthorized: false, // NOSONAR - AAP connects insecurely by default
+            }
+
+            const towerReq = request(options, (response) => {
+              if (!response) return notFound(req, res)
+              res.writeHead(response.statusCode ?? 500, response.headers)
+              pipeline(response, res as unknown as NodeJS.WritableStream, (err) => {
+                if (err) {
+                  logger.error(err)
+                }
+              })
+            })
+            towerReq.on('error', (e) => {
+              logger.error(e)
+              respond(res, JSON.stringify(e.message), constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
+            })
+            towerReq.end()
           })
-        })
-        towerReq.on('error', (e) => {
-          logger.error(e)
-          respond(res, JSON.stringify(e.message), constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
-        })
-        towerReq.end()
+          .catch(catchInternalServerError(res))
       })
     })
     .catch(catchInternalServerError(res))

--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -63,10 +63,20 @@ export function ansibleTower(req: Http2ServerRequest, res: Http2ServerResponse):
               return respondBadRequest(req, res)
             }
 
+            let hostUrl: URL
             let towerUrl: URL
             try {
-              towerUrl = new URL(body.ansiblePath, host)
+              hostUrl = new URL(host)
+              towerUrl = new URL(body.ansiblePath, hostUrl)
             } catch (err) {
+              return respondBadRequest(req, res)
+            }
+
+            // The ansiblePath is caller-supplied and only meant to be a relative
+            // API path. Reject absolute or network-path references that would
+            // point the proxy (and the Secret-derived token) at any origin other
+            // than the host configured in the credential Secret.
+            if (towerUrl.origin !== hostUrl.origin) {
               return respondBadRequest(req, res)
             }
 

--- a/backend/test/routes/ansibletower.test.ts
+++ b/backend/test/routes/ansibletower.test.ts
@@ -45,6 +45,41 @@ describe(`ansibletower Route`, function () {
     expect(res.statusCode).toEqual(400)
   })
 
+  it(`should preserve the query string for paginated requests`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
+    nock(TOWER_HOST).get(ansiblePaths[0]).query({ page: '2', page_size: '20' }).reply(200, response)
+    const res = await request('POST', '/ansibletower', {
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: `${ansiblePaths[0]}?page=2&page_size=20`,
+    })
+    expect(res.statusCode).toEqual(200)
+    expect(JSON.stringify(await parsePipedJsonBody(res))).toEqual(JSON.stringify(response))
+  })
+
+  it(`should reject an external absolute URL in ansiblePath`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
+    const res = await request('POST', '/ansibletower', {
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: `https://evil.example.com${ansiblePaths[0]}`,
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
+  it(`should reject a network-path reference in ansiblePath`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
+    const res = await request('POST', '/ansibletower', {
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: `//evil.example.com${ansiblePaths[0]}`,
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
   it(`should fail closed when caller cannot read the credential secret`, async function () {
     nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
     nock(process.env.CLUSTER_API_URL)

--- a/backend/test/routes/ansibletower.test.ts
+++ b/backend/test/routes/ansibletower.test.ts
@@ -5,25 +5,67 @@ import { ansiblePaths } from '../../src/routes/ansibletower'
 import nock from 'nock'
 
 const TOWER_HOST = 'https://ansible-tower.com'
+const SECRET_NS = 'app-team'
+const SECRET_NAME = 'tower-cred'
+
+function nockCredentialSecret(host: string) {
+  return nock(process.env.CLUSTER_API_URL)
+    .get(`/api/v1/namespaces/${SECRET_NS}/secrets/${SECRET_NAME}`)
+    .reply(200, {
+      kind: 'Secret',
+      apiVersion: 'v1',
+      metadata: { name: SECRET_NAME, namespace: SECRET_NS },
+      data: {
+        host: Buffer.from(host).toString('base64'),
+        token: Buffer.from('12345').toString('base64'),
+      },
+    })
+}
 
 describe(`ansibletower Route`, function () {
   it(`should list Ansible TowerJobs`, async function () {
     nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
     nock(TOWER_HOST).get(ansiblePaths[0]).reply(200, response)
     const res = await request('POST', '/ansibletower', {
-      towerHost: TOWER_HOST + ansiblePaths[0],
-      token: '12345',
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: ansiblePaths[0],
     })
     expect(res.statusCode).toEqual(200)
     expect(JSON.stringify(await parsePipedJsonBody(res))).toEqual(JSON.stringify(response))
   })
 
+  it(`should reject body-supplied tower hostname`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    const res = await request('POST', '/ansibletower', {
+      towerHost: TOWER_HOST + ansiblePaths[0],
+      token: '12345',
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
+  it(`should fail closed when caller cannot read the credential secret`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL)
+      .get(`/api/v1/namespaces/${SECRET_NS}/secrets/${SECRET_NAME}`)
+      .reply(403, { kind: 'Status', apiVersion: 'v1', status: 'Failure', reason: 'Forbidden', code: 403 })
+    const res = await request('POST', '/ansibletower', {
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: ansiblePaths[0],
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
   it(`when bad things happen to Ansible TowerJobs 1`, async function () {
     nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
     nock(TOWER_HOST).get(ansiblePaths[0]).reply(200, response)
     const res = await request('POST', '/ansibletower', {
-      towerHost: TOWER_HOST + '/badPath',
-      token: '12345',
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: '/badPath',
     })
     expect(res.statusCode).toEqual(400)
     expect(JSON.stringify(await parsePipedJsonBody(res))).toEqual(JSON.stringify({}))
@@ -31,9 +73,8 @@ describe(`ansibletower Route`, function () {
 
   it(`when bad things happen to Ansible TowerJobs 2`, async function () {
     nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
-    nock(TOWER_HOST).get(ansiblePaths[0]).reply(200, response)
     const res = await request('POST', '/ansibletower', {
-      token: '12345',
+      secretNamespace: SECRET_NS,
     })
     expect(JSON.stringify(await parsePipedJsonBody(res))).toEqual(JSON.stringify({}))
   })

--- a/frontend/src/lib/nock-util.ts
+++ b/frontend/src/lib/nock-util.ts
@@ -321,8 +321,9 @@ export function nockRBAC(resourceAttributes: ResourceAttributes, allowed = true)
 }
 
 interface AnsibleCredentialPostBody {
-  towerHost: string
-  token: string
+  secretNamespace: string
+  secretName: string
+  ansiblePath: string
 }
 
 interface GetGitBranchesArgoResponse {

--- a/frontend/src/resources/utils/resource-request.ts
+++ b/frontend/src/resources/utils/resource-request.ts
@@ -469,25 +469,25 @@ export function listNamespacedResources<Resource extends IResource>(
   }
 }
 
+interface AnsibleSecretRef {
+  namespace: string
+  name: string
+}
+
 async function getAnsibleTemplates(
   backendURLPath: string,
-  ansibleHostUrl: string,
-  token: string,
+  secretRef: AnsibleSecretRef,
   abortController: AbortController
 ) {
   const ansibleJobs: AnsibleTowerJobTemplate[] = []
 
   for (const path of ansiblePaths) {
-    let jobUrl: string = ansibleHostUrl + path
-    while (jobUrl) {
-      const result = await fetchGetAnsibleJobs(backendURLPath, jobUrl, token, abortController.signal)
+    let ansiblePath: string = path
+    while (ansiblePath) {
+      const result = await fetchGetAnsibleJobs(backendURLPath, secretRef, ansiblePath, abortController.signal)
       result.data.results && ansibleJobs.push(...result.data.results)
       const { next } = result.data
-      if (next) {
-        jobUrl = ansibleHostUrl + next
-      } else {
-        jobUrl = ''
-      }
+      ansiblePath = next ? next : ''
     }
   }
 
@@ -502,16 +502,15 @@ async function getAnsibleTemplates(
     }),
   }
 }
-// TODO: validation for URL input
-// Code assumes protocol is present & ansiblehosturl ends without a /
-export function listAnsibleTowerJobs(
-  ansibleHostUrl: string,
-  token: string
-): IRequestResult<AnsibleTowerJobTemplateList> {
+
+// The backend resolves the tower host + token from the credential Secret using the
+// caller's bearer token (kube-apiserver enforces RBAC), so callers pass only a
+// reference to the Secret and the allow-listed AAP API path — never a raw URL.
+export function listAnsibleTowerJobs(secretRef: AnsibleSecretRef): IRequestResult<AnsibleTowerJobTemplateList> {
   const backendURLPath = getBackendUrl() + '/ansibletower'
   const abortController = new AbortController()
   return {
-    promise: getAnsibleTemplates(backendURLPath, ansibleHostUrl, token, abortController).then((item) => {
+    promise: getAnsibleTemplates(backendURLPath, secretRef, abortController).then((item) => {
       return item as AnsibleTowerJobTemplateList
     }),
     abort: () => abortController.abort(),
@@ -520,8 +519,8 @@ export function listAnsibleTowerJobs(
 
 export function fetchGetAnsibleJobs(
   backendUrlPath: string,
-  ansibleJobsUrl: string,
-  token: string,
+  secretRef: AnsibleSecretRef,
+  ansiblePath: string,
   signal: AbortSignal
 ) {
   return fetchRetry<AnsibleTowerJobTemplateList>({
@@ -529,8 +528,9 @@ export function fetchGetAnsibleJobs(
     url: backendUrlPath,
     signal,
     data: {
-      towerHost: ansibleJobsUrl,
-      token: token,
+      secretNamespace: secretRef.namespace,
+      secretName: secretRef.name,
+      ansiblePath,
     },
     retries: process.env.NODE_ENV === 'production' ? 2 : 0,
     disableRedirectUnauthorizedLogin: true,
@@ -539,13 +539,11 @@ export function fetchGetAnsibleJobs(
 
 async function getAnsibleInventories(
   backendURLPath: string,
-  ansibleHostUrl: string,
-  token: string,
+  secretRef: AnsibleSecretRef,
   abortController: AbortController
 ) {
   const ansibleInventories: AnsibleTowerInventory[] = []
-  const inventoryUrl: string = ansibleHostUrl + '/api/v2/inventories/'
-  const result = await fetchGetAnsibleInventories(backendURLPath, inventoryUrl, token, abortController.signal)
+  const result = await fetchGetAnsibleInventories(backendURLPath, secretRef, abortController.signal)
   result.data.results && ansibleInventories.push(...result.data.results)
 
   return {
@@ -562,33 +560,26 @@ async function getAnsibleInventories(
   }
 }
 
-export function listAnsibleTowerInventories(
-  ansibleHostUrl: string,
-  token: string
-): IRequestResult<AnsibleTowerInventoryList> {
+export function listAnsibleTowerInventories(secretRef: AnsibleSecretRef): IRequestResult<AnsibleTowerInventoryList> {
   const backendURLPath = getBackendUrl() + '/ansibletower'
   const abortController = new AbortController()
   return {
-    promise: getAnsibleInventories(backendURLPath, ansibleHostUrl, token, abortController).then((item) => {
+    promise: getAnsibleInventories(backendURLPath, secretRef, abortController).then((item) => {
       return item as AnsibleTowerInventoryList
     }),
     abort: () => abortController.abort(),
   }
 }
 
-export function fetchGetAnsibleInventories(
-  backendUrlPath: string,
-  ansibleInventoriesUrl: string,
-  token: string,
-  signal: AbortSignal
-) {
+export function fetchGetAnsibleInventories(backendUrlPath: string, secretRef: AnsibleSecretRef, signal: AbortSignal) {
   return fetchRetry<AnsibleTowerInventoryList>({
     method: 'POST',
     url: backendUrlPath,
     signal,
     data: {
-      towerHost: ansibleInventoriesUrl,
-      token: token,
+      secretNamespace: secretRef.namespace,
+      secretName: secretRef.name,
+      ansiblePath: '/api/v2/inventories/',
     },
     retries: process.env.NODE_ENV === 'production' ? 2 : 0,
     disableRedirectUnauthorizedLogin: true,

--- a/frontend/src/routes/Governance/governance.sharedMocks.tsx
+++ b/frontend/src/routes/Governance/governance.sharedMocks.tsx
@@ -659,12 +659,14 @@ const secret: Secret = {
 }
 
 export const mockAnsibleCredential = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/v2/job_templates/',
-  token: 'abcd',
+  secretNamespace: 'test',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/v2/job_templates/',
 }
 export const mockAnsibleCredentialWorkflow = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/v2/workflow_job_templates/',
-  token: 'abcd',
+  secretNamespace: 'test',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/v2/workflow_job_templates/',
 }
 
 export const mockTemplateWorkflowList: AnsibleTowerJobTemplateList = {

--- a/frontend/src/routes/Governance/policies/CreatePolicyAutomation.tsx
+++ b/frontend/src/routes/Governance/policies/CreatePolicyAutomation.tsx
@@ -98,10 +98,9 @@ export function CreatePolicyAutomation() {
       }}
       onSubmit={(data) => handlePolicyAutomationSubmit(submitForm, data, secrets, history, toast, t)}
       getAnsibleJobsCallback={async (credential: any) => {
-        const host = Buffer.from(credential.data.host || '', 'base64').toString('ascii')
-        const token = Buffer.from(credential.data.token || '', 'base64').toString('ascii')
+        const secretRef = { namespace: credential.metadata.namespace, name: credential.metadata.name }
 
-        return listAnsibleTowerJobs(host, token).promise.then((response) => {
+        return listAnsibleTowerJobs(secretRef).promise.then((response) => {
           let templateList: { name: string; description?: string; id: string }[] = []
           if (response?.results) {
             templateList = response.results!.map((job) => ({

--- a/frontend/src/routes/Governance/policies/EditPolicyAutomation.tsx
+++ b/frontend/src/routes/Governance/policies/EditPolicyAutomation.tsx
@@ -101,11 +101,10 @@ export function EditPolicyAutomation() {
         handlePolicyAutomationSubmit(submitForm, data, secrets, history, toast, t, currentPolicyAutomation)
       }
       getAnsibleJobsCallback={async (credential: any) => {
-        const host = Buffer.from(credential.data.host || '', 'base64').toString('ascii')
-        const token = Buffer.from(credential.data.token || '', 'base64').toString('ascii')
+        const secretRef = { namespace: credential.metadata.namespace, name: credential.metadata.name }
 
         return new Promise((resolve, reject) => {
-          const ansibleJobs = listAnsibleTowerJobs(host, token)
+          const ansibleJobs = listAnsibleTowerJobs(secretRef)
           ansibleJobs.promise
             .then((response) => {
               if (response) {

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
@@ -114,17 +114,20 @@ const mockClusterCurator: ClusterCurator = {
 }
 
 const mockAnsibleCredential = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/v2/job_templates/',
-  token: 'abcd',
+  secretNamespace: 'namespace-1',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/v2/job_templates/',
 }
 const mockAnsibleCredentialWorkflow = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/v2/workflow_job_templates/',
-  token: 'abcd',
+  secretNamespace: 'namespace-1',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/v2/workflow_job_templates/',
 }
 
 const mockAnsibleCredentialInventory = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/v2/inventories/',
-  token: 'abcd',
+  secretNamespace: 'namespace-1',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/v2/inventories/',
 }
 
 const mockTemplateList: AnsibleTowerJobTemplateList = {

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -193,49 +193,46 @@ export function AnsibleAutomationsForm(props: {
 
     if (ansibleSelection) {
       const selectedCred = ansibleCredentials.find((credential) => credential.metadata.name === ansibleSelection)
+      const secretRef = { namespace: selectedCred?.metadata?.namespace!, name: selectedCred?.metadata?.name! }
       const inventoryList: { name: string; description?: string; id: string }[] | undefined = []
       const jobList: { name: string; description?: string; id: string }[] = []
       const workflowList: { name: string; description?: string; id: string }[] = []
       Promise.all([
-        listAnsibleTowerJobs(selectedCred?.stringData?.host!, selectedCred?.stringData?.token!).promise.then(
-          (response) => {
-            if (response) {
-              response.results.forEach((template) => {
-                if (template.type === 'job_template' && template.name) {
-                  jobList.push({
-                    name: template.name,
-                    description: template.description,
-                    id: template.id,
-                  })
-                } else if (template.type === 'workflow_job_template' && template.name) {
-                  workflowList.push({
-                    name: template.name,
-                    description: template.description,
-                    id: template.id,
-                  })
-                }
-              })
-              setAnsibleTowerJobTemplateList(jobList)
-              setAnsibleTowerWorkflowTemplateList(workflowList)
-            }
+        listAnsibleTowerJobs(secretRef).promise.then((response) => {
+          if (response) {
+            response.results.forEach((template) => {
+              if (template.type === 'job_template' && template.name) {
+                jobList.push({
+                  name: template.name,
+                  description: template.description,
+                  id: template.id,
+                })
+              } else if (template.type === 'workflow_job_template' && template.name) {
+                workflowList.push({
+                  name: template.name,
+                  description: template.description,
+                  id: template.id,
+                })
+              }
+            })
+            setAnsibleTowerJobTemplateList(jobList)
+            setAnsibleTowerWorkflowTemplateList(workflowList)
           }
-        ),
-        listAnsibleTowerInventories(selectedCred?.stringData?.host!, selectedCred?.stringData?.token!).promise.then(
-          (response) => {
-            if (response) {
-              response.results.forEach((inventory) => {
-                if (inventory.name) {
-                  inventoryList.push({
-                    name: inventory.name,
-                    description: inventory?.description,
-                    id: inventory.id,
-                  })
-                }
-              })
-              setAnsibleTowerInventoryList(inventoryList)
-            }
+        }),
+        listAnsibleTowerInventories(secretRef).promise.then((response) => {
+          if (response) {
+            response.results.forEach((inventory) => {
+              if (inventory.name) {
+                inventoryList.push({
+                  name: inventory.name,
+                  description: inventory?.description,
+                  id: inventory.id,
+                })
+              }
+            })
+            setAnsibleTowerInventoryList(inventoryList)
           }
-        ),
+        }),
       ]).catch((err) => {
         setAnsibleTowerAuthError(
           err.code === ResourceErrorCode.InternalServerError && err.reason


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Authenticated SSRF via /ansibletower (arbitrary host, full response disclosure)

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-39083
https://redhat.atlassian.net/browse/ACM-39086

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression