### PR TITLE
[ACM-32324] Add AnsibleWorkflow support for cluster curator pre/post hooks

### DIFF
--- a/backend/src/routes/events.ts
+++ b/backend/src/routes/events.ts
@@ -292,6 +292,7 @@ const definitions: IWatchOptions[] = [
   { kind: 'PolicySet', apiVersion: 'policy.open-cluster-management.io/v1beta1' },
   { kind: 'SubmarinerConfig', apiVersion: 'submarineraddon.open-cluster-management.io/v1alpha1' },
   { kind: 'AnsibleJob', apiVersion: 'tower.ansible.com/v1alpha1' },
+  { kind: 'AnsibleWorkflow', apiVersion: 'tower.ansible.com/v1alpha1' },
   {
     kind: 'ConfigMap',
     apiVersion: 'v1',

--- a/frontend/src/atoms.ts
+++ b/frontend/src/atoms.ts
@@ -19,7 +19,6 @@ import { atom, useRecoilValue } from 'recoil'
 import type { ClaimMappings } from './resources/authentication'
 import {
   AnsibleJob,
-  AnsibleWorkflow,
   Application,
   CertificateSigningRequest,
   Channel,
@@ -63,7 +62,7 @@ import {
   SubscriptionReport,
   User,
 } from './resources'
-import type { ClusterExtension } from './resources'
+import type { AnsibleWorkflow, ClusterExtension } from './resources'
 
 let atomArrayKey = 0
 function AtomArray<T>() {

--- a/frontend/src/atoms.ts
+++ b/frontend/src/atoms.ts
@@ -19,6 +19,7 @@ import { atom, useRecoilValue } from 'recoil'
 import type { ClaimMappings } from './resources/authentication'
 import {
   AnsibleJob,
+  AnsibleWorkflow,
   Application,
   CertificateSigningRequest,
   Channel,
@@ -82,6 +83,7 @@ export const agentMachinesState = AtomArray<AgentMachineK8sResource>()
 export const agentServiceConfigsState = AtomArray<AgentServiceConfigK8sResource>()
 export const agentsState = AtomArray<AgentK8sResource>()
 export const ansibleJobState = AtomArray<AnsibleJob>()
+export const ansibleWorkflowState = AtomArray<AnsibleWorkflow>()
 export const applicationsState = AtomArray<Application>()
 export const argoCDsState = AtomArray<IResource>()
 export const bareMetalHostsState = AtomArray<BareMetalHostK8sResource>()

--- a/frontend/src/components/LoadData.tsx
+++ b/frontend/src/components/LoadData.tsx
@@ -15,6 +15,7 @@ import {
   AgentServiceConfigKindVersion,
   AnsibleJobApiVersion,
   AnsibleJobKind,
+  AnsibleWorkflowKind,
   ApplicationApiVersion,
   ApplicationKind,
   BareMetalHostApiVersion,
@@ -124,6 +125,7 @@ import {
   agentServiceConfigsState,
   agentsState,
   ansibleJobState,
+  ansibleWorkflowState,
   applicationsState,
   argoCDsState,
   bareMetalHostsState,
@@ -213,6 +215,7 @@ export function LoadData(props: { children?: ReactNode }) {
   const setAgents = useSetRecoilState(agentsState)
   const setAgentServiceConfigs = useSetRecoilState(agentServiceConfigsState)
   const setAnsibleJobs = useSetRecoilState(ansibleJobState)
+  const setAnsibleWorkflows = useSetRecoilState(ansibleWorkflowState)
   const setApplicationsState = useSetRecoilState(applicationsState)
   const setArgoCDsState = useSetRecoilState(argoCDsState)
   const setBareMetalHosts = useSetRecoilState(bareMetalHostsState)
@@ -318,6 +321,7 @@ export function LoadData(props: { children?: ReactNode }) {
     addSetter(AgentMachineApiVersion, AgentMachineKind, setAgentMachinesState)
     addSetter(AgentServiceConfigKindVersion, AgentServiceConfigKind, setAgentServiceConfigs)
     addSetter(AnsibleJobApiVersion, AnsibleJobKind, setAnsibleJobs)
+    addSetter(AnsibleJobApiVersion, AnsibleWorkflowKind, setAnsibleWorkflows)
     addSetter(ApplicationApiVersion, ApplicationKind, setApplicationsState)
     addSetter(BareMetalHostApiVersion, BareMetalHostKind, setBareMetalHosts)
     addSetter(CertificateSigningRequestApiVersion, CertificateSigningRequestKind, setCertificateSigningRequests)
@@ -375,6 +379,7 @@ export function LoadData(props: { children?: ReactNode }) {
     setAgents,
     setAgentServiceConfigs,
     setAnsibleJobs,
+    setAnsibleWorkflows,
     setApplicationsState,
     setArgoCDsState,
     setBareMetalHosts,

--- a/frontend/src/resources/ansible-job.test.ts
+++ b/frontend/src/resources/ansible-job.test.ts
@@ -1,0 +1,143 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import {
+  AnsibleJob,
+  AnsibleJobApiVersion,
+  AnsibleJobKind,
+  AnsibleWorkflow,
+  AnsibleWorkflowKind,
+  getLatestAnsibleHook,
+} from './ansible-job'
+
+function ansibleJob(opts: {
+  name?: string
+  namespace?: string
+  jobtype?: 'prehook' | 'posthook'
+  annotate?: boolean
+  status?: string
+  url?: string
+  started?: string
+}): AnsibleJob {
+  const name = opts.name ?? 'prehookjob-a'
+  const annotations =
+    opts.annotate === false
+      ? undefined
+      : {
+          jobtype: opts.jobtype ?? 'prehook',
+        }
+  return {
+    apiVersion: AnsibleJobApiVersion,
+    kind: AnsibleJobKind,
+    metadata: {
+      name,
+      namespace: opts.namespace ?? 'ns',
+      annotations,
+    },
+    status: {
+      ansibleJobResult: {
+        changed: false,
+        failed: opts.status === 'error',
+        status: opts.status ?? 'successful',
+        url: opts.url,
+        finished: opts.started ?? '',
+        started: opts.started as unknown as string,
+      },
+    },
+  }
+}
+
+function ansibleWorkflow(opts: {
+  name?: string
+  namespace?: string
+  jobtype?: 'prehook' | 'posthook'
+  annotate?: boolean
+  status?: string
+  url?: string
+  started?: string
+}): AnsibleWorkflow {
+  const name = opts.name ?? 'prehookjob-wf'
+  const annotations =
+    opts.annotate === false
+      ? undefined
+      : {
+          jobtype: opts.jobtype ?? 'prehook',
+        }
+  return {
+    apiVersion: AnsibleJobApiVersion,
+    kind: AnsibleWorkflowKind,
+    metadata: {
+      name,
+      namespace: opts.namespace ?? 'ns',
+      annotations,
+    },
+    status: {
+      ansibleWorkflowResult: {
+        changed: false,
+        failed: opts.status === 'error',
+        status: opts.status ?? 'successful',
+        url: opts.url,
+        started: opts.started,
+      },
+    },
+  }
+}
+
+describe('getLatestAnsibleHook', () => {
+  it('returns the latest job by started when there are no workflows', () => {
+    const older = ansibleJob({ name: 'prehookjob-old', started: '2021-01-01T00:00:00Z', url: '/job/old' })
+    const newer = ansibleJob({ name: 'prehookjob-new', started: '2021-06-01T00:00:00Z', url: '/job/new' })
+    const latest = getLatestAnsibleHook([older, newer], [], 'ns')
+    expect(latest.prehook?.metadata.name).toBe('prehookjob-new')
+    expect(latest.prehook?.result?.url).toBe('/job/new')
+  })
+
+  it('prefers a failed unstarted run over later started runs', () => {
+    const failed = ansibleJob({ name: 'prehookjob-fail', status: 'error', url: undefined })
+    const later = ansibleJob({ name: 'prehookjob-later', started: '2021-06-01T00:00:00Z', url: '/job/later' })
+    const latest = getLatestAnsibleHook([failed, later], [], 'ns')
+    expect(latest.prehook?.metadata.name).toBe('prehookjob-fail')
+  })
+
+  it('prefers a workflow with a URL over a job with a URL', () => {
+    const job = ansibleJob({ url: '/#/jobs/playbook/1', started: '2021-06-01T00:00:00Z' })
+    const workflow = ansibleWorkflow({ url: '/#/jobs/workflow/9', started: '2021-05-01T00:00:00Z' })
+    const latest = getLatestAnsibleHook([job], [workflow], 'ns')
+    expect(latest.prehook?.kind).toBe('AnsibleWorkflow')
+    expect(latest.prehook?.result?.url).toBe('/#/jobs/workflow/9')
+  })
+
+  it('falls back to a job URL when the workflow has no URL', () => {
+    const job = ansibleJob({ url: '/#/jobs/playbook/1', started: '2021-06-01T00:00:00Z' })
+    const workflow = ansibleWorkflow({ status: 'error', started: '2021-06-02T00:00:00Z' })
+    const latest = getLatestAnsibleHook([job], [workflow], 'ns')
+    expect(latest.prehook?.kind).toBe('AnsibleJob')
+    expect(latest.prehook?.result?.url).toBe('/#/jobs/playbook/1')
+  })
+
+  it('falls back to a workflow without a URL when no job has a URL', () => {
+    const job = ansibleJob({ status: 'error', started: '2021-06-01T00:00:00Z' })
+    const workflow = ansibleWorkflow({ status: 'error', started: '2021-06-02T00:00:00Z' })
+    const latest = getLatestAnsibleHook([job], [workflow], 'ns')
+    expect(latest.prehook?.kind).toBe('AnsibleWorkflow')
+  })
+
+  it('matches prehook and posthook by name prefix when jobtype is missing', () => {
+    const pre = ansibleJob({ name: 'prehookjob-x', annotate: false, url: '/pre', started: '2021-06-01T00:00:00Z' })
+    const post = ansibleWorkflow({
+      name: 'posthookjob-y',
+      annotate: false,
+      url: '/post',
+      started: '2021-06-01T00:00:00Z',
+    })
+    const latest = getLatestAnsibleHook([pre], [post], 'ns')
+    expect(latest.prehook?.result?.url).toBe('/pre')
+    expect(latest.posthook?.result?.url).toBe('/post')
+  })
+
+  it('ignores resources in other namespaces', () => {
+    const other = ansibleWorkflow({ namespace: 'other', url: '/other', started: '2021-06-01T00:00:00Z' })
+    const latest = getLatestAnsibleHook([], [other], 'ns')
+    expect(latest.prehook).toBeUndefined()
+    expect(latest.posthook).toBeUndefined()
+  })
+})

--- a/frontend/src/resources/ansible-job.test.ts
+++ b/frontend/src/resources/ansible-job.test.ts
@@ -1,10 +1,10 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import {
-  AnsibleJob,
+  type AnsibleJob,
   AnsibleJobApiVersion,
   AnsibleJobKind,
-  AnsibleWorkflow,
+  type AnsibleWorkflow,
   AnsibleWorkflowKind,
   getLatestAnsibleHook,
 } from './ansible-job'

--- a/frontend/src/resources/ansible-job.ts
+++ b/frontend/src/resources/ansible-job.ts
@@ -17,6 +17,43 @@ export const AnsibleJobDefinition: IResourceDefinition = {
   kind: AnsibleJobKind,
 }
 
+export const AnsibleWorkflowKind = 'AnsibleWorkflow'
+export type AnsibleWorkflowKindType = 'AnsibleWorkflow'
+
+export const AnsibleWorkflowDefinition: IResourceDefinition = {
+  apiVersion: AnsibleJobApiVersion,
+  kind: AnsibleWorkflowKind,
+}
+
+export interface AnsibleHookResult {
+  changed?: boolean
+  failed?: boolean
+  status?: string
+  url?: string
+  finished?: string
+  started?: string
+}
+
+export interface AnsibleHookRun {
+  kind: 'AnsibleJob' | 'AnsibleWorkflow'
+  metadata: Metadata
+  result?: AnsibleHookResult
+}
+
+export interface AnsibleWorkflow {
+  apiVersion: AnsibleJobApiVersionType
+  kind: AnsibleWorkflowKindType
+  metadata: Metadata
+  spec?: {
+    extra_vars?: object
+    workflow_template_name?: string
+    connection_secret?: string
+  }
+  status?: {
+    ansibleWorkflowResult?: AnsibleHookResult
+  }
+}
+
 export interface AnsibleJob {
   apiVersion: AnsibleJobApiVersionType
   kind: AnsibleJobKindType
@@ -85,6 +122,80 @@ export function getLatestAnsibleJob(ansibleJobs: AnsibleJob[], namespace: string
   return {
     prehook: prehookJob,
     posthook: posthookJob,
+  }
+}
+
+function isHookType(resource: { metadata: Metadata }, type: 'prehook' | 'posthook'): boolean {
+  const jobtype = resource.metadata.annotations?.jobtype
+  if (jobtype === 'prehook' || jobtype === 'posthook') {
+    return jobtype === type
+  }
+  const name = resource.metadata.name ?? ''
+  if (type === 'prehook') {
+    return name.startsWith('prehookjob-')
+  }
+  return name.startsWith('posthookjob-')
+}
+
+function jobToHookRun(job: AnsibleJob): AnsibleHookRun {
+  return {
+    kind: 'AnsibleJob',
+    metadata: job.metadata,
+    result: job.status?.ansibleJobResult,
+  }
+}
+
+function workflowToHookRun(workflow: AnsibleWorkflow): AnsibleHookRun {
+  return {
+    kind: 'AnsibleWorkflow',
+    metadata: workflow.metadata,
+    result: workflow.status?.ansibleWorkflowResult,
+  }
+}
+
+function latestHookRun(runs: AnsibleHookRun[]): AnsibleHookRun | undefined {
+  const failedUnstarted = runs.filter((run) => run.result?.status === 'error' && run.result?.started === undefined)
+  if (failedUnstarted.length) {
+    return failedUnstarted[0]
+  }
+  return getLatest<AnsibleHookRun>(runs, 'result.started')
+}
+
+function pickHookRun(
+  job: AnsibleHookRun | undefined,
+  workflow: AnsibleHookRun | undefined
+): AnsibleHookRun | undefined {
+  if (workflow?.result?.url) {
+    return workflow
+  }
+  if (job?.result?.url) {
+    return job
+  }
+  if (workflow) {
+    return workflow
+  }
+  return job
+}
+
+export function getLatestAnsibleHook(
+  ansibleJobs: AnsibleJob[],
+  ansibleWorkflows: AnsibleWorkflow[],
+  namespace: string
+): { prehook: AnsibleHookRun | undefined; posthook: AnsibleHookRun | undefined } {
+  const jobs = ansibleJobs.filter((job) => job.metadata.namespace === namespace).map(jobToHookRun)
+  const workflows = ansibleWorkflows
+    .filter((workflow) => workflow.metadata.namespace === namespace)
+    .map(workflowToHookRun)
+
+  return {
+    prehook: pickHookRun(
+      latestHookRun(jobs.filter((run) => isHookType(run, 'prehook'))),
+      latestHookRun(workflows.filter((run) => isHookType(run, 'prehook')))
+    ),
+    posthook: pickHookRun(
+      latestHookRun(jobs.filter((run) => isHookType(run, 'posthook'))),
+      latestHookRun(workflows.filter((run) => isHookType(run, 'posthook')))
+    ),
   }
 }
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
@@ -3,6 +3,7 @@
 import { NodePoolK8sResource } from '@openshift-assisted/ui-lib/cim'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
 import * as nock from 'nock'
 import { MemoryRouter } from 'react-router'
 import { RecoilRoot } from 'recoil'
@@ -10,10 +11,10 @@ import { ansibleJobState, ansibleWorkflowState, clusterImageSetsState, nodePools
 import { nockIgnoreApiPaths, nockIgnoreRBAC, nockRBAC } from '../../../../../lib/nock-util'
 import { clickByText, waitForCalled, waitForNock, waitForNotText, waitForText } from '../../../../../lib/test-util'
 import {
-  AnsibleJob,
+  type AnsibleJob,
   AnsibleJobApiVersion,
   AnsibleJobKind,
-  AnsibleWorkflow,
+  type AnsibleWorkflow,
   AnsibleWorkflowKind,
   ClusterCurator,
   ClusterCuratorApiVersion,
@@ -898,7 +899,7 @@ describe('DistributionField', () => {
   })
 
   it('should open posthook ansible logs, not prehook', async () => {
-    await renderDistributionInfoField(
+    const { container } = await renderDistributionInfoField(
       mockManagedAnsibleFailedPosthookDistributionInfo,
       false,
       false,
@@ -911,6 +912,7 @@ describe('DistributionField', () => {
     await clickByText('Update posthook')
     await clickByText('View logs')
     expect(window.open).toHaveBeenCalledWith('/ansible/posthook-workflow')
+    expect(await axe(container)).toHaveNoViolations()
   })
 })
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.test.tsx
@@ -6,13 +6,15 @@ import userEvent from '@testing-library/user-event'
 import * as nock from 'nock'
 import { MemoryRouter } from 'react-router'
 import { RecoilRoot } from 'recoil'
-import { ansibleJobState, clusterImageSetsState, nodePoolsState } from '../../../../../atoms'
+import { ansibleJobState, ansibleWorkflowState, clusterImageSetsState, nodePoolsState } from '../../../../../atoms'
 import { nockIgnoreApiPaths, nockIgnoreRBAC, nockRBAC } from '../../../../../lib/nock-util'
 import { clickByText, waitForCalled, waitForNock, waitForNotText, waitForText } from '../../../../../lib/test-util'
 import {
   AnsibleJob,
   AnsibleJobApiVersion,
   AnsibleJobKind,
+  AnsibleWorkflow,
+  AnsibleWorkflowKind,
   ClusterCurator,
   ClusterCuratorApiVersion,
   ClusterCuratorKind,
@@ -346,6 +348,68 @@ const ansibleJob: AnsibleJob = {
       started: '2021-06-08T16:43:01.853019Z',
     },
   },
+}
+
+const ansibleWorkflowPosthook: AnsibleWorkflow = {
+  apiVersion: AnsibleJobApiVersion,
+  kind: AnsibleWorkflowKind,
+  metadata: {
+    name: 'posthookjob-workflow',
+    namespace: 'clusterName',
+    annotations: {
+      jobtype: 'posthook',
+    },
+  },
+  status: {
+    ansibleWorkflowResult: {
+      changed: false,
+      failed: true,
+      status: 'error',
+      url: '/ansible/posthook-workflow',
+      started: '2021-06-08T16:43:01.853019Z',
+      finished: '2021-06-08T16:43:09.023018Z',
+    },
+  },
+}
+
+const mockManagedAnsibleFailedPosthookDistributionInfo: DistributionInfo = {
+  ocp: {
+    version: '1.2.3',
+    availableUpdates: ['1.2.4', '1.2.5', '1.2.6', '1.2'],
+    desiredVersion: '1.2.3',
+    upgradeFailed: false,
+  },
+  upgradeInfo: {
+    upgradeFailed: false,
+    isUpgrading: false,
+    isReadyUpdates: false,
+    isReadySelectChannels: false,
+    availableUpdates: ['1.2.4', '1.2.6', '1.2.5'],
+    currentVersion: '1.2.3',
+    isUpgradeCuration: true,
+    hooksInProgress: false,
+    hookFailed: true,
+    latestJob: {
+      conditionMessage: 'posthook failed',
+      // Real curator leaves step as prehook when the posthook job failed.
+      step: CuratorCondition.prehook,
+    },
+    prehooks: {
+      failed: false,
+      hasHooks: true,
+      inProgress: false,
+      success: true,
+    },
+    posthooks: {
+      failed: true,
+      hasHooks: true,
+      inProgress: false,
+      success: false,
+    },
+  },
+  k8sVersion: '1.11',
+  displayVersion: 'openshift',
+  isManagedOpenShift: true,
 }
 
 const mockNodepools: NodePoolK8sResource[] = [
@@ -693,7 +757,9 @@ describe('DistributionField', () => {
     data: DistributionInfo,
     allowUpgrade: boolean,
     hasUpgrade = false,
-    clusterCurator?: ClusterCurator
+    clusterCurator?: ClusterCurator,
+    ansibleJobs: AnsibleJob[] = [ansibleJob],
+    ansibleWorkflows: AnsibleWorkflow[] = []
   ) => {
     let nockAction: nock.Scope | undefined = undefined
     let nockAction2: nock.Scope | undefined = undefined
@@ -734,7 +800,12 @@ describe('DistributionField', () => {
       isRegionalHubCluster: false,
     }
     const retResource = render(
-      <RecoilRoot initializeState={(snapshot) => snapshot.set(ansibleJobState, [ansibleJob])}>
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(ansibleJobState, ansibleJobs)
+          snapshot.set(ansibleWorkflowState, ansibleWorkflows)
+        }}
+      >
         <MemoryRouter>
           <DistributionField cluster={mockCluster} clusterCurator={clusterCurator} />
         </MemoryRouter>
@@ -824,6 +895,22 @@ describe('DistributionField', () => {
     await clickByText('Update prehook')
     await clickByText('View logs')
     await waitForCalled(window.open as jest.Mock)
+  })
+
+  it('should open posthook ansible logs, not prehook', async () => {
+    await renderDistributionInfoField(
+      mockManagedAnsibleFailedPosthookDistributionInfo,
+      false,
+      false,
+      clusterCuratorUpgradeFailed,
+      [ansibleJob],
+      [ansibleWorkflowPosthook]
+    )
+    window.open = jest.fn()
+    await waitForText('Update posthook')
+    await clickByText('Update posthook')
+    await clickByText('View logs')
+    expect(window.open).toHaveBeenCalledWith('/ansible/posthook-workflow')
   })
 })
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -12,7 +12,7 @@ import {
   ClusterCuratorApiVersion,
   ClusterCuratorDefinition,
   getClusterImageSetVersion,
-  getLatestAnsibleJob,
+  getLatestAnsibleHook,
   getVersionFromReleaseString,
   HostedClusterDefinition,
   NodePool,
@@ -42,8 +42,10 @@ export function DistributionField(props: {
   const toggle = () => toggleOpen(!open)
   const [showChannelSelectModal, setShowChannelSelectModal] = useState<boolean>(false)
   const [channelSelectionPending, setChannelSelectionPending] = useState<boolean>(false)
-  const { ansibleJobState, clusterImageSetsState, agentMachinesState, agentsState } = useSharedAtoms()
+  const { ansibleJobState, ansibleWorkflowState, clusterImageSetsState, agentMachinesState, agentsState } =
+    useSharedAtoms()
   const ansibleJobs = useRecoilValue(ansibleJobState)
+  const ansibleWorkflows = useRecoilValue(ansibleWorkflowState)
   const agents = useRecoilValue(agentsState)
   const agentMachines = useRecoilValue(agentMachinesState)
   const clusterImageSets = useRecoilValue(clusterImageSetsState)
@@ -166,10 +168,9 @@ export function DistributionField(props: {
     return <>{version ? `${microshiftText} ${version}` : '-'}</>
   }
 
-  const latestAnsibleJob =
-    props.cluster?.namespace && ansibleJobs
-      ? getLatestAnsibleJob(ansibleJobs, props.cluster?.namespace)
-      : { prehook: undefined, posthook: undefined }
+  const latestAnsibleJob = props.cluster?.namespace
+    ? getLatestAnsibleHook(ansibleJobs, ansibleWorkflows, props.cluster.namespace)
+    : { prehook: undefined, posthook: undefined }
 
   if (!props.cluster?.distribution) {
     // For HostedClusters without channel, show the warning even without distribution
@@ -215,14 +216,18 @@ export function DistributionField(props: {
         ? t('update.ansible.posthook')
         : t('update.ansible.prehook')
 
-    const jobUrl =
-      props.cluster?.distribution?.upgradeInfo?.latestJob?.step === CuratorCondition.posthook
-        ? latestAnsibleJob.posthook?.status?.ansibleJobResult?.url
-        : latestAnsibleJob.prehook?.status?.ansibleJobResult?.url
+    const hookFailed = !!props.cluster?.distribution?.upgradeInfo?.hookFailed
+    const prehookFailed = !!props.cluster?.distribution?.upgradeInfo?.prehooks?.failed
+    const isPosthook =
+      hookFailed && !prehookFailed
+        ? true
+        : props.cluster?.distribution?.upgradeInfo?.latestJob?.step === CuratorCondition.posthook
+
+    const jobUrl = isPosthook ? latestAnsibleJob.posthook?.result?.url : latestAnsibleJob.prehook?.result?.url
 
     const footerContent: ReactNode = (
       <AcmButton
-        onClick={() => window.open(latestAnsibleJob.prehook?.status?.ansibleJobResult?.url)}
+        onClick={() => jobUrl && window.open(jobUrl)}
         variant="link"
         size="sm"
         isInline

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.test.tsx
@@ -4,6 +4,8 @@ import {
   AnsibleJob,
   AnsibleJobApiVersion,
   AnsibleJobKind,
+  AnsibleWorkflow,
+  AnsibleWorkflowKind,
   ClusterCurator,
   ClusterCuratorApiVersion,
   ClusterCuratorKind,
@@ -15,7 +17,7 @@ import { Cluster, ClusterStatus } from '../../../../../resources/utils'
 import { render } from '@testing-library/react'
 import { MemoryRouter, Outlet, Route, Routes } from 'react-router'
 import { RecoilRoot } from 'recoil'
-import { ansibleJobState, clusterCuratorsState } from '../../../../../atoms'
+import { ansibleJobState, ansibleWorkflowState, clusterCuratorsState } from '../../../../../atoms'
 import { clickByTestId, clickByText, waitForCalled, waitForNocks, waitForText } from '../../../../../lib/test-util'
 import { ClusterDetailsContext } from '../ClusterDetails/ClusterDetails'
 import { ProgressStepBar } from './ProgressStepBar'
@@ -309,6 +311,28 @@ const FailedAnsibleJobPosthook: Pod = {
   },
 }
 
+const ansibleWorkflowPrehook: AnsibleWorkflow = {
+  apiVersion: AnsibleJobApiVersion,
+  kind: AnsibleWorkflowKind,
+  metadata: {
+    name: 'prehookjob-workflow',
+    namespace: 'test-cluster',
+    annotations: {
+      jobtype: 'prehook',
+    },
+  },
+  status: {
+    ansibleWorkflowResult: {
+      changed: false,
+      failed: false,
+      status: 'successful',
+      url: 'https://aap.example.com/#/jobs/workflow/1',
+      started: '2021-06-08T16:43:01.853019Z',
+      finished: '2021-06-08T16:43:09.023018Z',
+    },
+  },
+}
+
 describe('ProgressStepBar', () => {
   test('renders progress bar', async () => {
     const context: Partial<ClusterDetailsContext> = { cluster: mockCluster }
@@ -357,6 +381,30 @@ describe('ProgressStepBar', () => {
     await waitForText('Cluster install')
     await clickByText('View logs')
     await waitForCalled(window.open as jest.Mock)
+  })
+
+  test('workflow URL opens AAP logs', async () => {
+    window.open = jest.fn()
+    const context: Partial<ClusterDetailsContext> = { cluster: mockCluster }
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(clusterCuratorsState, [clusterCurator1])
+          snapshot.set(ansibleJobState, [ansibleJobFailedPrehook])
+          snapshot.set(ansibleWorkflowState, [ansibleWorkflowPrehook])
+        }}
+      >
+        <MemoryRouter>
+          <Routes>
+            <Route element={<Outlet context={context} />}>
+              <Route path="*" element={<ProgressStepBar />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+    await clickByText('View logs')
+    expect(window.open).toHaveBeenCalledWith('https://aap.example.com/#/jobs/workflow/1')
   })
 
   test('hypershift logs link', async () => {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.test.tsx
@@ -1,10 +1,10 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import {
-  AnsibleJob,
+  type AnsibleJob,
   AnsibleJobApiVersion,
   AnsibleJobKind,
-  AnsibleWorkflow,
+  type AnsibleWorkflow,
   AnsibleWorkflowKind,
   ClusterCurator,
   ClusterCuratorApiVersion,
@@ -15,6 +15,7 @@ import {
 } from '../../../../../resources'
 import { Cluster, ClusterStatus } from '../../../../../resources/utils'
 import { render } from '@testing-library/react'
+import { axe } from 'jest-axe'
 import { MemoryRouter, Outlet, Route, Routes } from 'react-router'
 import { RecoilRoot } from 'recoil'
 import { ansibleJobState, ansibleWorkflowState, clusterCuratorsState } from '../../../../../atoms'
@@ -386,12 +387,46 @@ describe('ProgressStepBar', () => {
   test('workflow URL opens AAP logs', async () => {
     window.open = jest.fn()
     const context: Partial<ClusterDetailsContext> = { cluster: mockCluster }
-    render(
+    const { container } = render(
       <RecoilRoot
         initializeState={(snapshot) => {
           snapshot.set(clusterCuratorsState, [clusterCurator1])
           snapshot.set(ansibleJobState, [ansibleJobFailedPrehook])
           snapshot.set(ansibleWorkflowState, [ansibleWorkflowPrehook])
+        }}
+      >
+        <MemoryRouter>
+          <Routes>
+            <Route element={<Outlet context={context} />}>
+              <Route path="*" element={<ProgressStepBar />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+    await clickByText('View logs')
+    expect(window.open).toHaveBeenCalledWith('https://aap.example.com/#/jobs/workflow/1')
+    expect(await axe(container)).toHaveNoViolations()
+  })
+
+  test('workflow URL opens AAP logs when cluster name differs from namespace', async () => {
+    window.open = jest.fn()
+    const cluster = { ...mockCluster, namespace: 'clusters' }
+    const curator = {
+      ...clusterCurator1,
+      metadata: { ...clusterCurator1.metadata, namespace: 'clusters' },
+    }
+    const workflow = {
+      ...ansibleWorkflowPrehook,
+      metadata: { ...ansibleWorkflowPrehook.metadata, namespace: 'clusters' },
+    }
+    const context: Partial<ClusterDetailsContext> = { cluster }
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(clusterCuratorsState, [curator])
+          snapshot.set(ansibleJobState, [])
+          snapshot.set(ansibleWorkflowState, [workflow])
         }}
       >
         <MemoryRouter>

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { ClusterCurator, getMostRecentAnsibleJobPod, getLatestAnsibleJob, AnsibleJob } from '../../../../../resources'
+import { AnsibleHookRun, ClusterCurator, getLatestAnsibleHook, getMostRecentAnsibleJobPod } from '~/resources'
 import { ClusterStatus } from '../../../../../resources/utils'
 import { getFailedCuratorJobName } from '../../../../../resources/utils/status-conditions'
 import { AcmProgressTracker, getStatusLabel, ProgressTrackerStep, StatusType } from '../../../../../ui-components'
@@ -14,11 +14,12 @@ import { launchToOCP } from '../../../../../lib/ocp-utils'
 export function ProgressStepBar() {
   const { t } = useTranslation()
   const { cluster, clusterDeployment } = useClusterDetailsContext()
-  const { ansibleJobState, clusterCuratorsState, configMapsState } = useSharedAtoms()
+  const { ansibleJobState, ansibleWorkflowState, clusterCuratorsState, configMapsState } = useSharedAtoms()
   const curators = useRecoilValue(clusterCuratorsState)
   const ansibleJobs = useRecoilValue(ansibleJobState)
+  const ansibleWorkflows = useRecoilValue(ansibleWorkflowState)
   const configMaps = useRecoilValue(configMapsState)
-  const latestJobs = getLatestAnsibleJob(ansibleJobs, cluster.name)
+  const latestJobs = getLatestAnsibleHook(ansibleJobs, ansibleWorkflows, cluster.name)
   const curator = curators.find(
     (curator) => curator.metadata.name === cluster.name && curator.metadata.namespace == cluster?.namespace
   )
@@ -126,10 +127,9 @@ export function ProgressStepBar() {
           link: {
             linkName: !prehooks && !posthooks ? t('status.link.info') : t('status.link.logs'),
             // TODO: add ansible documentation url
-            linkUrl:
-              !prehooks && !posthooks ? DOC_LINKS.ANSIBLE_JOBS : latestJobs.prehook?.status?.ansibleJobResult?.url,
+            linkUrl: !prehooks && !posthooks ? DOC_LINKS.ANSIBLE_JOBS : latestJobs.prehook?.result?.url,
             isDisabled: isPrehookLinkDisabled(prehooks, posthooks, latestJobs, curator),
-            linkCallback: !latestJobs.prehook?.status?.ansibleJobResult?.url
+            linkCallback: !latestJobs.prehook?.result?.url
               ? () => {
                   if (curator) {
                     launchJobLogs(curator)
@@ -172,12 +172,12 @@ export function ProgressStepBar() {
         ...(posthooks &&
           (cluster?.status === 'posthookjob' ||
             cluster?.status === 'posthookfailed' ||
-            latestJobs.posthook?.status?.ansibleJobResult?.url) && {
+            latestJobs.posthook?.result?.url) && {
             link: {
               linkName: t('status.link.logs'),
-              linkUrl: latestJobs.posthook?.status?.ansibleJobResult?.url,
+              linkUrl: latestJobs.posthook?.result?.url,
               isDisabled: isPosthookLinkDisabled(latestJobs, curator),
-              linkCallback: !latestJobs.posthook?.status?.ansibleJobResult?.url
+              linkCallback: !latestJobs.posthook?.result?.url
                 ? () => {
                     if (curator) {
                       launchJobLogs(curator)
@@ -240,8 +240,8 @@ export const isPrehookLinkDisabled = (
   prehooks: number | undefined,
   posthooks: number | undefined,
   latestJobs: {
-    prehook: AnsibleJob | undefined
-    posthook: AnsibleJob | undefined
+    prehook: AnsibleHookRun | undefined
+    posthook: AnsibleHookRun | undefined
   },
   curator: ClusterCurator | undefined
 ) => {
@@ -254,8 +254,8 @@ export const isPrehookLinkDisabled = (
   }
   // if there are prehooks, an undefined url, an error in latest job status, and the pods are avaiable,
   // enable link to pods
-  if (!!prehooks && latestJobs.prehook?.status?.ansibleJobResult?.url === undefined) {
-    if (latestJobs.prehook?.status?.ansibleJobResult?.status === 'error' && jobPodsStillAvailable(curator)) {
+  if (!!prehooks && latestJobs.prehook?.result?.url === undefined) {
+    if (latestJobs.prehook?.result?.status === 'error' && jobPodsStillAvailable(curator)) {
       return false
     }
     return true
@@ -265,14 +265,14 @@ export const isPrehookLinkDisabled = (
 
 export const isPosthookLinkDisabled = (
   latestJobs: {
-    prehook: AnsibleJob | undefined
-    posthook: AnsibleJob | undefined
+    prehook: AnsibleHookRun | undefined
+    posthook: AnsibleHookRun | undefined
   },
   curator: ClusterCurator | undefined
 ) => {
   if (
-    latestJobs.posthook?.status?.ansibleJobResult?.url ||
-    (latestJobs.posthook?.status?.ansibleJobResult?.status === 'error' && jobPodsStillAvailable(curator))
+    latestJobs.posthook?.result?.url ||
+    (latestJobs.posthook?.result?.status === 'error' && jobPodsStillAvailable(curator))
   ) {
     return false
   }

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ProgressStepBar.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { AnsibleHookRun, ClusterCurator, getLatestAnsibleHook, getMostRecentAnsibleJobPod } from '~/resources'
+import { type AnsibleHookRun, ClusterCurator, getLatestAnsibleHook, getMostRecentAnsibleJobPod } from '~/resources'
 import { ClusterStatus } from '../../../../../resources/utils'
 import { getFailedCuratorJobName } from '../../../../../resources/utils/status-conditions'
 import { AcmProgressTracker, getStatusLabel, ProgressTrackerStep, StatusType } from '../../../../../ui-components'
@@ -19,7 +19,9 @@ export function ProgressStepBar() {
   const ansibleJobs = useRecoilValue(ansibleJobState)
   const ansibleWorkflows = useRecoilValue(ansibleWorkflowState)
   const configMaps = useRecoilValue(configMapsState)
-  const latestJobs = getLatestAnsibleHook(ansibleJobs, ansibleWorkflows, cluster.name)
+  const latestJobs = cluster.namespace
+    ? getLatestAnsibleHook(ansibleJobs, ansibleWorkflows, cluster.namespace)
+    : { prehook: undefined, posthook: undefined }
   const curator = curators.find(
     (curator) => curator.metadata.name === cluster.name && curator.metadata.namespace == cluster?.namespace
   )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.test.tsx
@@ -4,9 +4,10 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router'
 import { RecoilRoot } from 'recoil'
-import { ansibleJobState, configMapsState } from '../../../../../atoms'
-import { waitForText } from '../../../../../lib/test-util'
+import { ansibleJobState, ansibleWorkflowState, configMapsState } from '../../../../../atoms'
+import { clickByText, waitForText } from '../../../../../lib/test-util'
 import { Cluster, ClusterStatus } from '../../../../../resources/utils'
+import { AnsibleJob, AnsibleJobApiVersion, AnsibleJobKind, AnsibleWorkflow, AnsibleWorkflowKind } from '~/resources'
 import { StatusField } from './StatusField'
 
 const cluster: Cluster = {
@@ -86,5 +87,75 @@ describe('ScaleClusterAlert', () => {
     cluster.status = ClusterStatus.unreachable
     rerender(Component({ ...props }))
     await waitForText('Unreachable')
+  })
+})
+
+describe('StatusField ansible hooks', () => {
+  const posthookCluster: Cluster = {
+    ...cluster,
+    status: ClusterStatus.posthookfailed,
+    isHypershift: false,
+  }
+
+  const ansibleJobPrehook: AnsibleJob = {
+    apiVersion: AnsibleJobApiVersion,
+    kind: AnsibleJobKind,
+    metadata: {
+      name: 'prehookjob-a',
+      namespace: 'clusterName',
+      annotations: { jobtype: 'prehook' },
+    },
+    status: {
+      ansibleJobResult: {
+        changed: true,
+        failed: false,
+        status: 'successful',
+        url: '/ansible/prehook',
+        finished: '2021-06-08T16:43:09.023018Z',
+        started: '2021-06-08T16:43:01.853019Z',
+      },
+    },
+  }
+
+  const ansibleWorkflowPosthook: AnsibleWorkflow = {
+    apiVersion: AnsibleJobApiVersion,
+    kind: AnsibleWorkflowKind,
+    metadata: {
+      name: 'posthookjob-wf',
+      namespace: 'clusterName',
+      annotations: { jobtype: 'posthook' },
+    },
+    status: {
+      ansibleWorkflowResult: {
+        changed: false,
+        failed: true,
+        status: 'error',
+        url: '/#/jobs/workflow/post',
+        started: '2021-06-08T16:43:01.853019Z',
+        finished: '2021-06-08T16:43:09.023018Z',
+      },
+    },
+  }
+
+  it('opens the posthook workflow URL from View logs', async () => {
+    window.open = jest.fn()
+    render(
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(configMapsState, [])
+          snapshot.set(ansibleJobState, [ansibleJobPrehook])
+          snapshot.set(ansibleWorkflowState, [ansibleWorkflowPosthook])
+        }}
+      >
+        <MemoryRouter>
+          <StatusField cluster={posthookCluster} />
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+    await waitForText('Failed')
+    await clickByText('Failed')
+    await waitForText('View logs')
+    await clickByText('View logs')
+    expect(window.open).toHaveBeenCalledWith('/#/jobs/workflow/post')
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.test.tsx
@@ -2,12 +2,19 @@
 
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
 import { MemoryRouter } from 'react-router'
 import { RecoilRoot } from 'recoil'
 import { ansibleJobState, ansibleWorkflowState, configMapsState } from '../../../../../atoms'
 import { clickByText, waitForText } from '../../../../../lib/test-util'
 import { Cluster, ClusterStatus } from '../../../../../resources/utils'
-import { AnsibleJob, AnsibleJobApiVersion, AnsibleJobKind, AnsibleWorkflow, AnsibleWorkflowKind } from '~/resources'
+import {
+  type AnsibleJob,
+  AnsibleJobApiVersion,
+  AnsibleJobKind,
+  type AnsibleWorkflow,
+  AnsibleWorkflowKind,
+} from '~/resources'
 import { StatusField } from './StatusField'
 
 const cluster: Cluster = {
@@ -139,7 +146,7 @@ describe('StatusField ansible hooks', () => {
 
   it('opens the posthook workflow URL from View logs', async () => {
     window.open = jest.fn()
-    render(
+    const { container } = render(
       <RecoilRoot
         initializeState={(snapshot) => {
           snapshot.set(configMapsState, [])
@@ -157,5 +164,6 @@ describe('StatusField ansible hooks', () => {
     await waitForText('View logs')
     await clickByText('View logs')
     expect(window.open).toHaveBeenCalledWith('/#/jobs/workflow/post')
+    expect(await axe(container)).toHaveNoViolations()
   })
 })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { AnsibleHookRun, getLatestAnsibleHook } from '~/resources'
+import { type AnsibleHookRun, getLatestAnsibleHook } from '~/resources'
 import { Cluster, ClusterStatus, getClusterStatusLabel, getClusterStatusType } from '../../../../../resources/utils'
 import { AcmButton, AcmInlineStatus, Provider } from '../../../../../ui-components'
 import { ExternalLinkAltIcon, DownloadIcon } from '@patternfly/react-icons'
@@ -23,7 +23,9 @@ export function StatusField(props: { cluster: Cluster }) {
   const configMaps = useRecoilValue(configMapsState)
   const ansibleJobs = useRecoilValue(ansibleJobState)
   const ansibleWorkflows = useRecoilValue(ansibleWorkflowState)
-  const latestJob = getLatestAnsibleHook(ansibleJobs, ansibleWorkflows, props.cluster?.name!)
+  const latestJob = props.cluster?.namespace
+    ? getLatestAnsibleHook(ansibleJobs, ansibleWorkflows, props.cluster.namespace)
+    : { prehook: undefined, posthook: undefined }
   const agentClusterInstall = useAgentClusterInstall({
     name: props.cluster?.name!,
     namespace: props.cluster?.namespace!,

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/StatusField.tsx
@@ -1,5 +1,5 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { AnsibleJob, getLatestAnsibleJob } from '../../../../../resources'
+import { AnsibleHookRun, getLatestAnsibleHook } from '~/resources'
 import { Cluster, ClusterStatus, getClusterStatusLabel, getClusterStatusType } from '../../../../../resources/utils'
 import { AcmButton, AcmInlineStatus, Provider } from '../../../../../ui-components'
 import { ExternalLinkAltIcon, DownloadIcon } from '@patternfly/react-icons'
@@ -19,10 +19,11 @@ import { DOC_LINKS } from '../../../../../lib/doc-util'
 export function StatusField(props: { cluster: Cluster }) {
   const { t } = useTranslation()
   const location = useLocation()
-  const { ansibleJobState, configMapsState, clusterCuratorsState } = useSharedAtoms()
+  const { ansibleJobState, ansibleWorkflowState, configMapsState, clusterCuratorsState } = useSharedAtoms()
   const configMaps = useRecoilValue(configMapsState)
   const ansibleJobs = useRecoilValue(ansibleJobState)
-  const latestJob = getLatestAnsibleJob(ansibleJobs, props.cluster?.name!)
+  const ansibleWorkflows = useRecoilValue(ansibleWorkflowState)
+  const latestJob = getLatestAnsibleHook(ansibleJobs, ansibleWorkflows, props.cluster?.name!)
   const agentClusterInstall = useAgentClusterInstall({
     name: props.cluster?.name!,
     namespace: props.cluster?.namespace!,
@@ -44,11 +45,12 @@ export function StatusField(props: { cluster: Cluster }) {
   let Action = () => <></>
   let header = ''
 
-  const launchToLogs = (hookJob: AnsibleJob | undefined) => {
-    if (hookJob?.status?.ansibleJobResult.status === 'error' && jobPodsStillAvailable(curator)) {
+  const launchToLogs = (hookRun: AnsibleHookRun | undefined) => {
+    if (hookRun?.result?.url) {
+      return window.open(hookRun.result.url)
+    }
+    if (hookRun?.result?.status === 'error' && jobPodsStillAvailable(curator)) {
       return launchJobLogs(curator)
-    } else {
-      return window.open(latestJob.prehook?.status?.ansibleJobResult.url)
     }
   }
 


### PR DESCRIPTION
# 📝 Summary

**Ticket:** [ACM-32324](https://redhat.atlassian.net/browse/ACM-32324) — Automation status for workflow templates not working

**Root cause:** Cluster curator pre/post hook UI read only `AnsibleJob` (`ansibleJobResult.url`). When the controller records the run on `AnsibleWorkflow` (`ansibleWorkflowResult.url`) instead, **View logs** was missing, disabled, or fell back to a hub pod log URL.

**Fix:** Watch `AnsibleWorkflow`, add `getLatestAnsibleHook()` (prefer workflow-with-url → job-with-url → workflow → job), and use it in `ProgressStepBar`, `StatusField`, and `DistributionField` (including posthook-only navigation in the distribution popover).

**Type of Change:**
- [x] 🐞 Bug Fix

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

## 🧪 Test plan

### Dedicated test hub (repro clusters already provisioned)

| Item | Value |
|------|--------|
| **OpenShift API** | `https://api.emingora-acm-32324.dev09.red-chesterfield.com:6443` |
| **OpenShift Console (cluster)** | `https://console-openshift-console.apps.emingora-acm-32324.dev09.red-chesterfield.com` |
| **Username** | `kubeadmin` |
| **Password** | `32QDf-jIryT-ypCeq-qCebH` |

> **Note:** This is a short-lived engineering test hub. Clusters are frozen (cluster-curator-controller scaled to 0) so hook statuses stay stable for manual testing.

Repro clusters (label `acm-32324-repro=true`):

| Cluster | Scenario |
|---------|----------|
| `acm32324-ph-fail-off` | 01 — Install prehook failed |
| `acm32324-ph-fail-pod` | 02 — Install prehook failed (recent failure / pod-fallback window) |
| `acm32324-ph-run` | 03 — Install prehook running |
| `acm32324-poh-fail` | 04 — Install posthook failed |
| `acm32324-up-ph-fail` | 05 — Upgrade prehook failed |
| `acm32324-up-poh-fail` | 06 — Upgrade posthook failed |

### Run the fixed console locally (required)

The console deployed on the hub does **not** include this PR. Validate against **your local build** of branch `ACM-32324`:

```bash
git fetch origin ACM-32324 && git checkout ACM-32324
npm ci
npm run setup   # point backend/.env at the hub API above; use kubeadmin token or password
npm run plugins # recommended — ACM plugin at http://localhost:9000 via local OCP console
# or: npm start — standalone at https://localhost:3000
```

Log in through the local console flow with **kubeadmin** / password above when prompted.

**Navigation:** *Infrastructure* → *Clusters* → open each cluster below → *Overview* tab.

Synthetic `AnsibleWorkflow` URLs on the hub use host `auto-con-aap.apps.emingora-acm-32324.dev09.red-chesterfield.com`. The browser may redirect to the real AAP *overview* if that workflow ID does not exist — that is expected for repro data; the console fix is verified by the **URL opened** in the new tab, not by AAP showing a live job.

### Manual scenarios (expected **after** this fix)

#### 01 — `acm32324-ph-fail-off` (ProgressStepBar)

1. Open cluster overview; progress bar shows **Prehook jobs failed**.
2. **View logs** is **enabled** when `ansibleWorkflowResult.url` is present on the hub (stamped for repro).
3. Click **View logs** → new tab opens the **Ansible workflow URL** (not hub pod logs).

#### 02 — `acm32324-ph-fail-pod` (ProgressStepBar)

1. Progress bar: **Prehook jobs failed**.
2. Click **View logs** (prehook link) → opens workflow URL  
   `https://auto-con-aap.apps.emingora-acm-32324.dev09.red-chesterfield.com/#/jobs/workflow/32324-02-install-prehook-failed-pod-fallback`

#### 03 — `acm32324-ph-run` (ProgressStepBar)

1. Progress bar shows prehook **In progress**.
2. Confirm hook status reflects running workflow; no regression in progress display.

#### 04 — `acm32324-poh-fail` (ProgressStepBar + StatusField)

1. Progress bar / status: **Posthook jobs failed**.
2. Click **View logs** on the **posthook** step (prehook link may be disabled) → opens posthook workflow URL  
   `https://auto-con-aap.apps.emingora-acm-32324.dev09.red-chesterfield.com/#/jobs/workflow/32324-04-install-posthook-failed`

#### 05 — `acm32324-up-ph-fail` (DistributionField)

1. On overview, open the **Distribution** popover (failed upgrade prehook indicator).
2. Click **View logs** in the popover → opens workflow URL  
   `https://auto-con-aap.apps.emingora-acm-32324.dev09.red-chesterfield.com/#/jobs/workflow/32324-05-upgrade-prehook-failed`

#### 06 — `acm32324-up-poh-fail` (DistributionField — posthook regression)

1. Open **Distribution** popover for failed **posthook** upgrade.
2. Click **View logs** → must open the **posthook** workflow URL (not prehook):  
   `https://auto-con-aap.apps.emingora-acm-32324.dev09.red-chesterfield.com/#/jobs/workflow/32324-06-upgrade-posthook-failed`

**Pod fallback (still supported):** If there is **no** workflow/job URL, hook status is error, and curator failure is **< 1 hour** old, **View logs** still falls back to hub pod logs. Scenarios 02/04 on the hub now have stamped workflow URLs, so they demonstrate the primary fix path.

### Automated tests

```bash
npm run test:frontend -- --testPathPattern='ansible-job|ProgressStepBar|StatusField|DistributionField'
```

Or full suite: `npm run test:frontend`

---

## 🗒️ Notes for Reviewers

- Before the fix, UI ignored `AnsibleWorkflow`; **View logs** often had no URL or used pod fallback incorrectly (scenario 06 always opened prehook URL from the distribution footer).
- After the fix, prefer `ansibleWorkflowResult.url` via `getLatestAnsibleHook()`.
- Unit tests cover helper selection order and component wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Ansible Workflow resources.
  * Updated cluster progress, distribution, and status views to use Ansible Workflow results.
  * “View logs” opens relevant workflow URLs for prehook and posthook runs when available.
  * Added pod-log fallback for errored hooks without a workflow URL.

* **Bug Fixes**
  * Improved selection of the latest relevant Ansible hook, including failed and URL-bearing runs.
  * Improved hook matching by cluster namespace for more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[ACM-32324]: https://redhat.atlassian.net/browse/ACM-32324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
