### PR TITLE
fix: upgrade axios to 0.33.0 to fix CVE-2026-67321 [mce-2.10]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,7 @@
         "@stolostron/react-data-view": "^2.5.1",
         "@tanstack/react-query": "^4.36.1",
         "ajv": "8.11.0",
-        "axios": "^0.32.0",
+        "axios": "^0.33.0",
         "cidr-tools": "^12.1.3",
         "debounce": "1.2.1",
         "deep-diff": "1.0.2",
@@ -13151,9 +13151,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.32.0.tgz",
-      "integrity": "sha512-sGQArzERW2SI8IRkjuJ5y91Sm9QjiRq4Ay4kOLqpbBt5CeKDNq4g6nirJdyD+palK3yEDXnJiVXsesX66AjwyA==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.33.0.tgz",
+      "integrity": "sha512-juz19g7B3UWT9r3+tgRFQf2Bdy6IKDVroiyuVOUrkILVKHpqHL++K1l8ybvfdEP9B/VE72vk8vllbnedVCm/og==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,7 @@
     "@stolostron/react-data-view": "^2.5.1",
     "@tanstack/react-query": "^4.36.1",
     "ajv": "8.11.0",
-    "axios": "^0.32.0",
+    "axios": "^0.33.0",
     "cidr-tools": "^12.1.3",
     "debounce": "1.2.1",
     "deep-diff": "1.0.2",


### PR DESCRIPTION
Bumps `axios` to `0.33.0` to address CVE-2026-67321.

Related: ACM-41626

Made with [Cursor](https://cursor.com)