### PR TITLE
fix(wizards): expand newly added array item even when defaultCollapsed

### DIFF
--- a/frontend/packages/react-form-wizard/src/inputs/WizArrayInput.tsx
+++ b/frontend/packages/react-form-wizard/src/inputs/WizArrayInput.tsx
@@ -21,6 +21,7 @@ import {
   forwardRef,
   useCallback,
   useContext,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -82,23 +83,39 @@ export function WizArrayInput(props: WizArrayInputProps) {
   const item = useContext(ItemContext)
   const values = wizardArrayItems(props, item)
 
+  // Tracks the index of the item most recently added via addItem, so it can be
+  // rendered expanded even when defaultCollapsed collapses pre-existing rows.
+  const [addedIndex, setAddedIndex] = useState<number | null>(null)
+
   const addItem = useCallback(
     (newItem: object | object[]) => {
       if (path === null) {
         ;(item as any[]).push(newItem)
+        setAddedIndex((item as any[]).length - 1)
       } else {
         let newArray = values
+        let newIndex = newArray.length
         if (Array.isArray(newItem)) {
           newArray = [...newArray, ...newItem]
+          newIndex = newArray.length - newItem.length
         } else {
           newArray.push(newItem as never)
         }
         setValue(newArray)
+        setAddedIndex(newIndex)
       }
       update()
     },
     [item, path, setValue, update, values]
   )
+
+  // Clear the added-item marker once it has been used for the initial mount of the
+  // corresponding ArrayInputItem; later add/remove actions won't re-expand this index.
+  useEffect(() => {
+    if (addedIndex !== null) {
+      setAddedIndex(null)
+    }
+  }, [addedIndex])
 
   if (!values.length && props.disallowEmpty) {
     addItem(props.newValue ?? {})
@@ -195,7 +212,7 @@ export function WizArrayInput(props: WizArrayInputProps) {
                 moveUp={moveUp}
                 moveDown={moveDown}
                 removeItem={removeItem}
-                defaultExpanded={!props.defaultCollapsed}
+                defaultExpanded={index === addedIndex ? true : !props.defaultCollapsed}
                 hideFromReviewStep={props.hideFromReviewStep}
               >
                 {props.children}

--- a/frontend/packages/react-form-wizard/src/inputs/WizArrayInput.tsx
+++ b/frontend/packages/react-form-wizard/src/inputs/WizArrayInput.tsx
@@ -78,6 +78,7 @@ export function WizArrayInput(props: WizArrayInputProps) {
   const onToggle = useCallback(() => setOpen((open: boolean) => !open), [])
 
   const path = props.path
+  const filter = props.filter
 
   const { update } = useData()
   const item = useContext(ItemContext)
@@ -90,8 +91,15 @@ export function WizArrayInput(props: WizArrayInputProps) {
   const addItem = useCallback(
     (newItem: object | object[]) => {
       if (path === null) {
-        ;(item as any[]).push(newItem)
-        setAddedIndex((item as any[]).length - 1)
+        const rawArray = item as any[]
+        rawArray.push(newItem)
+        if (filter && !filter(newItem)) {
+          // The added item won't be rendered at all, so there's no row to expand.
+          setAddedIndex(null)
+        } else {
+          const renderedArray = filter ? rawArray.filter(filter) : rawArray
+          setAddedIndex(renderedArray.length - 1)
+        }
       } else {
         let newArray = values
         let newIndex = newArray.length
@@ -106,7 +114,7 @@ export function WizArrayInput(props: WizArrayInputProps) {
       }
       update()
     },
-    [item, path, setValue, update, values]
+    [filter, item, path, setValue, update, values]
   )
 
   // Clear the added-item marker once it has been used for the initial mount of the


### PR DESCRIPTION
WizArrayInput applied the same defaultCollapsed value to every row, including one just added via the "Add" button, so a new label expression added while editing an existing ApplicationSet mounted collapsed and looked like nothing had been added. Track the index of the most recently added item and force only that row to render expanded.

# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->

**Ticket Link:**  
<!-- e.g. https://redhat.atlassian.net/browse/ACM-12345 -->

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General
- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces
#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newly added form items now open expanded automatically, making them easier to complete immediately.
  * Existing items continue to follow the configured collapsed or expanded default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->