### PR TITLE
ACM-41784: Fix install-aap.sh to actually disable Automation Hub

### DIFF
--- a/scripts/aap-automation/install-aap.sh
+++ b/scripts/aap-automation/install-aap.sh
@@ -332,6 +332,14 @@ spec:
         PLATFORM_SPEC="$PLATFORM_SPEC
   hub:
     replicas: 1"
+    else
+        # The operator's ansibleautomationplatform role enables Hub whenever the
+        # hub key is absent from spec at all (see determine_if_enabled.yml) -
+        # omitting the key does NOT disable it. hub.disabled: true is the only
+        # way to keep Hub (and its ReadWriteMany PVC) from being provisioned.
+        PLATFORM_SPEC="$PLATFORM_SPEC
+  hub:
+    disabled: true"
     fi
 
     if [ "$ENABLE_EDA" = "true" ]; then


### PR DESCRIPTION
## Summary
- `ENABLE_HUB=false` (the script default) omitted the `hub:` key from the `AnsibleAutomationPlatform` spec, but the current AAP operator bundle (`aap-operator.v2.7.0-0.1785438991`) enables Hub whenever that key is absent entirely — omission is not disablement.
- This silently deployed Hub on every install regardless of intent. Hub's file-storage PVC requests `ReadWriteMany`, which is incompatible with EBS-backed storage classes (`gp3-csi`/`gp2-csi`), leaving the PVC permanently `Pending` and 5-6 Hub pods stuck `Pending`/`Init` indefinitely.
- Fix: emit `hub: {disabled: true}` instead of omitting the key when `ENABLE_HUB != "true"` — the only mechanism the operator's own Ansible role (`common/tasks/determine_if_enabled.yml`) actually honors as "do not provision Hub."

## Test plan
- [x] Verified root cause by reading the operator's Ansible role source directly from the running operator pod
- [x] Reproduced the stuck-PVC/stuck-pods failure on a live cluster prior to the fix
- [x] Applied the fix and ran a full fresh install end-to-end: no `AutomationHub` CR, no Hub pods, no Hub PVC created; Gateway/Controller/EDA all healthy
- [x] Confirmed the ACM shared credential and Red Hat subscription manifest steps both still complete successfully in the same run

Jira: https://redhat.atlassian.net/browse/ACM-41784

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Platform deployments now explicitly disable Hub when Hub is not enabled, ensuring the generated configuration accurately reflects the selected settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->