### PR TITLE
ACM-41796 Update/Remove automation template actions do not work for Hosted Control Plane clusters

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/RemoveAutomationModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/RemoveAutomationModal.test.tsx
@@ -1,5 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
+import { Cluster, ClusterStatus } from '../../../../../resources/utils'
 import { ClusterCurator } from '../../../../../resources'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -8,7 +9,7 @@ import { RecoilRoot } from 'recoil'
 import { MemoryRouter } from 'react-router'
 import { clusterCuratorsState } from '../../../../../atoms'
 import { nockDelete, nockIgnoreApiPaths, nockIgnoreRBAC } from '../../../../../lib/nock-util'
-//import { clickByText, waitForNocks, waitForNotText, waitForText } from '../../../../../lib/test-util'
+import { waitForNocks } from '../../../../../lib/test-util'
 
 const mockClose = jest.fn()
 
@@ -54,6 +55,30 @@ describe('RemoveAutomationModal', () => {
     props.open = true
     props.clusters = []
     rerender(<Component {...props} />)
+  })
+
+  // ACM-41796: Hosted Control Plane clusters (e.g. OpenShift Virtualization) share a namespace for
+  // their ClusterCurator/Secrets, distinct from the cluster name. Remove must resolve the curator
+  // in that hosted namespace instead of assuming namespace === cluster.name (the Hive layout).
+  test('should remove automation template for a Hosted Control Plane cluster in a shared namespace', async () => {
+    const hcpProps = { clusters: [mockHostedCluster], open: true, close: mockClose }
+    render(<Component {...hcpProps} />)
+
+    // the HCP cluster must be listed as removable even though its namespace differs from its name
+    await waitFor(() => expect(screen.getByText('hcp-cluster-1')).toBeInTheDocument())
+
+    const nockCurator = nockDelete(deleteHostedClustercurator.req, deleteHostedClustercurator.res)
+    const nockSecretInstall = nockDelete(deleteHostedSecretInstall.req, deleteHostedSecretInstall.res)
+    const nockSecretUpgrade = nockDelete(deleteHostedSecretUpgrade.req, deleteHostedSecretUpgrade.res)
+
+    userEvent.click(
+      screen.getByRole('button', {
+        name: /remove/i,
+      })
+    )
+
+    await waitForNocks([nockCurator, nockSecretInstall, nockSecretUpgrade])
+    await waitFor(() => expect(mockClose).toHaveBeenCalled())
   })
 })
 
@@ -207,7 +232,82 @@ const mockClusterCurators: ClusterCurator[] = [
       },
     },
   },
+  // ACM-41796: a Hosted Control Plane cluster whose ClusterCurator lives in a namespace shared by
+  // other HCP clusters (e.g. 'clusters'), rather than a namespace matching its own name. Its
+  // towerAuthSecret names are differentiated by cluster name, per the ACM-39253 create-time fix.
+  {
+    apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+    kind: 'ClusterCurator',
+    metadata: {
+      name: 'hcp-cluster-1',
+      namespace: 'clusters',
+    },
+    spec: {
+      install: {
+        jobMonitorTimeout: 5,
+        posthook: [],
+        prehook: [
+          {
+            extra_vars: {},
+            name: 'hcp-install-job',
+            type: 'Job',
+          },
+        ],
+        towerAuthSecret: 'toweraccess-install-hcp-cluster-1',
+      },
+      upgrade: {
+        monitorTimeout: 120,
+        posthook: [],
+        prehook: [],
+        towerAuthSecret: 'toweraccess-upgrade-hcp-cluster-1',
+      },
+    },
+  },
 ]
