### PR TITLE
ACM-39085 ACM-39087 glasswing: fix f001 — derive Ansible host/token from RBAC-checked Secret [release-2.15]

### DIFF
--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -72,10 +72,20 @@ export function ansibleTower(req: Http2ServerRequest, res: Http2ServerResponse):
               return respondBadRequest(req, res)
             }
 
+            let hostUrl: URL
             let towerUrl: URL
             try {
-              towerUrl = new URL(body.ansiblePath, host)
+              hostUrl = new URL(host)
+              towerUrl = new URL(body.ansiblePath, hostUrl)
             } catch (err) {
+              return respondBadRequest(req, res)
+            }
+
+            // The ansiblePath is caller-supplied and only meant to be a relative
+            // API path. Reject absolute or network-path references that would
+            // point the proxy (and the Secret-derived token) at any origin other
+            // than the host configured in the credential Secret.
+            if (towerUrl.origin !== hostUrl.origin) {
               return respondBadRequest(req, res)
             }
 

--- a/backend/src/routes/ansibletower.ts
+++ b/backend/src/routes/ansibletower.ts
@@ -5,13 +5,23 @@ import type { RequestOptions } from 'node:https'
 import { request } from 'node:https'
 import { pipeline } from 'node:stream'
 import { URL } from 'node:url'
+import { jsonRequest } from '../lib/json-request'
 import { logger } from '../lib/logger'
 import { catchInternalServerError, notFound, respond, respondBadRequest } from '../lib/respond'
 import { getAuthenticatedToken } from '../lib/token'
 
