### PR TITLE
ACM-39253 fix(clusters): differentiate automation secrets by cluster name

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
@@ -132,7 +132,7 @@ const mockClusterCuratorInstall: ClusterCurator = {
   kind: ClusterCuratorKind,
   metadata: {
     name: clusterName,
-    namespace: null as unknown as string,
+    namespace: clusterName,
     labels: {
       'open-cluster-management': 'curator',
     },
@@ -183,7 +183,7 @@ const mockProviderConnectionAnsibleCopied: Secret = {
   type: 'Opaque',
   metadata: {
     name: 'toweraccess-install',
-    namespace: null as unknown as string,
+    namespace: clusterName,
     labels: {
       'cluster.open-cluster-management.io/type': 'ans',
       'cluster.open-cluster-management.io/copiedFromNamespace': 'test-ii',
@@ -203,7 +203,7 @@ const mockProviderConnectionAnsibleCopiedUpgrade: Secret = {
   type: 'Opaque',
   metadata: {
     name: 'toweraccess-upgrade',
-    namespace: null as unknown as string,
+    namespace: clusterName,
     labels: {
       'cluster.open-cluster-management.io/type': 'ans',
       'cluster.open-cluster-management.io/copiedFromNamespace': 'test-ii',
@@ -1577,6 +1577,211 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
     await waitForText('Creating cluster ...')
 
     // make sure creating
+    await waitForNocks(createNocks)
+  })
+
+  // ACM-39253: a second Hosted Control Plane cluster created in the same namespace must not
+  // collide on the automation (toweraccess) Secret, so the secret name and the ClusterCurator
+  // towerAuthSecret reference are differentiated by cluster name.
+  const upgradeOnlyCurator: ClusterCurator = {
+    apiVersion: ClusterCuratorApiVersion,
+    kind: ClusterCuratorKind,
+    metadata: {
+      name: 'kubevirt-automation',
+      namespace: 'test-ii',
+      labels: {
+        'open-cluster-management': 'curator',
+      },
+    },
+    spec: {
+      upgrade: {
+        posthook: [
+          {
+            name: 'test-posthook-upgrade',
+            extra_vars: {},
+          },
+        ],
+        towerAuthSecret: 'ansible-connection',
+      },
+    },
+  }
+
+  const AutomationComponent = () => {
+    return (
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(configMapsState, [
+            {
+              kind: 'ConfigMap',
+              apiVersion: 'v1',
+              metadata: {
+                name: 'supported-versions',
+                namespace: 'hypershift',
+              },
+              data: {
+                'supported-versions': '{"versions":["4.15","4.14","4.13"]}',
+              },
+            },
+          ])
+          snapshot.set(namespacesState, [
+            {
+              apiVersion: NamespaceApiVersion,
+              kind: NamespaceKind,
+              metadata: { name: 'clusters' },
+            },
+          ])
+          snapshot.set(managedClustersState, [])
+          snapshot.set(managedClusterSetsState, [])
+          snapshot.set(managedClusterInfosState, [
+            {
+              apiVersion: ManagedClusterInfoApiVersion,
+              kind: ManagedClusterInfoKind,
+              metadata: { name: 'local-cluster', namespace: 'local-cluster' },
+              status: {
+                consoleURL: 'https://testCluster.com',
+                conditions: [
+                  {
+                    type: 'ManagedClusterConditionAvailable',
+                    reason: 'ManagedClusterConditionAvailable',
+                    status: 'True',
+                  },
+                  { type: 'ManagedClusterJoined', reason: 'ManagedClusterJoined', status: 'True' },
+                  { type: 'HubAcceptedManagedCluster', reason: 'HubAcceptedManagedCluster', status: 'True' },
+                ],
+                version: '1.17',
+                distributionInfo: {
+                  type: 'ocp',
+                  ocp: {
+                    version: '1.2.3',
+                    availableUpdates: [],
+                    desiredVersion: '1.2.3',
+                    upgradeFailed: false,
+                  },
+                },
+              },
+            },
+          ])
+          snapshot.set(secretsState, [mockKubevirtSecret as Secret, providerConnectionAnsible as Secret])
+          snapshot.set(clusterCuratorsState, [upgradeOnlyCurator])
+          snapshot.set(subscriptionOperatorsState, [subscriptionOperator])
+          snapshot.set(settingsState, { ansibleIntegration: 'enabled' })
+        }}
+      >
+        <MemoryRouter initialEntries={[`${NavigationPath.createCluster}?${CLUSTER_INFRA_TYPE_PARAM}=kubevirt`]}>
+          <Routes>
+            <Route path={NavigationPath.createCluster} element={<CreateClusterPage />} />
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+  }
+
+  test('differentiates the automation toweraccess secret by cluster name for a shared namespace (ACM-39253)', async () => {
+    window.scrollBy = () => {}
+    const initialNocks = [
+      nockList(clusterImageSetKubervirt as IResource, [clusterImageSetKubervirt] as IResource[]),
+      nockList(storageClass as IResource, [storageClass] as IResource[]),
+    ]
+    render(<AutomationComponent />)
+
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    await waitForNocks(initialNocks)
+
+    await waitForText('Cluster details', true)
+
+    // step 1 -- cluster details
+    await typeByTestId('clusterName', clusterName)
+    await clickByPlaceholderText('Select or enter a release image')
+    await clickByRole('option', { name: /OpenShift 4\.15\.36/i })
+
+    const inputElement = screen.getByTestId('emanspace')
+    expect(inputElement).toHaveValue('clusters')
+
+    // step 2 -- node pools
+    await clickByText('Next')
+    const nodePoolNameInput = screen.getByTestId('nodePoolName')
+    fireEvent.change(nodePoolNameInput, { target: { value: 'nodepool' } })
+
+    // storage mappings
+    await clickByText('Next')
+    await clickByText('Add storage class mapping')
+    await typeByTestId('infraStorageClassName', 'storage-class1')
+    await typeByTestId('guestStorageClassName', 'guest-storage1')
+    await typeByTestId('storageClassGroup', 'group1')
+    await clickByText('Add volume snapshot class mapping')
+    await typeByTestId('infraVolumeSnapshotClassName', 'snapshot-class1')
+    await typeByTestId('guestVolumeSnapshotClassName', 'guest-snap1')
+    await typeByTestId('volumeSnapshotGroup', 'group1')
+    await clickByText('Next')
+
+    // step -- automation: select the template so the toweraccess secret is copied
+    await waitForText('Automation template')
+    await waitForNotText('Install the operator')
+    await clickByPlaceholderText('Select an automation template')
+    await clickByText('kubevirt-automation')
+    await clickByText('Next')
+
+    const expectedAnsibleSecret: Secret = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      type: 'Opaque',
+      metadata: {
+        name: 'toweraccess-upgrade-test',
+        namespace: 'clusters',
+        labels: {
+          'cluster.open-cluster-management.io/type': 'ans',
+          'cluster.open-cluster-management.io/copiedFromNamespace': 'test-ii',
+          'cluster.open-cluster-management.io/copiedFromSecretName': 'ansible-connection',
+          'cluster.open-cluster-management.io/backup': 'cluster',
+        },
+      },
+      stringData: {
+        host: 'test',
+        token: 'test',
+      },
+    }
+    const expectedCurator: ClusterCurator = {
+      apiVersion: ClusterCuratorApiVersion,
+      kind: ClusterCuratorKind,
+      metadata: {
+        name: 'test',
+        namespace: 'clusters',
+        labels: {
+          'open-cluster-management': 'curator',
+        },
+      },
+      spec: {
+        upgrade: {
+          posthook: [
+            {
+              name: 'test-posthook-upgrade',
+              extra_vars: {},
+            },
+          ],
+          towerAuthSecret: 'toweraccess-upgrade-test',
+        },
+      },
+    }
+
+    const createNocks = [
+      nockCreate(mockProject, mockProjectResponse),
+      nockCreate(mockClusterProjectKubevirt, mockClusterProjectKubevirtResponse),
+      nockCreate(mockNodePools),
+      nockCreate(managedCluster),
+      nockCreate(mockHostedClusterKubervirt),
+      nockCreate(mockKlusterletAddonConfigKubevirt),
+      nockCreate(mockKubeConfigSecretKubevirt),
+      nockCreate(mockPullSecretKubevirt),
+      nockCreate(mockSSHKeySecret),
+      nockCreate(expectedCurator),
+      nockCreate(expectedAnsibleSecret),
+    ]
+
+    await clickByText('Create')
+
+    await waitForText('Creating cluster ...')
+
     await waitForNocks(createNocks)
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
@@ -28,8 +28,10 @@ import {
 import {
   append,
   arrayItemHasKey,
+  differentiateCuratorSecrets,
   getName,
   getNamespace,
+  secretName,
   setAvailableConnections,
 } from './controlData/ControlDataHelpers'
 import aiTemplate from './templates/assisted-installer/ai-template.hbs'
@@ -345,6 +347,12 @@ export default function CreateCluster(props: { infrastructureType: ClusterInfras
   Handlebars.registerHelper('append', append)
   Handlebars.registerHelper('getName', getName)
   Handlebars.registerHelper('getNamespace', getNamespace)
+  Handlebars.registerHelper('secretName', (curation, options) =>
+    secretName(curation, getName(options), getNamespace(options))
+  )
+  Handlebars.registerHelper('curatorSpec', (spec, options) =>
+    differentiateCuratorSecrets(spec, getName(options), getNamespace(options))
+  )
   Handlebars.registerHelper('escapeYAML', (value) => jsyaml.dump(Array.isArray(value) ? value[0] : value))
 
   const { canJoinClusterSets } = useCanJoinClusterSets()

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -657,6 +657,28 @@ export const proxyControlData = (t) => {
   ]
 }
 
+// ACM-39253: automation Secrets are created in the cluster's namespace. Hosted Control Plane
+// clusters (e.g. OpenShift Virtualization) share a namespace, so the Secret name is differentiated
+// by cluster name to avoid collisions. Hive clusters use a namespace per cluster (namespace ===
+// name) and keep the undifferentiated name expected by the Update/Remove automation actions.
+export const secretName = (curation, name, namespace) =>
+  name && namespace && name !== namespace ? `toweraccess-${curation}-${name}` : `toweraccess-${curation}`
+
+// Render-time rewrite of the ClusterCurator spec YAML so each towerAuthSecret matches the current,
+// live cluster name (ACM-39253). Derived from the same name/namespace as the Secret name so the
+// reference and the Secret can never drift, even as the cluster name changes in the editor.
+export const differentiateCuratorSecrets = (specYaml, name, namespace) => {
+  if (!specYaml) return specYaml
+  const parsed = jsYaml.load(specYaml)
+  const curations = ['install', 'upgrade', 'scale', 'destroy']
+  curations.forEach((curation) => {
+    if (parsed?.spec?.[curation]?.towerAuthSecret) {
+      parsed.spec[curation].towerAuthSecret = secretName(curation, name, namespace)
+    }
+  })
+  return jsYaml.dump(parsed)
+}
+
 export const onChangeAutomationTemplate = (control, controlData, isAI) => {
   const clusterCuratorSpec = getControlByID(controlData, 'clusterCuratorSpec')
   const reconcilePause = getControlByID(controlData, 'reconcilePause')
@@ -674,23 +696,21 @@ export const onChangeAutomationTemplate = (control, controlData, isAI) => {
     curations.forEach((curation) => {
       if (clusterCurator?.spec?.[curation]?.towerAuthSecret) {
         // Create copies of each Ansible secret
-        const secretName = `toweraccess-${curation}`
-        const secretControl = getControlByID(controlData, secretName)
+        const secretControl = getControlByID(controlData, `toweraccess-${curation}`)
         const matchingSecret = control.availableSecrets.find(
           (s) =>
             s.metadata.name === clusterCurator.spec[curation].towerAuthSecret &&
             s.metadata.namespace === clusterCuratorTemplate.metadata.namespace
         )
         secretControl.active = _.cloneDeep(matchingSecret)
-        clusterCurator.spec[curation].towerAuthSecret = secretName
+        clusterCurator.spec[curation].towerAuthSecret = `toweraccess-${curation}`
       }
     })
     clusterCuratorSpec.active = jsYaml.dump({ spec: clusterCurator.spec })
   } else {
     // Clear Ansible secrets
     curations.forEach((curation) => {
-      const secretName = `toweraccess-${curation}`
-      const secretControl = getControlByID(controlData, secretName)
+      const secretControl = getControlByID(controlData, `toweraccess-${curation}`)
       secretControl.active = ''
     })
     clusterCuratorSpec.active = ''
@@ -803,7 +823,8 @@ export const architectureData = (t) => {
 export const getName = ({ data }) =>
   data.root.ai?.name ?? data.root.hypershift?.name ?? data.root.clusterName ?? data.root.name
 
-export const getNamespace = ({ data }) => data.root.ai?.name ?? data.root.hypershift?.name ?? data.root.namespace
+export const getNamespace = ({ data }) =>
+  data.root.ai?.name ?? data.root.hypershift?.name ?? data.root.namespace ?? data.root.clusterName ?? data.root.name
 
 const versionRegex = /([\d]{1,5})\.([\d]{1,5})\.([\d]{1,5})/
 function versionGreater(version, x, y) {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.js
@@ -668,7 +668,9 @@ export const secretName = (curation, name, namespace) =>
 // live cluster name (ACM-39253). Derived from the same name/namespace as the Secret name so the
 // reference and the Secret can never drift, even as the cluster name changes in the editor.
 export const differentiateCuratorSecrets = (specYaml, name, namespace) => {
-  if (!specYaml) return specYaml
+  if (!specYaml) {
+    return specYaml
+  }
   const parsed = jsYaml.load(specYaml)
   const curations = ['install', 'upgrade', 'scale', 'destroy']
   curations.forEach((curation) => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataHelpers.test.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 Red Hat, Inc.
 // Copyright Contributors to the Open Cluster Management project
 'use strict'
-import { reverseMultitext } from './ControlDataHelpers'
+import { differentiateCuratorSecrets, reverseMultitext, secretName } from './ControlDataHelpers'
 
 const controlTemplate = {
   tooltip: 'Add the ingress to be created',
@@ -146,5 +146,36 @@ describe('ControlDataHelper', () => {
     expect(control.controlData.length).toEqual(1)
     expect(control.active.multitextEntries[0]).toEqual('')
     expect(control.controlData[0].active).toEqual('')
+  })
+})
+
+describe('automation secret naming (ACM-39253)', () => {
+  it('differentiates by cluster name only when the namespace differs from the name', () => {
+    expect(secretName('install', 'mycluster', 'clusters')).toEqual('toweraccess-install-mycluster')
+    expect(secretName('upgrade', 'mycluster', 'mycluster')).toEqual('toweraccess-upgrade')
+    expect(secretName('scale', 'mycluster', undefined)).toEqual('toweraccess-scale')
+    expect(secretName('destroy', 'mycluster', '')).toEqual('toweraccess-destroy')
+  })
+
+  it('rewrites each ClusterCurator towerAuthSecret to the differentiated Secret name', () => {
+    const specYaml =
+      'spec:\n  install:\n    towerAuthSecret: toweraccess-install\n  upgrade:\n    towerAuthSecret: toweraccess-upgrade\n'
+    const result = differentiateCuratorSecrets(specYaml, 'mycluster', 'clusters')
+    expect(result).toContain('towerAuthSecret: toweraccess-install-mycluster')
+    expect(result).toContain('towerAuthSecret: toweraccess-upgrade-mycluster')
+  })
+
+  it('recomputes from the current cluster name without drift or double-append', () => {
+    const staleYaml = 'spec:\n  install:\n    towerAuthSecret: toweraccess-install-oldname\n'
+    const renamed = differentiateCuratorSecrets(staleYaml, 'newname', 'clusters')
+    expect(renamed).toContain('towerAuthSecret: toweraccess-install-newname')
+    expect(renamed).not.toContain('oldname')
+    const cleared = differentiateCuratorSecrets(staleYaml, 'oldname', '')
+    expect(cleared).toContain('toweraccess-install\n')
+    expect(cleared).not.toContain('oldname')
+  })
+
+  it('returns an empty spec unchanged when no automation template is selected', () => {
+    expect(differentiateCuratorSecrets('', 'mycluster', 'clusters')).toEqual('')
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/cluster-curator.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/cluster-curator.hbs
@@ -5,7 +5,7 @@ kind: ClusterCurator
 metadata:
   name: {{{getName}}}
   namespace: {{{getNamespace}}}
-{{{clusterCuratorSpec}}}
+{{{curatorSpec clusterCuratorSpec}}}
 {{/if}}
 
 {{#each supportedCurations}}
@@ -16,7 +16,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{{append "toweraccess-" ..}}}
+  name: {{{secretName ..}}}
   namespace: {{{getNamespace}}}
   labels:
     cluster.open-cluster-management.io/type: ans


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**
Creating a second OpenShift Virtualization cluster with automation fails

**Ticket Link:**
https://redhat.atlassian.net/browse/ACM-39253

**Type of Change:**
- [x] 🐞 Bug Fix

---

## Root cause

Hosted Control Plane clusters (e.g. OpenShift Virtualization / KubeVirt) are all created in a shared **Hosted cluster namespace** (default `clusters`). During cluster creation the console copies the Ansible automation Secrets named `toweraccess-<curation>` (e.g. `toweraccess-install`) into that namespace, and creates a `ClusterCurator` whose `spec.<curation>.towerAuthSecret` references that name.

Because the secret name was **not differentiated by cluster**, creating a second cluster in the same namespace collided with the already-existing `toweraccess-*` Secret and failed. For Hive clusters this never happened because each cluster gets its own namespace (namespace == cluster name).

Per the ticket, tolerating the existing Secret is not acceptable (different clusters may use different Ansible environments), so the secrets must be differentiated by cluster name.

## Fix

The name is generated where the YAML is generated — in the creation template — so the name shown in the live YAML editor is exactly what gets created:

- A `secretName` Handlebars helper names each copied automation Secret.
- A `curatorSpec` Handlebars helper rewrites the matching `ClusterCurator` `towerAuthSecret` references.

Both helpers derive the name from the same `getName`/`getNamespace` at render time, so the Secret name and the curator reference are always computed together and can never drift — even as the cluster name / hosted namespace change in the editor. Names are differentiated as `toweraccess-<curation>-<clusterName>` only when the cluster namespace differs from its name (the shared-namespace / HCP case); Hive clusters (namespace == name) keep the undifferentiated `toweraccess-<curation>` name that the Update/Remove automation actions rely on.

## Tests

- `CreateCluster` KubeVirt test: selects an automation template and asserts the copied Secret and the curator `towerAuthSecret` are differentiated (`toweraccess-upgrade-test`) when created in the shared `clusters` namespace. Verified it fails without the fix and passes with it.
- `ControlDataHelpers` unit tests: `secretName` (shared vs dedicated namespace) and `differentiateCuratorSecrets` (rewrites references; recomputes from the current cluster name with no drift / no double-append when the name changes).
- Full frontend suite green.

## How to test

1. On a cluster with OpenShift Virtualization + Ansible Automation Platform, create a KubeVirt cluster with an automation template using the default `clusters` Hosted cluster namespace.
2. Create a **second** KubeVirt cluster in the same `clusters` namespace with an automation template.
3. Both creations succeed. In the YAML editor, each cluster's Secret is named `toweraccess-<curation>-<clusterName>` and the ClusterCurator `towerAuthSecret` references match — including as you change the cluster name / hosted namespace.

---

## ✅ Checklist

### General

- [x] PR title follows the convention
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (no new strings added)

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

- Scoped to `getName !== getNamespace` so **Hive clusters are unchanged**. The existing `can create AWS cluster with ansible template` test (asserting the undifferentiated names) still passes, acting as the Hive no-op guard.
- The name is generated at template-render time (not patched at submit), so the live YAML editor always shows the real name, and the Secret and the curator reference stay in sync as the cluster name / namespace change.
- **Pre-existing, out of scope (tracked in ACM-41796):** the *Update automation template* and *Remove automation template* cluster actions do not function for HCP clusters — they write to `namespace: cluster.name` with the fixed `toweraccess-<curation>` name, while for HCP the curator lives in the shared hosted namespace. Independent of this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted control plane cluster creation when automation secrets are shared across namespaces.
  * Generated automation secrets and ClusterCurator configurations now use unique, cluster-specific names.
  * Prevented stale or duplicate secret suffixes when renaming clusters.
  * Improved namespace-aware secret handling, including reliable fallback behavior during cluster creation.

* **Tests**
  * Added coverage for secret isolation, renaming, namespace behavior, and empty curator specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->