### PR TITLE
ACM-39821: Bump form-data to 4.0.6 to fix CVE-2026-12143 [rhacm-2.14]

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3527,17 +3527,17 @@
       "dev": true
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -3980,10 +3980,11 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18445,16 +18445,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -19355,9 +19355,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -26315,19 +26316,21 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
       "dependencies": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
         "node": ">= 0.6"


### PR DESCRIPTION
> **ACM-39821 update form-data to 4.0.6**
> 
> https://redhat.atlassian.net/browse/ACM-39821
> 
> Bumps `form-data` from vulnerable versions to **4.0.6** to address **CVE-2026-12143** (CRLF injection via unescaped multipart field names and filenames — [GHSA-hmw2-7cc7-3qxx](https://github.com/form-data/form-data/security/advisories/GHSA-hmw2-7cc7-3qxx)).
> 
> `form-data` is a transitive dependency present in both `backend/` and `frontend/` lock files. The fix was applied by running `npm update form-data` in each directory, bumping only the lock files (`package-lock.json`). No `package.json` changes are needed since `form-data` is not a direct dependency.
> 
> **Updated packages:**
> 
> | Directory | Package | Before | After |
> |-----------|---------|--------|-------|
> | `backend/` | `form-data` | 4.0.4 | 4.0.6 |
> | `backend/` | `hasown` | 2.0.2 | 2.0.4 |
> | `frontend/` | `form-data` | 4.0.5 | 4.0.6 |
> | `frontend/` | `hasown` | 2.0.2 | 2.0.4 |
> | `frontend/` | `mime-db` | 1.51.0 | 1.52.0 |
> | `frontend/` | `mime-types` | 2.1.34 | 2.1.35 |
> 
> Same pattern as [PR #6661](https://github.com/stolostron/console/pull/6661) (release-2.17), [PR #6704](https://github.com/stolostron/console/pull/6704) (release-2.16), and [PR #6726](https://github.com/stolostron/console/pull/6726) (release-2.15).

---

### Commands (in order of execution)

```bash
git checkout ACM-39821-214
git fetch upstream
git pull --ff-only
cd backend && npm update form-data
cd ../frontend && npm update form-data
cd ..
git add backend/package-lock.json frontend/package-lock.json
git commit -s -m "ACM-39821 update form-data to 4.0.6" \
  -m "Bumps form-data from 4.0.4/4.0.5 to 4.0.6 to address CVE-2026-12143 (CRLF injection via unescaped multipart field names and filenames)." \
  -m "Related: ACM-39821"
git push -u origin ACM-39821-214
```

This PR also fixes:
ACM-39819-CVE-2026-12143-[mce-2.9]