### PR TITLE
ACM-37235 Fix clustercurator lookup to include name

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterDetails.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/ClusterDetails/ClusterDetails.tsx
@@ -124,7 +124,9 @@ export default function ClusterDetailsPage() {
       cc.spec?.namespace === clusterDeployment?.metadata?.namespace
   )
 
-  const clusterCurator = clusterCurators.find((cc) => cc.metadata?.namespace === namespace)
+  const clusterCurator = clusterCurators.find(
+    (cc) => cc.metadata?.namespace === namespace && cc.metadata?.name === name
+  )
 
   const agentClusterInstall = agentClusterInstalls.find(
     (aci) =>


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
ClusterDetails matches ClusterCurator by namespace only, causing false upgrade status for hypershift clusters sharing a hosting namespace

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-37235

**Type of Change:**  
<!-- Select one -->
- [X] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cluster curator selection so cluster details display the appropriate curator when multiple clusters share a namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->