+
+const mockHostedCluster: Cluster = {
+  name: 'hcp-cluster-1',
+  displayName: 'hcp-cluster-1',
+  namespace: 'clusters',
+  uid: 'hcp-cluster-1-uid',
+  status: ClusterStatus.ready,
+  isHive: false,
+  distribution: {
+    k8sVersion: '1.28',
+    ocp: {
+      availableUpdates: [],
+      desiredVersion: '4.15.0',
+      upgradeFailed: false,
+      version: '4.15.0',
+    },
+    displayVersion: 'OpenShift 4.15.0',
+    isManagedOpenShift: false,
+    upgradeInfo: {
+      upgradeFailed: false,
+      isUpgrading: false,
+      isReadyUpdates: false,
+      isReadySelectChannels: false,
+      availableUpdates: [],
+      currentVersion: '4.15.0',
+      desiredVersion: '4.15.0',
+      latestJob: {},
+    },
+  },
+  hasAutomationTemplate: true,
+  hive: {
+    isHibernatable: false,
+    secrets: {},
+  },
+  isManaged: true,
+  isCurator: true,
+  isHostedCluster: true,
+  isSNOCluster: false,
+  owner: {},
+  kubeadmin: '',
+  kubeconfig: '',
+  isHypershift: true,
+  isRegionalHubCluster: false,
+}
 
 const props = {
   clusters: [
@@ -757,6 +857,72 @@ const deleteSecrets2 = {
     status: 'Success',
     details: {
       name: 'toweraccess-install',
+      kind: 'secrets',
+    },
+  },
+}
+
+//---delete 'clustercurators' hcp-cluster-1 in the shared 'clusters' namespace---
+const deleteHostedClustercurator = {
+  req: {
+    apiVersion: 'cluster.open-cluster-management.io/v1beta1',
+    kind: 'clustercurators',
+    metadata: {
+      namespace: 'clusters',
+      name: 'hcp-cluster-1',
+    },
+  },
+  res: {
+    kind: 'Status',
+    apiVersion: 'v1',
+    metadata: {},
+    status: 'Success',
+    details: {
+      name: 'hcp-cluster-1',
+      group: 'cluster.open-cluster-management.io',
+      kind: 'clustercurators',
+    },
+  },
+}
+
+//---delete differentiated 'secrets' for hcp-cluster-1 in the shared 'clusters' namespace---
+const deleteHostedSecretInstall = {
+  req: {
+    apiVersion: 'v1',
+    kind: 'secrets',
+    metadata: {
+      namespace: 'clusters',
+      name: 'toweraccess-install-hcp-cluster-1',
+    },
+  },
+  res: {
+    kind: 'Status',
+    apiVersion: 'v1',
+    metadata: {},
+    status: 'Success',
+    details: {
+      name: 'toweraccess-install-hcp-cluster-1',
+      kind: 'secrets',
+    },
+  },
+}
+
+const deleteHostedSecretUpgrade = {
+  req: {
+    apiVersion: 'v1',
+    kind: 'secrets',
+    metadata: {
+      namespace: 'clusters',
+      name: 'toweraccess-upgrade-hcp-cluster-1',
+    },
+  },
+  res: {
+    kind: 'Status',
+    apiVersion: 'v1',
+    metadata: {},
+    status: 'Success',
+    details: {
+      name: 'toweraccess-upgrade-hcp-cluster-1',
       kind: 'secrets',
     },
   },

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/RemoveAutomationModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/RemoveAutomationModal.tsx
@@ -63,13 +63,22 @@ export function RemoveAutomationModal(props: {
   const onConfirm = async () => {
     setIsRemoving(true)
 
-    // for every cluster that has a curator, get its clusterCurator
+    // for all clusters selected in the modal:
+    //   - remove its ClusterCurator (which determines what Ansible automation template to run for this cluster)
     const results: IRequestResult[] = []
     removableClusters?.forEach((cluster) => {
-      // For Hosted Control Plane clusters (e.g. OpenShift Virtualization), the ClusterCurator and
-      // toweraccess-* Secrets live in the cluster's actual (hosted) namespace, which may be shared
-      // by multiple HCP clusters. Hive clusters have their own namespace equal to their name.
+      // hive clusters have a namespace that equals its name
+      // hosted clusters also have a hive cluster (namespace===name) but they also have a
+      //    "Hosted cluster namespace" specified when created that will contain other resources related
+      //    to that cluster, including:
+      //    - ClusterCurator: which defines what Ansible automation jobs to run when installing/updating that cluster
+      //    - toweraccess-* Secrets: which contain the credentials for the Ansible Tower server to use when running the automation jobs
+
+      // get the shared namespace from the hosted cluster
+      // this is where the ClusterCurator lives (default is 'clusters')
       const curatorNamespace = automationCuratorNamespace(cluster)
+
+      // find the ClusterCurator for this cluster
       const clusterCurator = clusterCurators.find(
         ({ metadata }) => cluster.name === metadata.name && curatorNamespace === metadata.namespace
       )

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/RemoveAutomationModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/RemoveAutomationModal.tsx
@@ -1,12 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import {
-  ClusterCuratorDefinition,
-  IResource,
-  SecretDefinition,
-  ClusterCuratorKind,
-  isAutomationTemplate,
-} from '../../../../../resources'
+import { ClusterCuratorDefinition, IResource, SecretDefinition, isAutomationTemplate } from '../../../../../resources'
 import { Cluster, IRequestResult, ResourceError, deleteResource } from '../../../../../resources/utils'
 import { css } from '@emotion/css'
 import { AcmEmptyState, AcmForm, AcmModal, AcmTable, IAcmTableColumn } from '../../../../../ui-components'
@@ -16,6 +10,7 @@ import { useMemo, useState, JSX } from 'react'
 import { useTranslation } from '../../../../../lib/acm-i18next'
 import { useSharedAtoms, useRecoilValue, useSharedSelectors } from '../../../../../shared-recoil'
 import { useClusterDistributionColumn, useClusterProviderColumn } from '../../../../../components/Clusters'
+import { automationCuratorNamespace } from '../utils/cluster-actions'
 
 const table = css({
   '& .pf-v6-c-toolbar': {
@@ -41,9 +36,12 @@ export function RemoveAutomationModal(props: {
   const removableClusters = useMemo<Cluster[] | undefined>(
     () =>
       props.clusters &&
-      props.clusters.filter(({ name }) =>
+      props.clusters.filter((cluster) =>
         clusterCurators.find(
-          (cc) => name === cc.metadata.name && name === cc.metadata.namespace && isAutomationTemplate(cc)
+          (cc) =>
+            cluster.name === cc.metadata.name &&
+            automationCuratorNamespace(cluster) === cc.metadata.namespace &&
+            isAutomationTemplate(cc)
         )
       ),
     [props.clusters, clusterCurators]
@@ -68,8 +66,12 @@ export function RemoveAutomationModal(props: {
     // for every cluster that has a curator, get its clusterCurator
     const results: IRequestResult[] = []
     removableClusters?.forEach((cluster) => {
+      // For Hosted Control Plane clusters (e.g. OpenShift Virtualization), the ClusterCurator and
+      // toweraccess-* Secrets live in the cluster's actual (hosted) namespace, which may be shared
+      // by multiple HCP clusters. Hive clusters have their own namespace equal to their name.
+      const curatorNamespace = automationCuratorNamespace(cluster)
       const clusterCurator = clusterCurators.find(
-        ({ metadata }) => cluster.name === metadata.name && cluster.name === metadata.namespace
+        ({ metadata }) => cluster.name === metadata.name && curatorNamespace === metadata.namespace
       )
       if (clusterCurator) {
         // Set up resources to patch/remove
@@ -80,10 +82,11 @@ export function RemoveAutomationModal(props: {
 
         // delete curator
         resources.push({
-          resource: { ...ClusterCuratorDefinition },
+          resource: { ...ClusterCuratorDefinition, metadata: { name: cluster.name, namespace: curatorNamespace } },
         })
 
-        // delete secrets
+        // delete secrets, using the actual Secret name referenced by the curator so the
+        // differentiated name (ACM-39253) used for shared-namespace clusters is respected
         supportedCurations.forEach((curationType) => {
           const curation = clusterCurator.spec?.[curationType]
           if (curation?.towerAuthSecret) {
@@ -91,7 +94,8 @@ export function RemoveAutomationModal(props: {
               ...SecretDefinition,
               type: 'Opaque',
               metadata: {
-                name: `toweraccess-${curationType}`,
+                name: curation.towerAuthSecret,
+                namespace: curatorNamespace,
               },
             }
             resources.push({
@@ -102,15 +106,7 @@ export function RemoveAutomationModal(props: {
 
         // delete resources
         resources.forEach((resource) => {
-          const resourceCopy = {
-            ...resource.resource,
-            metadata: {
-              ...(resource.resource.metadata || {}),
-              ...(resource.resource.kind === ClusterCuratorKind ? { name: cluster.name } : {}), // For curator, override name per cluster
-              namespace: cluster.name, // For curator and secrets, override namespace per cluster
-            },
-          }
-          const result = deleteResource(resourceCopy)
+          const result = deleteResource(resource.resource)
           results.push({
             promise: new Promise((resolve, reject) => {
               result.promise

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.test.tsx
@@ -256,10 +256,13 @@ const mockClusterRoks: Cluster = {
   isRegionalHubCluster: false,
 }
 
+// ACM-41796: Hosted Control Plane clusters (e.g. OpenShift Virtualization) place their
+// ClusterCurator/toweraccess-* Secrets in a shared hosted namespace, distinct from the cluster
+// name (unlike Hive clusters, which use a namespace equal to their own name).
 const mockClusterHosted: Cluster = {
   name: 'cluster-5-hosted',
   displayName: 'cluster-5-hosted',
-  namespace: 'cluster-5-hosted',
+  namespace: 'clusters',
   uid: 'cluster-5-hosted',
   status: ClusterStatus.ready,
   isHive: false,
@@ -378,16 +381,17 @@ const clusterCuratorHosted = {
   kind: ClusterCuratorDefinition.kind,
   metadata: {
     name: 'cluster-5-hosted',
-    namespace: 'cluster-5-hosted',
+    namespace: 'clusters',
   },
 }
 
+// differentiated per ACM-39253/ACM-41796 since the cluster name differs from the shared namespace
 const mockSecretHosted = {
   apiVersion: ProviderConnectionApiVersion,
   kind: ProviderConnectionKind,
   metadata: {
-    namespace: 'cluster-5-hosted',
-    name: 'toweraccess-install',
+    namespace: 'clusters',
+    name: 'toweraccess-install-cluster-5-hosted',
   },
 }
 
@@ -401,6 +405,21 @@ const clusterCuratorPatch = {
         },
       ],
       towerAuthSecret: mockSecret.metadata.name,
+    },
+  },
+}
+
+// the hosted cluster's ClusterCurator must reference the differentiated Secret name
+const clusterCuratorPatchHosted = {
+  spec: {
+    install: {
+      prehook: [
+        {
+          name: 'test-prehook-install',
+          extra_vars: {},
+        },
+      ],
+      towerAuthSecret: mockSecretHosted.metadata.name,
     },
   },
 }
@@ -472,7 +491,7 @@ describe('UpdateAutomationModal', () => {
     const mockSecretUpdate = nockPatch(mockSecret, secretPatch)
     const mockCuratorUpdate = nockPatch(clusterCuratorReady1, clusterCuratorPatch)
     const mockSecretHostedUpdate = nockPatch(mockSecretHosted, secretPatch)
-    const mockCuratorHostedUpdate = nockPatch(clusterCuratorHosted, clusterCuratorPatch)
+    const mockCuratorHostedUpdate = nockPatch(clusterCuratorHosted, clusterCuratorPatchHosted)
     render(<Component />)
     // select dropdown
     await waitForText('Select a template', false)

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.tsx
@@ -111,10 +111,20 @@ export function UpdateAutomationModal(props: {
 
     const results: IRequestResult[] = []
 
+    // for all clusters selected in the modal:
+    //   - add an automation template to a cluster that never had one
+    //        (a cluster can be hosted but not have an Ansible automation template to run)
+    //   - update the automation template for a cluster that already had one
     updatableClusters?.forEach((cluster) => {
-      // For Hosted Control Plane clusters (e.g. OpenShift Virtualization), the ClusterCurator and
-      // toweraccess-* Secrets live in the cluster's actual (hosted) namespace, which may be shared
-      // by multiple HCP clusters. Hive clusters have their own namespace equal to their name.
+      // hive clusters have a namespace that equals its name
+      // hosted clusters also have a hive cluster (namespace===name) but they also have a
+      //    "Hosted cluster namespace" specified when created that will contain other resources related
+      //    to that cluster, including:
+      //    - ClusterCurator: which defines what Ansible automation jobs to run when installing/updating that cluster
+      //    - toweraccess-* Secrets: which contain the credentials for the Ansible Tower server to use when running the automation jobs
+
+      // get the namespace from the hosted cluster
+      // this is where the ClusterCurator lives (default is 'clusters')
       const curatorNamespace = automationCuratorNamespace(cluster)
 
       // Set up resources to patch and/or create
@@ -142,6 +152,8 @@ export function UpdateAutomationModal(props: {
               s.metadata.namespace === selectedCuratorTemplate.metadata.namespace
           )
           if (matchingSecret && matchingSecret.metadata.name && matchingSecret.metadata.namespace) {
+            // because all curators wind up in same "Hosted cluster namespace" (eg 'clusters'), their names must be unique
+            // the cluster name is unique (because of hive) therefore we need to include the cluster name in the secret name
             const secretName = automationSecretName(curationType, cluster)
             const copiedSecret = {
               ...SecretDefinition,
@@ -171,6 +183,8 @@ export function UpdateAutomationModal(props: {
         }
       })
 
+      // now that we have all ClusterCurator and secret names in resources array
+      // patch kube with those resources
       resources.forEach((resource) => {
         const result = patchResource(resource.resource, resource.data)
         let createResult: IRequestResult | undefined = undefined

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/UpdateAutomationModal.tsx
@@ -36,7 +36,12 @@ import {
   AcmTable,
   IAcmTableColumn,
 } from '../../../../../ui-components'
-import { ClusterAction, clusterSupportsAction } from '../utils/cluster-actions'
+import {
+  automationCuratorNamespace,
+  automationSecretName,
+  ClusterAction,
+  clusterSupportsAction,
+} from '../utils/cluster-actions'
 
 const select = css({
   '& > div': {
@@ -104,72 +109,70 @@ export function UpdateAutomationModal(props: {
     }
     setIsUpdating(true)
 
-    // Set up resources to patch and/or create
-    const resources: {
-      resource: IResource
-      data: any
-    }[] = []
-
-    const curatorPatch = {
-      spec: cloneDeep(selectedCuratorTemplate.spec),
-    }
-
-    resources.push({
-      resource: { ...ClusterCuratorDefinition },
-      data: curatorPatch,
-    })
-
-    // Collect Ansible secrets for each supported curation type
-    supportedCurations.forEach((curationType) => {
-      const curation = curatorPatch.spec?.[curationType]
-      if (curation?.towerAuthSecret) {
-        const matchingSecret = ansibleCredentials.find(
-          (s) =>
-            s.metadata.name === curatorPatch.spec?.[curationType]?.towerAuthSecret &&
-            s.metadata.namespace === selectedCuratorTemplate.metadata.namespace
-        )
-        if (matchingSecret && matchingSecret.metadata.name && matchingSecret.metadata.namespace) {
-          const secretName = `toweraccess-${curationType}`
-          const copiedSecret = {
-            ...SecretDefinition,
-            type: 'Opaque',
-            metadata: {
-              name: secretName,
-            },
-          }
-          const copiedSecretSpec = {
-            metadata: {
-              labels: {
-                'cluster.open-cluster-management.io/type': 'ans',
-                'cluster.open-cluster-management.io/copiedFromSecretName': matchingSecret.metadata.name,
-                'cluster.open-cluster-management.io/copiedFromNamespace': matchingSecret.metadata.namespace,
-                'cluster.open-cluster-management.io/backup': 'cluster',
-              },
-            },
-            stringData: cloneDeep(matchingSecret.stringData),
-          }
-          curation.towerAuthSecret = secretName
-          resources.push({
-            resource: copiedSecret,
-            data: copiedSecretSpec,
-          })
-        }
-      }
-    })
-
     const results: IRequestResult[] = []
-    updatableClusters?.forEach((cluster) => {
-      resources.forEach((resource) => {
-        const resourceCopy = {
-          ...resource.resource,
-          metadata: {
-            ...(resource.resource.metadata || {}),
-            ...(resource.resource.kind === ClusterCuratorKind ? { name: cluster.name } : {}), // For curator, override name per cluster
-            namespace: cluster.name, // For curator and secrets, override namespace per cluster
-          },
-        }
 
-        const result = patchResource(resourceCopy, resource.data)
+    updatableClusters?.forEach((cluster) => {
+      // For Hosted Control Plane clusters (e.g. OpenShift Virtualization), the ClusterCurator and
+      // toweraccess-* Secrets live in the cluster's actual (hosted) namespace, which may be shared
+      // by multiple HCP clusters. Hive clusters have their own namespace equal to their name.
+      const curatorNamespace = automationCuratorNamespace(cluster)
+
+      // Set up resources to patch and/or create
+      const resources: {
+        resource: IResource
+        data: any
+      }[] = []
+
+      const curatorPatch = {
+        spec: cloneDeep(selectedCuratorTemplate.spec),
+      }
+
+      resources.push({
+        resource: { ...ClusterCuratorDefinition, metadata: { name: cluster.name, namespace: curatorNamespace } },
+        data: curatorPatch,
+      })
+
+      // Collect Ansible secrets for each supported curation type
+      supportedCurations.forEach((curationType) => {
+        const curation = curatorPatch.spec?.[curationType]
+        if (curation?.towerAuthSecret) {
+          const matchingSecret = ansibleCredentials.find(
+            (s) =>
+              s.metadata.name === curation.towerAuthSecret &&
+              s.metadata.namespace === selectedCuratorTemplate.metadata.namespace
+          )
+          if (matchingSecret && matchingSecret.metadata.name && matchingSecret.metadata.namespace) {
+            const secretName = automationSecretName(curationType, cluster)
+            const copiedSecret = {
+              ...SecretDefinition,
+              type: 'Opaque',
+              metadata: {
+                name: secretName,
+                namespace: curatorNamespace,
+              },
+            }
+            const copiedSecretSpec = {
+              metadata: {
+                labels: {
+                  'cluster.open-cluster-management.io/type': 'ans',
+                  'cluster.open-cluster-management.io/copiedFromSecretName': matchingSecret.metadata.name,
+                  'cluster.open-cluster-management.io/copiedFromNamespace': matchingSecret.metadata.namespace,
+                  'cluster.open-cluster-management.io/backup': 'cluster',
+                },
+              },
+              stringData: cloneDeep(matchingSecret.stringData),
+            }
+            curation.towerAuthSecret = secretName
+            resources.push({
+              resource: copiedSecret,
+              data: copiedSecretSpec,
+            })
+          }
+        }
+      })
+
+      resources.forEach((resource) => {
+        const result = patchResource(resource.resource, resource.data)
         let createResult: IRequestResult | undefined = undefined
 
         results.push({
@@ -181,13 +184,13 @@ export function UpdateAutomationModal(props: {
               .catch((err: ResourceError) => {
                 if (err.code === ResourceErrorCode.NotFound) {
                   const combinedResource = {
-                    ...resourceCopy,
+                    ...resource.resource,
                     ...resource.data,
                     // for Secrets, need to preserve metadata from both resources for name/namespace and labels
-                    metadata: { ...(resource.data.metadata || {}), ...resourceCopy.metadata },
+                    metadata: { ...(resource.data.metadata || {}), ...resource.resource.metadata },
                   }
                   createResult =
-                    resourceCopy.kind === ClusterCuratorKind
+                    resource.resource.kind === ClusterCuratorKind
                       ? createClusterCurator(combinedResource as ClusterCurator)
                       : createResource(combinedResource)
                   createResult.promise.then((data) => resolve(data)).catch((err) => reject(err))

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.test.tsx
@@ -2,7 +2,13 @@
 
 import { Cluster, ClusterStatus } from '../../../../../resources/utils'
 import { Provider } from '../../../../../ui-components'
-import { ClusterAction, clusterDestroyable, clusterSupportsAction } from './cluster-actions'
+import {
+  automationCuratorNamespace,
+  automationSecretName,
+  ClusterAction,
+  clusterDestroyable,
+  clusterSupportsAction,
+} from './cluster-actions'
 
 describe('ClusterDestroyable', () => {
   test('hive clusters should return true', () => {
@@ -226,7 +232,7 @@ describe('clusterSupportsAction UpdateAutomationTemplate', () => {
     labels: { cloud: 'aws' },
     kubeApiServer: '',
     consoleURL: '',
-    hasAutomationTemplate: false,
+    hasAutomationTemplate: true,
     hive: { isHibernatable: false, secrets: {} },
     isHive: false,
     isManaged: true,
@@ -255,6 +261,36 @@ describe('clusterSupportsAction UpdateAutomationTemplate', () => {
       }
       expect(clusterSupportsAction(hcpCluster, ClusterAction.UpdateAutomationTemplate)).toBe(true)
     })
+  })
+})
+
+// ACM-41796: Update/Remove automation template actions must resolve the ClusterCurator's real
+// namespace and Secret name for Hosted Control Plane clusters, which share a namespace instead of
+// using a Hive-style namespace-per-cluster layout.
+describe('automation namespace/secret naming (ACM-39253/ACM-41796)', () => {
+  test('automationCuratorNamespace falls back to the cluster name when namespace is unset (Hive-style)', () => {
+    expect(automationCuratorNamespace({ name: 'mycluster' } as Cluster)).toEqual('mycluster')
+    expect(automationCuratorNamespace({ name: 'mycluster', namespace: 'mycluster' } as Cluster)).toEqual('mycluster')
+  })
+
+  test('automationCuratorNamespace resolves the shared hosted namespace for HCP clusters', () => {
+    expect(automationCuratorNamespace({ name: 'hcp-cluster-1', namespace: 'clusters' } as Cluster)).toEqual('clusters')
+  })
+
+  test('automationSecretName is undifferentiated when the namespace matches the cluster name', () => {
+    expect(automationSecretName('install', { name: 'mycluster', namespace: 'mycluster' } as Cluster)).toEqual(
+      'toweraccess-install'
+    )
+    expect(automationSecretName('upgrade', { name: 'mycluster' } as Cluster)).toEqual('toweraccess-upgrade')
+  })
+
+  test('automationSecretName is differentiated by cluster name when the namespace is shared', () => {
+    expect(automationSecretName('install', { name: 'hcp-cluster-1', namespace: 'clusters' } as Cluster)).toEqual(
+      'toweraccess-install-hcp-cluster-1'
+    )
+    expect(automationSecretName('destroy', { name: 'hcp-cluster-2', namespace: 'clusters' } as Cluster)).toEqual(
+      'toweraccess-destroy-hcp-cluster-2'
+    )
   })
 })
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.ts
@@ -27,6 +27,7 @@ function clusterSupportsAutomationTemplateChange(cluster: Cluster) {
   return (
     !!cluster.name && // name is set
     !!cluster.distribution?.ocp?.version && // is OpenShift
+    cluster.hasAutomationTemplate && // has an automation template
     cluster.labels?.cloud !== 'auto-detect' && // cloud label is set
     cluster.status === ClusterStatus.ready && // cluster is ready
     (cluster.isHypershift || // is HCP
@@ -35,6 +36,22 @@ function clusterSupportsAutomationTemplateChange(cluster: Cluster) {
     !cluster.distribution?.upgradeInfo?.isUpgrading && // is not currently upgrading
     cluster.provider !== Provider.ibm // is not ROKS
   )
+}
+
+// ACM-39253 differentiates the create-time toweraccess-* Secret name by cluster name for clusters
+// that share a namespace for their ClusterCurator (e.g. Hosted Control Plane clusters such as
+// OpenShift Virtualization). ACM-41796: the Update/Remove automation template actions must resolve
+// the same namespace and Secret name, rather than assuming a Hive-style layout where the cluster
+// has its own namespace equal to its name.
+export function automationCuratorNamespace(cluster: Cluster): string {
+  return cluster.namespace || cluster.name
+}
+
+export function automationSecretName(curationType: string, cluster: Cluster): string {
+  const namespace = automationCuratorNamespace(cluster)
+  return cluster.name && namespace !== cluster.name
+    ? `toweraccess-${curationType}-${cluster.name}`
+    : `toweraccess-${curationType}`
 }
 
 export function clusterDestroyable(cluster: Cluster) {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.ts
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/utils/cluster-actions.ts
@@ -27,7 +27,6 @@ function clusterSupportsAutomationTemplateChange(cluster: Cluster) {
   return (
     !!cluster.name && // name is set
     !!cluster.distribution?.ocp?.version && // is OpenShift
-    cluster.hasAutomationTemplate && // has an automation template
     cluster.labels?.cloud !== 'auto-detect' && // cloud label is set
     cluster.status === ClusterStatus.ready && // cluster is ready
     (cluster.isHypershift || // is HCP


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
ACM-41796 Update/Remove automation template actions do not work for Hosted Control Plane clusters

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-41796

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General
- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces
- [ ] 
#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation template updates and removals for hosted clusters using shared namespaces.
  * Correctly identifies and manages cluster-specific automation secrets.
  * Prevents failures when creating, updating, or deleting automation resources in non-default namespaces.

* **Tests**
  * Added coverage for shared hosted-cluster namespaces and differentiated automation secret names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->