### PR TITLE
ACM-42794: Ensure typeahead inputs disable browser autocomplete

### DIFF
--- a/frontend/packages/react-form-wizard/src/inputs/InputSelect.tsx
+++ b/frontend/packages/react-form-wizard/src/inputs/InputSelect.tsx
@@ -225,10 +225,10 @@ export const InputSelect = ({
           onClick={onInputClick}
           onChange={onTextInputChange}
           onKeyDown={onInputKeyDown}
-          autoComplete="off"
           innerRef={textInputRef}
           placeholder={placeholder}
           isExpanded={open}
+          inputProps={{ autoComplete: 'off' }}
           style={isMultiSelect && Array.isArray(value) && value.length > 0 ? { overflow: 'auto' } : undefined}
         >
           {Array.isArray(value) && (

--- a/frontend/src/components/AcmSelectBase.tsx
+++ b/frontend/src/components/AcmSelectBase.tsx
@@ -232,6 +232,7 @@ export function AcmSelectBase(props: AcmSelectBaseProps) {
   } = props
 
   const resolvedInputProps = {
+    autoComplete: 'off',
     ...inputProps,
     ...(id && { id }),
   }
@@ -722,7 +723,6 @@ export function AcmSelectBase(props: AcmSelectBaseProps) {
               commitTypeaheadInput(event.currentTarget.value)
             }
           }}
-          autoComplete="off"
           innerRef={textInputRef}
           placeholder={placeholder}
           inputId={id}

--- a/frontend/src/components/TemplateEditor/controls/__snapshots__/ControlPanelMultiSelect.test.js.snap
+++ b/frontend/src/components/TemplateEditor/controls/__snapshots__/ControlPanelMultiSelect.test.js.snap
@@ -73,7 +73,6 @@ exports[`ControlPanelMultiSelect component renders as expected 1`] = `
               class="pf-v6-c-text-input-group pf-m-plain"
             >
               <div
-                autocomplete="off"
                 class="pf-v6-c-text-input-group__main"
               >
                 <span
@@ -83,6 +82,7 @@ exports[`ControlPanelMultiSelect component renders as expected 1`] = `
                     aria-controls="select-multi-typeahead-listbox"
                     aria-expanded="false"
                     aria-label="Options menu"
+                    autocomplete="off"
                     class="pf-v6-c-text-input-group__text-input"
                     data-testid="multi-controlId"
                     placeholder="None"

--- a/frontend/src/components/TemplateEditor/controls/__snapshots__/ControlPanelSingleSelect.test.js.snap
+++ b/frontend/src/components/TemplateEditor/controls/__snapshots__/ControlPanelSingleSelect.test.js.snap
@@ -78,7 +78,6 @@ exports[`ControlPanelSingleSelect component renders as expected 1`] = `
               >
                 <div
                   aria-labelledby="controlId-label"
-                  autocomplete="off"
                   class="pf-v6-c-text-input-group__main"
                 >
                   <span
@@ -88,6 +87,7 @@ exports[`ControlPanelSingleSelect component renders as expected 1`] = `
                       aria-controls="select-multi-typeahead-listbox"
                       aria-expanded="false"
                       aria-label="Type to filter"
+                      autocomplete="off"
                       class="pf-v6-c-text-input-group__text-input"
                       data-testid="select-controlId"
                       id="controlId"

--- a/frontend/src/ui-components/AcmSelect/AcmSelect.test.tsx
+++ b/frontend/src/ui-components/AcmSelect/AcmSelect.test.tsx
@@ -71,6 +71,28 @@ describe('AcmSelect', () => {
     expect(getByPlaceholderText('Select one')).toBeInTheDocument()
   })
 
+  test('typeahead variant disables browser autocomplete on the input (ACM-42794)', async () => {
+    const TypeaheadSelect = () => {
+      const [value, setValue] = useState<string>()
+      return (
+        <AcmSelect
+          variant={SelectVariant.typeahead}
+          id="acm-select"
+          label="ACM select"
+          value={value}
+          onChange={setValue}
+          placeholder="Select one"
+        >
+          <SelectOption key="red" value="red">
+            Red
+          </SelectOption>
+        </AcmSelect>
+      )
+    }
+    const { getByPlaceholderText } = render(<TypeaheadSelect />)
+    expect(getByPlaceholderText('Select one')).toHaveAttribute('autocomplete', 'off')
+  })
+
   test('validates required input', async () => {
     const Component = () => {
       const [value, setValue] = useState<string | undefined>(undefined)


### PR DESCRIPTION
## Summary
- Chrome's native autocomplete was saving and suggesting previously-typed values in ACM's typeahead/combobox fields (e.g. release image selection, automation template dropdown), and its suggestion popover visually obscured ACM's own dropdown options.
- Both `AcmSelectBase` and `react-form-wizard`'s `InputSelect` already attempted to disable this by passing `autoComplete="off"` directly to PatternFly's `TextInputGroupMain`, but that component only forwards a fixed allowlist of props (plus `inputProps`) to the underlying `<input>` — everything else, including `autoComplete`, was landing on the wrapping `<div>` instead of the actual input element.
- Since virtually all typeahead/combobox usage in the codebase routes through these two shared components, routing `autoComplete: 'off'` through the working `inputProps` mechanism fixes the issue app-wide without touching ~30 individual consumer call sites.

## Test plan
- [x] Added a regression test (`AcmSelect.test.tsx`) asserting the rendered `<input>` has `autocomplete="off"` for the typeahead variant; confirmed it fails without the fix and passes with it
- [x] `npm run check` (i18n, prettier, lint, tsc) passes clean
- [x] Full relevant Jest suite passes (AcmSelect, AcmMultiSelect, NamespaceSelector — 43 tests)
- [ ] Manual verification in browser (`npm run plugins`) that Chrome no longer suggests/obscures options on the release image typeahead and automation template dropdown
- [x] CodeRabbit review run locally — 0 findings

Jira: https://redhat.atlassian.net/browse/ACM-42794

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved select input behavior by disabling browser autocomplete consistently.
  * Preserved custom input properties while applying the autocomplete setting.

* **Tests**
  * Added regression coverage to verify autocomplete is disabled for typeahead selects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->