-interface AnsibleCredential {
-  towerHost: string
-  token: string
+interface AnsibleTowerRequest {
+  // Reference to the Ansible credential Secret. The backend reads it with the
+  // caller's bearer token so kube-apiserver enforces RBAC; the tower host and
+  // token are derived server-side and never accepted from the request body.
+  secretNamespace: string
+  secretName: string
+  // Allow-listed AAP API path (optionally with query string for pagination).
+  ansiblePath: string
+}
+
+interface AnsibleSecret {
+  data?: { host?: string; token?: string }
 }
 
 // must match ansiblePaths in frontend/src/resources/utils/resource-request.ts
@@ -28,53 +38,80 @@ export const ansiblePaths = [
 
 export function ansibleTower(req: Http2ServerRequest, res: Http2ServerResponse): void {
   getAuthenticatedToken(req, res)
-    .then(() => {
+    .then((userToken) => {
       const chucks: string[] = []
-      let ansibleCredential: AnsibleCredential
-
       req.on('data', (chuck: string) => {
         chucks.push(chuck)
       })
       req.on('end', () => {
-        const body = chucks.join()
-        ansibleCredential = JSON.parse(body) as AnsibleCredential
-        let towerUrl = null
+        let body: AnsibleTowerRequest
         try {
-          towerUrl = new URL(ansibleCredential.towerHost.toString())
+          body = JSON.parse(chucks.join('')) as AnsibleTowerRequest
         } catch (err) {
           return respondBadRequest(req, res)
         }
-
-        // allow list of apis our ui calls
-        if (!ansiblePaths.includes(towerUrl.pathname)) {
+        if (
+          typeof body.secretNamespace !== 'string' ||
+          typeof body.secretName !== 'string' ||
+          typeof body.ansiblePath !== 'string'
+        ) {
           return respondBadRequest(req, res)
         }
 
-        const options: RequestOptions = {
-          protocol: towerUrl.protocol,
-          hostname: towerUrl.hostname,
-          path: `${towerUrl.pathname}${towerUrl.search ? towerUrl.search : ''}`,
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${ansibleCredential.token}`,
-          },
-          rejectUnauthorized: false, // NOSONAR - AAP connects insecurely by default
-        }
-
-        const towerReq = request(options, (response) => {
-          if (!response) return notFound(req, res)
-          res.writeHead(response.statusCode ?? 500, response.headers)
-          pipeline(response, res as unknown as NodeJS.WritableStream, (err) => {
-            if (err) {
-              logger.error(err)
+        // Resolve the tower host + token from the credential Secret using the
+        // caller's own token. A 401/403 from kube-apiserver means the caller
+        // is not authorized for this credential; never proxy in that case.
+        const secretPath =
+          process.env.CLUSTER_API_URL +
+          `/api/v1/namespaces/${encodeURIComponent(body.secretNamespace)}/secrets/${encodeURIComponent(body.secretName)}`
+        jsonRequest<AnsibleSecret>(secretPath, userToken, 0)
+          .then((secret) => {
+            const host = secret?.data?.host ? Buffer.from(secret.data.host, 'base64').toString('utf8') : ''
+            const token = secret?.data?.token ? Buffer.from(secret.data.token, 'base64').toString('utf8') : ''
+            if (!host || !token) {
+              return respondBadRequest(req, res)
             }
+
+            let towerUrl: URL
+            try {
+              towerUrl = new URL(body.ansiblePath, host)
+            } catch (err) {
+              return respondBadRequest(req, res)
+            }
+
+            // allow list of apis our ui calls
+            if (!ansiblePaths.includes(towerUrl.pathname)) {
+              return respondBadRequest(req, res)
+            }
+
+            const options: RequestOptions = {
+              protocol: towerUrl.protocol,
+              hostname: towerUrl.hostname,
+              port: towerUrl.port,
+              path: `${towerUrl.pathname}${towerUrl.search ? towerUrl.search : ''}`,
+              method: 'GET',
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+              rejectUnauthorized: false, // NOSONAR - AAP connects insecurely by default
+            }
+
+            const towerReq = request(options, (response) => {
+              if (!response) return notFound(req, res)
+              res.writeHead(response.statusCode ?? 500, response.headers)
+              pipeline(response, res as unknown as NodeJS.WritableStream, (err) => {
+                if (err) {
+                  logger.error(err)
+                }
+              })
+            })
+            towerReq.on('error', (e) => {
+              logger.error(e)
+              respond(res, JSON.stringify(e.message), constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
+            })
+            towerReq.end()
           })
-        })
-        towerReq.on('error', (e) => {
-          logger.error(e)
-          respond(res, JSON.stringify(e.message), constants.HTTP_STATUS_INTERNAL_SERVER_ERROR)
-        })
-        towerReq.end()
+          .catch(catchInternalServerError(res))
       })
     })
     .catch(catchInternalServerError(res))

--- a/backend/test/routes/ansibletower.test.ts
+++ b/backend/test/routes/ansibletower.test.ts
@@ -45,6 +45,41 @@ describe(`ansibletower Route`, function () {
     expect(res.statusCode).toEqual(400)
   })
 
+  it(`should preserve the query string for paginated requests`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
+    nock(TOWER_HOST).get(ansiblePaths[0]).query({ page: '2', page_size: '20' }).reply(200, response)
+    const res = await request('POST', '/ansibletower', {
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: `${ansiblePaths[0]}?page=2&page_size=20`,
+    })
+    expect(res.statusCode).toEqual(200)
+    expect(JSON.stringify(await parsePipedJsonBody(res))).toEqual(JSON.stringify(response))
+  })
+
+  it(`should reject an external absolute URL in ansiblePath`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
+    const res = await request('POST', '/ansibletower', {
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: `https://evil.example.com${ansiblePaths[0]}`,
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
+  it(`should reject a network-path reference in ansiblePath`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
+    const res = await request('POST', '/ansibletower', {
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: `//evil.example.com${ansiblePaths[0]}`,
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
   it(`should fail closed when caller cannot read the credential secret`, async function () {
     nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
     nock(process.env.CLUSTER_API_URL)

--- a/backend/test/routes/ansibletower.test.ts
+++ b/backend/test/routes/ansibletower.test.ts
@@ -5,25 +5,89 @@ import { ansiblePaths } from '../../src/routes/ansibletower'
 import nock from 'nock'
 
 const TOWER_HOST = 'https://ansible-tower.com'
+const SECRET_NS = 'app-team'
+const SECRET_NAME = 'tower-cred'
+
+function nockCredentialSecret(host: string) {
+  return nock(process.env.CLUSTER_API_URL)
+    .get(`/api/v1/namespaces/${SECRET_NS}/secrets/${SECRET_NAME}`)
+    .reply(200, {
+      kind: 'Secret',
+      apiVersion: 'v1',
+      metadata: { name: SECRET_NAME, namespace: SECRET_NS },
+      data: {
+        host: Buffer.from(host).toString('base64'),
+        token: Buffer.from('12345').toString('base64'),
+      },
+    })
+}
 
 describe(`ansibletower Route`, function () {
   it(`should list Ansible TowerJobs`, async function () {
     nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
     nock(TOWER_HOST).get(ansiblePaths[0]).reply(200, response)
     const res = await request('POST', '/ansibletower', {
-      towerHost: TOWER_HOST + ansiblePaths[0],
-      token: '12345',
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: ansiblePaths[0],
     })
     expect(res.statusCode).toEqual(200)
     expect(JSON.stringify(await parsePipedJsonBody(res))).toEqual(JSON.stringify(response))
   })
 
+  it(`should reject body-supplied tower hostname`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    const res = await request('POST', '/ansibletower', {
+      towerHost: TOWER_HOST + ansiblePaths[0],
+      token: '12345',
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
+  it(`should fail closed when caller cannot read the credential secret`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL)
+      .get(`/api/v1/namespaces/${SECRET_NS}/secrets/${SECRET_NAME}`)
+      .reply(403, { kind: 'Status', apiVersion: 'v1', status: 'Failure', reason: 'Forbidden', code: 403 })
+    const res = await request('POST', '/ansibletower', {
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: ansiblePaths[0],
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
+  it(`should reject body-supplied tower hostname`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    const res = await request('POST', '/ansibletower', {
+      towerHost: TOWER_HOST + ansiblePaths[0],
+      token: '12345',
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
+  it(`should fail closed when caller cannot read the credential secret`, async function () {
+    nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nock(process.env.CLUSTER_API_URL)
+      .get(`/api/v1/namespaces/${SECRET_NS}/secrets/${SECRET_NAME}`)
+      .reply(403, { kind: 'Status', apiVersion: 'v1', status: 'Failure', reason: 'Forbidden', code: 403 })
+    const res = await request('POST', '/ansibletower', {
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: ansiblePaths[0],
+    })
+    expect(res.statusCode).toEqual(400)
+  })
+
   it(`when bad things happen to Ansible TowerJobs 1`, async function () {
     nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
     nock(TOWER_HOST).get(ansiblePaths[0]).reply(200, response)
     const res = await request('POST', '/ansibletower', {
-      towerHost: TOWER_HOST + '/badPath',
-      token: '12345',
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: '/badPath',
     })
     expect(res.statusCode).toEqual(400)
     expect(JSON.stringify(await parsePipedJsonBody(res))).toEqual(JSON.stringify({}))
@@ -31,9 +95,12 @@ describe(`ansibletower Route`, function () {
 
   it(`when bad things happen to Ansible TowerJobs 2`, async function () {
     nock(process.env.CLUSTER_API_URL).get('/apis').reply(200)
+    nockCredentialSecret(TOWER_HOST)
     nock(TOWER_HOST).get(ansiblePaths[0]).reply(200, response)
     const res = await request('POST', '/ansibletower', {
-      token: '12345',
+      secretNamespace: SECRET_NS,
+      secretName: SECRET_NAME,
+      ansiblePath: '/badPath',
     })
     expect(JSON.stringify(await parsePipedJsonBody(res))).toEqual(JSON.stringify({}))
   })

--- a/frontend/src/lib/nock-util.ts
+++ b/frontend/src/lib/nock-util.ts
@@ -319,8 +319,9 @@ export function nockRBAC(resourceAttributes: ResourceAttributes, allowed = true)
 }
 
 interface AnsibleCredentialPostBody {
-  towerHost: string
-  token: string
+  secretNamespace: string
+  secretName: string
+  ansiblePath: string
 }
 
 interface GetGitBranchesArgoResponse {
@@ -336,7 +337,7 @@ interface GetGitPathsArgoResponse {
 }
 
 export function nockAnsibleTower(
-  data: AnsibleCredentialPostBody | unknown,
+  data: AnsibleCredentialPostBody,
   response: AnsibleTowerJobTemplateList,
   statusCode = 200
 ) {
@@ -350,7 +351,7 @@ export function nockAnsibleTower(
 }
 
 export function nockAnsibleTowerInventory(
-  data: AnsibleCredentialPostBody | unknown,
+  data: AnsibleCredentialPostBody,
   response: AnsibleTowerInventoryList,
   statusCode = 200
 ) {
@@ -365,7 +366,7 @@ export function nockAnsibleTowerInventory(
     })
 }
 
-export function nockAnsibleTowerError(data: AnsibleCredentialPostBody | unknown, error: string | object) {
+export function nockAnsibleTowerError(data: AnsibleCredentialPostBody, error: string | object) {
   return nocked(process.env.JEST_DEFAULT_HOST as string, {
     encodedQueryParams: true,
   })

--- a/frontend/src/resources/utils/resource-request.test.ts
+++ b/frontend/src/resources/utils/resource-request.test.ts
@@ -1,6 +1,20 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
+import { ClusterCurator, ClusterCuratorApiVersion, ClusterCuratorKind } from '../cluster-curator'
+import { Namespace, NamespaceApiVersion, NamespaceKind } from '../namespace'
 import {
+  ResourceError,
+  ResourceErrorCode,
+  createResource,
+  createResources,
+  deleteResources,
+  listAnsibleTowerJobs,
+  reconcileResources,
+  updateResources,
+} from './resource-request'
+import { StatusApiVersion, StatusKind } from '../status'
+import {
+  nockAnsibleTower,
   nockCreate,
   nockCreateError,
   nockDelete,
@@ -8,23 +22,9 @@ import {
   nockIgnoreApiPaths,
   nockReplace,
   nockReplaceError,
-  nockAnsibleTower,
 } from '../../lib/nock-util'
+
 import nock from 'nock'
-import { ClusterCurator, ClusterCuratorApiVersion, ClusterCuratorKind } from '../cluster-curator'
-import { Namespace, NamespaceApiVersion, NamespaceKind } from '../namespace'
-import {
-  createResource,
-  createResources,
-  deleteResources,
-  reconcileResources,
-  ResourceError,
-  ResourceErrorCode,
-  updateResources,
-  isAnsibleGatewayURL,
-  listAnsibleTowerJobs,
-} from './resource-request'
-import { StatusApiVersion, StatusKind } from '../status'
 
 export const clusterName = 'test-cluster'
 
@@ -78,17 +78,6 @@ describe('reconcileResources', () => {
   })
 })
 
-describe('isAnsibleGatewayURL', () => {
-  it('returns false for controller URL (name-controller-namespace)', () => {
-    const host = 'https://example-controller-aap.apps.lucas-sno.apps.ocp.rdu.eng.ansible.com'
-    expect(isAnsibleGatewayURL(host)).toBe(false)
-  })
-
-  it('returns true for gateway URL (name-namespace)', () => {
-    const host = 'https://example-aap.apps.lucas-sno.apps.ocp.rdu.eng.ansible.com'
-    expect(isAnsibleGatewayURL(host)).toBe(true)
-  })
-})
 describe('createResource', () => {
   nockIgnoreApiPaths()
   it('catches error creating resource', async () => {
@@ -160,8 +149,7 @@ describe('deleteResources', () => {
 describe('listAnsibleTowerJobs', () => {
   nockIgnoreApiPaths()
 
-  const ansibleHost = 'https://ansible-tower.alpha.internal'
-  const token = 'test-token-12345'
+  const secretRef = { namespace: 'test-ns', name: 'ansible-credential' }
 
   const mockJobTemplateResponse = {
     count: 2,
@@ -184,7 +172,11 @@ describe('listAnsibleTowerJobs', () => {
   it('ACM-30375: fallback to controller paths when gateway paths return 404', async () => {
     // Mock gateway paths returning 404 (AAP 2.4 doesn't have these paths)
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/controller/v2/job_templates/', token },
+      {
+        secretNamespace: secretRef.namespace,
+        secretName: secretRef.name,
+        ansiblePath: '/api/controller/v2/job_templates/',
+      },
       {
         kind: StatusKind,
         apiVersion: StatusApiVersion,
@@ -195,7 +187,11 @@ describe('listAnsibleTowerJobs', () => {
       404
     )
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/controller/v2/workflow_job_templates/', token },
+      {
+        secretNamespace: secretRef.namespace,
+        secretName: secretRef.name,
+        ansiblePath: '/api/controller/v2/workflow_job_templates/',
+      },
       {
         kind: StatusKind,
         apiVersion: StatusApiVersion,
@@ -208,15 +204,19 @@ describe('listAnsibleTowerJobs', () => {
 
     // Mock controller paths returning success (AAP 2.4 has these paths)
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/v2/job_templates/', token },
+      { secretNamespace: secretRef.namespace, secretName: secretRef.name, ansiblePath: '/api/v2/job_templates/' },
       { results: [mockJobTemplateResponse.results[0]] }
     )
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/v2/workflow_job_templates/', token },
+      {
+        secretNamespace: secretRef.namespace,
+        secretName: secretRef.name,
+        ansiblePath: '/api/v2/workflow_job_templates/',
+      },
       { results: [mockJobTemplateResponse.results[1]] }
     )
 
-    const result = await listAnsibleTowerJobs(ansibleHost, token).promise
+    const result = await listAnsibleTowerJobs(secretRef).promise
 
     expect(result.results).toHaveLength(2)
     expect(result.results[0].name).toBe('Test Job Template')
@@ -226,11 +226,19 @@ describe('listAnsibleTowerJobs', () => {
   it('returns jobs when gateway paths work (AAP 2.5+)', async () => {
     // Mock gateway paths returning success
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/controller/v2/job_templates/', token },
+      {
+        secretNamespace: secretRef.namespace,
+        secretName: secretRef.name,
+        ansiblePath: '/api/controller/v2/job_templates/',
+      },
       { results: [mockJobTemplateResponse.results[0]] }
     )
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/controller/v2/workflow_job_templates/', token },
+      {
+        secretNamespace: secretRef.namespace,
+        secretName: secretRef.name,
+        ansiblePath: '/api/controller/v2/workflow_job_templates/',
+      },
       { results: [mockJobTemplateResponse.results[1]] }
     )
 
@@ -238,7 +246,7 @@ describe('listAnsibleTowerJobs', () => {
     // If code regresses and calls these paths, they will return 500 errors causing test failure
     // Using .optionally() so test passes when paths aren't called (expected behavior)
     nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
-      .post('/ansibletower', (body: any) => body.towerHost === ansibleHost + '/api/v2/job_templates/')
+      .post('/ansibletower', (body: any) => body.ansiblePath === '/api/v2/job_templates/')
       .optionally()
       .reply(
         500,
@@ -257,7 +265,7 @@ describe('listAnsibleTowerJobs', () => {
       )
 
     nock(process.env.JEST_DEFAULT_HOST as string, { encodedQueryParams: true })
-      .post('/ansibletower', (body: any) => body.towerHost === ansibleHost + '/api/v2/workflow_job_templates/')
+      .post('/ansibletower', (body: any) => body.ansiblePath === '/api/v2/workflow_job_templates/')
       .optionally()
       .reply(
         500,
@@ -276,7 +284,7 @@ describe('listAnsibleTowerJobs', () => {
         }
       )
 
-    const result = await listAnsibleTowerJobs(ansibleHost, token).promise
+    const result = await listAnsibleTowerJobs(secretRef).promise
 
     expect(result.results).toHaveLength(2)
     expect(result.results[0].name).toBe('Test Job Template')
@@ -286,7 +294,11 @@ describe('listAnsibleTowerJobs', () => {
   it('re-throws non-404 errors (auth, network, etc.)', async () => {
     // Mock gateway paths returning 401 Unauthorized
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/controller/v2/job_templates/', token },
+      {
+        secretNamespace: secretRef.namespace,
+        secretName: secretRef.name,
+        ansiblePath: '/api/controller/v2/job_templates/',
+      },
       {
         kind: StatusKind,
         apiVersion: StatusApiVersion,
@@ -298,14 +310,18 @@ describe('listAnsibleTowerJobs', () => {
     )
 
     await expect(async () => {
-      await listAnsibleTowerJobs(ansibleHost, token).promise
+      await listAnsibleTowerJobs(secretRef).promise
     }).rejects.toThrow(ResourceError)
   })
 
   it('throws raw 404 error when all paths return 404 (wrong URL or misconfigured)', async () => {
     // Mock ALL paths returning 404 (wrong base URL, misconfigured Ansible Tower, etc.)
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/controller/v2/job_templates/', token },
+      {
+        secretNamespace: secretRef.namespace,
+        secretName: secretRef.name,
+        ansiblePath: '/api/controller/v2/job_templates/',
+      },
       {
         kind: StatusKind,
         apiVersion: StatusApiVersion,
@@ -316,7 +332,11 @@ describe('listAnsibleTowerJobs', () => {
       404
     )
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/controller/v2/workflow_job_templates/', token },
+      {
+        secretNamespace: secretRef.namespace,
+        secretName: secretRef.name,
+        ansiblePath: '/api/controller/v2/workflow_job_templates/',
+      },
       {
         kind: StatusKind,
         apiVersion: StatusApiVersion,
@@ -327,7 +347,7 @@ describe('listAnsibleTowerJobs', () => {
       404
     )
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/v2/job_templates/', token },
+      { secretNamespace: secretRef.namespace, secretName: secretRef.name, ansiblePath: '/api/v2/job_templates/' },
       {
         kind: StatusKind,
         apiVersion: StatusApiVersion,
@@ -338,7 +358,11 @@ describe('listAnsibleTowerJobs', () => {
       404
     )
     nockAnsibleTower(
-      { towerHost: ansibleHost + '/api/v2/workflow_job_templates/', token },
+      {
+        secretNamespace: secretRef.namespace,
+        secretName: secretRef.name,
+        ansiblePath: '/api/v2/workflow_job_templates/',
+      },
       {
         kind: StatusKind,
         apiVersion: StatusApiVersion,
@@ -349,7 +373,7 @@ describe('listAnsibleTowerJobs', () => {
       404
     )
 
-    const error = await listAnsibleTowerJobs(ansibleHost, token).promise.catch((e) => e)
+    const error = await listAnsibleTowerJobs(secretRef).promise.catch((e) => e)
 
     expect(error).toBeInstanceOf(ResourceError)
     expect(error.code).toBe(ResourceErrorCode.NotFound)

--- a/frontend/src/resources/utils/resource-request.ts
+++ b/frontend/src/resources/utils/resource-request.ts
@@ -487,11 +487,9 @@ export function listNamespacedResources<Resource extends IResource>(
   }
 }
 
-export function isAnsibleGatewayURL(ansibleHostUrl: string): boolean {
-  const firstLabel = ansibleHostUrl.split('.')[0] ?? ''
-
-  if (/^.+-controller-.+$/.test(firstLabel)) return false
-  return true
+interface AnsibleSecretRef {
+  namespace: string
+  name: string
 }
 
 interface AnsiblePaginatedResponse<T> {
@@ -505,8 +503,8 @@ interface AnsiblePaginatedResponse<T> {
  */
 function fetchAnsibleResource<T>(
   backendUrlPath: string,
-  ansibleResourceUrl: string,
-  token: string,
+  secretRef: AnsibleSecretRef,
+  ansiblePath: string,
   signal: AbortSignal
 ) {
   return fetchRetry<AnsiblePaginatedResponse<T>>({
@@ -514,8 +512,9 @@ function fetchAnsibleResource<T>(
     url: backendUrlPath,
     signal,
     data: {
-      towerHost: ansibleResourceUrl,
-      token: token,
+      secretNamespace: secretRef.namespace,
+      secretName: secretRef.name,
+      ansiblePath,
     },
     retries: process.env.NODE_ENV === 'production' ? 2 : 0,
     disableRedirectUnauthorizedLogin: true,
@@ -530,8 +529,7 @@ function fetchAnsibleResource<T>(
  */
 async function getAnsibleResourcesWithPagination<T>(
   backendURLPath: string,
-  ansibleHostUrl: string,
-  token: string,
+  secretRef: AnsibleSecretRef,
   abortController: AbortController,
   paths: string[]
 ): Promise<T[]> {
@@ -540,12 +538,12 @@ async function getAnsibleResourcesWithPagination<T>(
   let anyPathSucceeded = false
 
   for (const path of paths) {
-    let resourceUrl: string = ansibleHostUrl + path
+    let ansiblePath = path
     let isFirstRequest = true
 
-    while (resourceUrl) {
+    while (ansiblePath) {
       try {
-        const result = await fetchAnsibleResource<T>(backendURLPath, resourceUrl, token, abortController.signal)
+        const result = await fetchAnsibleResource<T>(backendURLPath, secretRef, ansiblePath, abortController.signal)
 
         if (result.data.results) {
           resources.push(...result.data.results)
@@ -555,14 +553,14 @@ async function getAnsibleResourcesWithPagination<T>(
         anyPathSucceeded = true
         isFirstRequest = false
         const { next } = result.data
-        resourceUrl = next ? ansibleHostUrl + next : ''
+        ansiblePath = next ?? ''
       } catch (error) {
         if (error instanceof ResourceError && error.code === ResourceErrorCode.NotFound) {
           // Only treat 404 as "path doesn't exist" on the first request
           // Later-page 404s are real errors (path exists but page is missing)
           if (isFirstRequest) {
             first404Error = error
-            resourceUrl = ''
+            ansiblePath = ''
           } else {
             // 404 on pagination - this is a real error, re-throw
             throw error
@@ -601,8 +599,7 @@ async function withAnsiblePathFallback<T>(primaryFn: () => Promise<T>, fallbackF
 
 async function getAnsibleTemplates(
   backendURLPath: string,
-  ansibleHostUrl: string,
-  token: string,
+  secretRef: AnsibleSecretRef,
   abortController: AbortController
 ) {
   // Try gateway paths first (AAP 2.5+), then fall back to controller paths (AAP 2.4 and earlier)
@@ -610,16 +607,14 @@ async function getAnsibleTemplates(
     () =>
       getAnsibleResourcesWithPagination<AnsibleTowerJobTemplate>(
         backendURLPath,
-        ansibleHostUrl,
-        token,
+        secretRef,
         abortController,
         ansibleGatewayPaths
       ),
     () =>
       getAnsibleResourcesWithPagination<AnsibleTowerJobTemplate>(
         backendURLPath,
-        ansibleHostUrl,
-        token,
+        secretRef,
         abortController,
         ansibleControllerPaths
       )
@@ -633,14 +628,11 @@ async function getAnsibleTemplates(
 
 // TODO: validation for URL input
 // Code assumes protocol is present & ansiblehosturl ends without a /
-export function listAnsibleTowerJobs(
-  ansibleHostUrl: string,
-  token: string
-): IRequestResult<AnsibleTowerJobTemplateList> {
+export function listAnsibleTowerJobs(secretRef: AnsibleSecretRef): IRequestResult<AnsibleTowerJobTemplateList> {
   const backendURLPath = getBackendUrl() + '/ansibletower'
   const abortController = new AbortController()
   return {
-    promise: getAnsibleTemplates(backendURLPath, ansibleHostUrl, token, abortController).then((item) => {
+    promise: getAnsibleTemplates(backendURLPath, secretRef, abortController).then((item) => {
       return item as AnsibleTowerJobTemplateList
     }),
     abort: () => abortController.abort(),
@@ -649,18 +641,17 @@ export function listAnsibleTowerJobs(
 
 async function getAnsibleInventories(
   backendURLPath: string,
-  ansibleHostUrl: string,
-  token: string,
+  secretRef: AnsibleSecretRef,
   abortController: AbortController
 ) {
   // Try gateway path first (AAP 2.5+), then fall back to controller path (AAP 2.4 and earlier)
   const ansibleInventories = await withAnsiblePathFallback(
     () =>
-      getAnsibleResourcesWithPagination<AnsibleTowerInventory>(backendURLPath, ansibleHostUrl, token, abortController, [
+      getAnsibleResourcesWithPagination<AnsibleTowerInventory>(backendURLPath, secretRef, abortController, [
         '/api/controller/v2/inventories/',
       ]),
     () =>
-      getAnsibleResourcesWithPagination<AnsibleTowerInventory>(backendURLPath, ansibleHostUrl, token, abortController, [
+      getAnsibleResourcesWithPagination<AnsibleTowerInventory>(backendURLPath, secretRef, abortController, [
         '/api/v2/inventories/',
       ])
   )
@@ -671,14 +662,11 @@ async function getAnsibleInventories(
   }
 }
 
-export function listAnsibleTowerInventories(
-  ansibleHostUrl: string,
-  token: string
-): IRequestResult<AnsibleTowerInventoryList> {
+export function listAnsibleTowerInventories(secretRef: AnsibleSecretRef): IRequestResult<AnsibleTowerInventoryList> {
   const backendURLPath = getBackendUrl() + '/ansibletower'
   const abortController = new AbortController()
   return {
-    promise: getAnsibleInventories(backendURLPath, ansibleHostUrl, token, abortController).then((item) => {
+    promise: getAnsibleInventories(backendURLPath, secretRef, abortController).then((item) => {
       return item as AnsibleTowerInventoryList
     }),
     abort: () => abortController.abort(),

--- a/frontend/src/routes/Governance/governance.sharedMocks.tsx
+++ b/frontend/src/routes/Governance/governance.sharedMocks.tsx
@@ -737,12 +737,14 @@ const secret: Secret = {
 }
 
 export const mockAnsibleCredential = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/controller/v2/job_templates/',
-  token: 'abcd',
+  secretNamespace: 'test',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/controller/v2/job_templates/',
 }
 export const mockAnsibleCredentialWorkflow = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/controller/v2/workflow_job_templates/',
-  token: 'abcd',
+  secretNamespace: 'test',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/controller/v2/workflow_job_templates/',
 }
 
 export const mockTemplateWorkflowList: AnsibleTowerJobTemplateList = {

--- a/frontend/src/routes/Governance/policies/CreatePolicyAutomation.tsx
+++ b/frontend/src/routes/Governance/policies/CreatePolicyAutomation.tsx
@@ -104,10 +104,9 @@ export function CreatePolicyAutomation() {
       }}
       onSubmit={(data) => handlePolicyAutomationSubmit(submitForm, data, secrets, navigate, destination, toast, t)}
       getAnsibleJobsCallback={async (credential: any) => {
-        const host = Buffer.from(credential.data.host || '', 'base64').toString('ascii')
-        const token = Buffer.from(credential.data.token || '', 'base64').toString('ascii')
+        const secretRef = { namespace: credential.metadata.namespace, name: credential.metadata.name }
 
-        return listAnsibleTowerJobs(host, token).promise.then((response) => {
+        return listAnsibleTowerJobs(secretRef).promise.then((response) => {
           let templateList: { name: string; description?: string; id: string }[] = []
           if (response?.results) {
             templateList = response.results!.map((job) => ({

--- a/frontend/src/routes/Governance/policies/EditPolicyAutomation.tsx
+++ b/frontend/src/routes/Governance/policies/EditPolicyAutomation.tsx
@@ -122,11 +122,10 @@ export function EditPolicyAutomation() {
         )
       }
       getAnsibleJobsCallback={async (credential: any) => {
-        const host = Buffer.from(credential.data.host || '', 'base64').toString('ascii')
-        const token = Buffer.from(credential.data.token || '', 'base64').toString('ascii')
+        const secretRef = { namespace: credential.metadata.namespace, name: credential.metadata.name }
 
         return new Promise((resolve, reject) => {
-          const ansibleJobs = listAnsibleTowerJobs(host, token)
+          const ansibleJobs = listAnsibleTowerJobs(secretRef)
           ansibleJobs.promise
             .then((response) => {
               if (response) {

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.test.tsx
@@ -116,17 +116,20 @@ const mockClusterCurator: ClusterCurator = {
 }
 
 const mockAnsibleCredential = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/controller/v2/job_templates/',
-  token: 'abcd',
+  secretNamespace: 'namespace-1',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/controller/v2/job_templates/',
 }
 const mockAnsibleCredentialWorkflow = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/controller/v2/workflow_job_templates/',
-  token: 'abcd',
+  secretNamespace: 'namespace-1',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/controller/v2/workflow_job_templates/',
 }
 
 const mockAnsibleCredentialInventory = {
-  towerHost: 'https://ansible-tower-web-svc-tower.com/api/controller/v2/inventories/',
-  token: 'abcd',
+  secretNamespace: 'namespace-1',
+  secretName: 'ansible-test-secret',
+  ansiblePath: '/api/controller/v2/inventories/',
 }
 
 const mockTemplateList: AnsibleTowerJobTemplateList = {

--- a/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
+++ b/frontend/src/routes/Infrastructure/Automations/AnsibleAutomationsForm.tsx
@@ -199,49 +199,46 @@ export function AnsibleAutomationsForm(props: {
 
     if (ansibleSelection) {
       const selectedCred = ansibleCredentials.find((credential) => credential.metadata.name === ansibleSelection)
+      const secretRef = { namespace: selectedCred?.metadata?.namespace!, name: selectedCred?.metadata?.name! }
       const inventoryList: { name: string; description?: string; id: string }[] | undefined = []
       const jobList: { name: string; description?: string; id: string }[] = []
       const workflowList: { name: string; description?: string; id: string }[] = []
       Promise.all([
-        listAnsibleTowerJobs(selectedCred?.stringData?.host!, selectedCred?.stringData?.token!).promise.then(
-          (response) => {
-            if (response) {
-              response.results.forEach((template) => {
-                if (template.type === 'job_template' && template.name) {
-                  jobList.push({
-                    name: template.name,
-                    description: template.description,
-                    id: template.id,
-                  })
-                } else if (template.type === 'workflow_job_template' && template.name) {
-                  workflowList.push({
-                    name: template.name,
-                    description: template.description,
-                    id: template.id,
-                  })
-                }
-              })
-              setAnsibleTowerJobTemplateList(jobList)
-              setAnsibleTowerWorkflowTemplateList(workflowList)
-            }
+        listAnsibleTowerJobs(secretRef).promise.then((response) => {
+          if (response) {
+            response.results.forEach((template) => {
+              if (template.type === 'job_template' && template.name) {
+                jobList.push({
+                  name: template.name,
+                  description: template.description,
+                  id: template.id,
+                })
+              } else if (template.type === 'workflow_job_template' && template.name) {
+                workflowList.push({
+                  name: template.name,
+                  description: template.description,
+                  id: template.id,
+                })
+              }
+            })
+            setAnsibleTowerJobTemplateList(jobList)
+            setAnsibleTowerWorkflowTemplateList(workflowList)
           }
-        ),
-        listAnsibleTowerInventories(selectedCred?.stringData?.host!, selectedCred?.stringData?.token!).promise.then(
-          (response) => {
-            if (response) {
-              response.results.forEach((inventory) => {
-                if (inventory.name) {
-                  inventoryList.push({
-                    name: inventory.name,
-                    description: inventory?.description,
-                    id: inventory.id,
-                  })
-                }
-              })
-              setAnsibleTowerInventoryList(inventoryList)
-            }
+        }),
+        listAnsibleTowerInventories(secretRef).promise.then((response) => {
+          if (response) {
+            response.results.forEach((inventory) => {
+              if (inventory.name) {
+                inventoryList.push({
+                  name: inventory.name,
+                  description: inventory?.description,
+                  id: inventory.id,
+                })
+              }
+            })
+            setAnsibleTowerInventoryList(inventoryList)
           }
-        ),
+        }),
       ]).catch((err) => {
         setAnsibleTowerAuthError(
           err.code === ResourceErrorCode.InternalServerError && err.reason


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Authenticated SSRF via /ansibletower (arbitrary host, full response disclosure)

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-39085
https://redhat.atlassian.net/browse/ACM-39087

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression