### PR TITLE
fix: upgrade find-my-way to ^9.7.0 to fix CVE-2026-47219 [mce-2.8]

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,7 @@
         "abort-controller": "3.0.0",
         "dotenv": "16.0.1",
         "event-stream": "4.0.1",
-        "find-my-way": "^9.1.0",
+        "find-my-way": "^9.7.0",
         "fuse.js": "6.6.2",
         "get-value": "3.0.1",
         "got": "^12.5.3",
@@ -3400,17 +3400,17 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.1.0.tgz",
-      "integrity": "sha512-Y5jIsuYR4BwWDYYQ2A/RWWE6gD8a0FMgtU+HOq1WKku+Cwdz8M1v8wcAmRXXM1/iqtoqg06v+LjAxMYbCjViMw==",
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.7.0.tgz",
+      "integrity": "sha512-f2JHn75x2JlwUwLenZypgczR7YWMb/uO9BvUXtus+JMgkbIkLADd38cI4EiV+OQqrGo1Zlq6V8wnqMJ8e62wUQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-querystring": "^1.0.0",
-        "safe-regex2": "^4.0.0"
+        "safe-regex2": "^5.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/find-up": {
@@ -6296,12 +6296,25 @@
       ]
     },
     "node_modules/safe-regex2": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-4.0.0.tgz",
-      "integrity": "sha512-Hvjfv25jPDVr3U+4LDzBuZPPOymELG3PYcSk5hcevooo1yxxamQL/bHs/GrEPGmMoMEwRrHVGiCA1pXi97B8Ew==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
       }
     },
     "node_modules/safe-stable-stringify": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,7 @@
     "abort-controller": "3.0.0",
     "dotenv": "16.0.1",
     "event-stream": "4.0.1",
-    "find-my-way": "^9.1.0",
+    "find-my-way": "^9.7.0",
     "fuse.js": "6.6.2",
     "get-value": "3.0.1",
     "got": "^12.5.3",


### PR DESCRIPTION
Bumps `find-my-way` in `backend/` to `^9.7.0` (lockfile 9.7.0) to address CVE-2026-47219.

Reference: https://github.com/stolostron/console/pull/6543

Related: ACM-42523

Made with [Cursor](https://cursor.com)