### PR TITLE
fix: upgrade find-my-way to ^9.7.0 to fix CVE-2026-47219 [mce-2.17]

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "abort-controller": "3.0.0",
         "dotenv": "16.6.1",
-        "find-my-way": "^9.5.0",
+        "find-my-way": "^9.7.0",
         "fuse.js": "6.6.2",
         "get-value": "3.0.1",
         "got": "^12.6.1",
@@ -3714,9 +3714,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
-      "integrity": "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/backend/package.json
+++ b/backend/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "abort-controller": "3.0.0",
     "dotenv": "16.6.1",
-    "find-my-way": "^9.5.0",
+    "find-my-way": "^9.7.0",
     "fuse.js": "6.6.2",
     "get-value": "3.0.1",
     "got": "^12.6.1",


### PR DESCRIPTION
Bumps `find-my-way` in `backend/` to `^9.7.0` (lockfile 9.7.0) to address CVE-2026-47219.

Reference: https://github.com/stolostron/console/pull/6543

Related: ACM-42521

Made with [Cursor](https://cursor.com)