### PR TITLE
ACM-42787 Reduce websocket polling

### DIFF
--- a/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResource.test.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResource.test.ts
@@ -341,7 +341,7 @@ describe('handleWebsocketEvent', () => {
     expect(mockConsoleWarn).toHaveBeenCalledWith('Event object does not have a metadata.uid', expect.any(Object))
   })
 
-  it('should not add duplicate ADDED event for single resources', () => {
+  it('should replace single resource on ADDED event regardless of UID match', () => {
     const mockPod: K8sResourceCommon = {
       apiVersion: 'v1',
       kind: 'Pod',
@@ -361,8 +361,37 @@ describe('handleWebsocketEvent', () => {
     handleWebsocketEvent(event, mockRequestPath, false, mockCluster)
 
     const cachedResult = store.getResult(mockRequestPath)
-    // Should not change since we already have data
     expect(cachedResult?.data).toEqual({ cluster: mockCluster, ...mockPod })
+  })
+
+  it('should replace single resource when recreated with a new UID', () => {
+    const originalPod: K8sResourceCommon = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'test-pod', uid: 'original-uid', resourceVersion: '100' },
+    }
+
+    const recreatedPod: K8sResourceCommon = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'test-pod', uid: 'new-uid-after-recreate', resourceVersion: '200' },
+    }
+
+    const store = useFleetK8sWatchResourceStore.getState()
+    store.setResult(mockRequestPath, { cluster: mockCluster, ...originalPod }, true)
+
+    const event = {
+      data: JSON.stringify({
+        type: 'ADDED',
+        object: recreatedPod,
+      }),
+    }
+
+    handleWebsocketEvent(event, mockRequestPath, false, mockCluster)
+
+    const cachedResult = store.getResult(mockRequestPath)
+    // Should replace with the recreated resource even though UID differs
+    expect(cachedResult?.data).toEqual({ cluster: mockCluster, ...recreatedPod })
   })
 
   it('should return early for DELETED event when list data is not present', () => {

--- a/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResource.test.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResource.test.ts
@@ -1,11 +1,19 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { handleWebsocketEvent, useGetInitialResult, startWatch, stopWatch, subscribe } from './fleetK8sWatchResource'
-import { useFleetK8sWatchResourceStore } from './fleetK8sWatchResourceStore'
-import type { K8sResourceCommon, K8sModel } from '@openshift-console/dynamic-plugin-sdk'
+// Import after mocking
+import * as apiRequests from './apiRequests'
+
+import type { K8sModel, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk'
+import {
+  getErrorRetryInterval,
+  getSocketMonitoringInterval,
+  useFleetK8sWatchResourceStore,
+} from './fleetK8sWatchResourceStore'
+import { handleWebsocketEvent, startWatch, stopWatch, subscribe, useGetInitialResult } from './fleetK8sWatchResource'
+
 import type { FleetWatchK8sResource } from '../types'
-import { renderHook } from '@testing-library/react-hooks'
 import { NO_FLEET_AVAILABLE_ERROR } from './constants'
+import { renderHook } from '@testing-library/react-hooks'
 
 // Mock console methods
 const originalConsoleWarn = console.warn
@@ -69,9 +77,6 @@ jest.mock('../api', () => ({
   useIsFleetAvailable: () => mockUseIsFleetAvailable(),
   useHubClusterName: () => mockUseHubClusterName(),
 }))
-
-// Import after mocking
-import * as apiRequests from './apiRequests'
 
 beforeEach(() => {
   console.warn = mockConsoleWarn
@@ -207,6 +212,32 @@ describe('handleWebsocketEvent', () => {
     const cachedResult = store.getResult(mockRequestPath)
     expect(cachedResult?.data).toHaveLength(1)
     expect((cachedResult?.data as any)[0]).toEqual({ cluster: mockCluster, ...mockPod2 })
+  })
+
+  it('should return true for single resource DELETED to signal caller to GET', () => {
+    const mockPod: K8sResourceCommon = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'test-pod', uid: 'test-uid' },
+    }
+
+    const store = useFleetK8sWatchResourceStore.getState()
+    store.setResult(mockRequestPath, { cluster: mockCluster, ...mockPod }, true)
+
+    const deleteEvent = {
+      data: JSON.stringify({
+        type: 'DELETED',
+        object: mockPod,
+      }),
+    }
+
+    const shouldRefresh = handleWebsocketEvent(deleteEvent, mockRequestPath, false, mockCluster)
+
+    // Should signal caller to perform a GET (to confirm 404) without modifying store
+    expect(shouldRefresh).toBe(true)
+    const cachedResult = store.getResult(mockRequestPath)
+    expect(cachedResult?.data).toEqual({ cluster: mockCluster, ...mockPod })
+    expect(cachedResult?.loaded).toBe(true)
   })
 
   it('should handle WebSocket events for list resources - MODIFIED', () => {
@@ -922,8 +953,8 @@ describe('Socket monitoring behavior', () => {
     ;(apiRequests.fleetWatch as jest.Mock).mockClear()
     mockConsoleFetchJSON.mockClear()
 
-    // Advance time past the monitoring interval (30 seconds) and flush async
-    await jest.advanceTimersByTimeAsync(31000)
+    // Advance time past the monitoring interval and flush async
+    await jest.advanceTimersByTimeAsync(getSocketMonitoringInterval() + 1000)
 
     // The monitor should have checked - since data is now stale,
     // it should attempt to reload and reconnect
@@ -1011,7 +1042,7 @@ describe('Socket monitoring behavior', () => {
     expect(apiRequests.fleetWatch).toHaveBeenCalledTimes(1)
 
     // Advance time past the monitoring interval
-    await jest.advanceTimersByTimeAsync(31000)
+    await jest.advanceTimersByTimeAsync(getSocketMonitoringInterval() + 1000)
 
     // Old socket should be closed
     expect(mockSocket1.close).toHaveBeenCalled()
@@ -1054,7 +1085,7 @@ describe('Socket monitoring behavior', () => {
     ;(apiRequests.fleetWatch as jest.Mock).mockClear()
 
     // Advance time past the monitoring interval
-    await jest.advanceTimersByTimeAsync(31000)
+    await jest.advanceTimersByTimeAsync(getSocketMonitoringInterval() + 1000)
 
     // Socket should be closed
     expect(mockSocket.close).toHaveBeenCalled()
@@ -1066,6 +1097,63 @@ describe('Socket monitoring behavior', () => {
     const store = useFleetK8sWatchResourceStore.getState()
     const result = store.getResult(mockRequestPath)
     expect(result?.loadError).toBeDefined()
+  })
+
+  it('should retry after shorter interval when in error state', async () => {
+    const mockResource: FleetWatchK8sResource = {
+      cluster: 'test-cluster',
+      namespace: 'default',
+      isList: true,
+    }
+
+    const mockPod: K8sResourceCommon = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'test-pod', uid: 'test-uid' },
+    }
+
+    // First call succeeds (use Once so default can be overridden)
+    mockConsoleFetchJSON.mockResolvedValueOnce({
+      items: [mockPod],
+      metadata: { resourceVersion: '1000' },
+    })
+
+    const mockSocket = {
+      onmessage: null,
+      onclose: null,
+      onerror: null,
+      close: jest.fn(),
+    }
+    ;(apiRequests.fleetWatch as jest.Mock).mockReturnValue(mockSocket)
+
+    await startWatch(mockResource, mockModel, mockBasePath)
+    expect(apiRequests.fleetWatch).toHaveBeenCalledTimes(1)
+
+    // Subsequent calls fail (network offline)
+    mockConsoleFetchJSON.mockRejectedValue(new Error('Network error'))
+    ;(apiRequests.fleetWatch as jest.Mock).mockClear()
+
+    // Advance past monitoring interval to trigger reconnect attempt (which will fail)
+    await jest.advanceTimersByTimeAsync(getSocketMonitoringInterval() + 1000)
+
+    // Socket should be closed and error stored
+    expect(mockSocket.close).toHaveBeenCalled()
+    expect(apiRequests.fleetWatch).not.toHaveBeenCalled()
+    const storeAfterError = useFleetK8sWatchResourceStore.getState()
+    expect(storeAfterError.getResult(mockRequestPath)?.loadError).toBeDefined()
+
+    // Switch to success for the retry
+    mockConsoleFetchJSON.mockResolvedValue({
+      items: [mockPod],
+      metadata: { resourceVersion: '2000' },
+    })
+
+    // Advance by just the error retry interval (not the full monitoring interval)
+    // This proves the shorter retry is in effect
+    await jest.advanceTimersByTimeAsync(getErrorRetryInterval() + 1000)
+
+    // Should have successfully reconnected after the shorter error interval
+    expect(apiRequests.fleetWatch).toHaveBeenCalled()
   })
 
   it('should continue monitoring after successful reconnection', async () => {
@@ -1098,12 +1186,12 @@ describe('Socket monitoring behavior', () => {
     await startWatch(mockResource, mockModel, mockBasePath)
 
     // First reconnection
-    await jest.advanceTimersByTimeAsync(31000)
+    await jest.advanceTimersByTimeAsync(getSocketMonitoringInterval() + 1000)
 
     expect(apiRequests.fleetWatch).toHaveBeenCalledTimes(2)
 
     // Second reconnection
-    await jest.advanceTimersByTimeAsync(31000)
+    await jest.advanceTimersByTimeAsync(getSocketMonitoringInterval() + 1000)
 
     expect(apiRequests.fleetWatch).toHaveBeenCalledTimes(3)
   })
@@ -1156,5 +1244,240 @@ describe('Socket monitoring behavior', () => {
     // So no reconnection should occur
     expect(mockConsoleFetchJSON).not.toHaveBeenCalled()
     expect(apiRequests.fleetWatch).not.toHaveBeenCalled()
+  })
+
+  it('should GET on single resource DELETED and keep socket open', async () => {
+    const mockResource: FleetWatchK8sResource = {
+      cluster: 'test-cluster',
+      namespace: 'default',
+      name: 'test-pod',
+      isList: false,
+    }
+
+    const mockPod: K8sResourceCommon = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'test-pod', uid: 'test-uid', resourceVersion: '100' },
+    }
+
+    mockConsoleFetchJSON.mockResolvedValueOnce(mockPod)
+
+    const mockSocket = {
+      onmessage: null as ((event: any) => void) | null,
+      onclose: null,
+      onerror: null,
+      close: jest.fn(),
+      readyState: 1,
+    }
+    ;(apiRequests.fleetWatch as jest.Mock).mockReturnValue(mockSocket)
+
+    await startWatch(mockResource, mockModel, mockBasePath)
+
+    expect(apiRequests.fleetWatch).toHaveBeenCalledTimes(1)
+
+    // Set up 404 for the confirmation GET
+    const notFoundError = Object.assign(new Error('Not Found'), { code: 404 })
+    mockConsoleFetchJSON.mockRejectedValue(notFoundError)
+
+    // Simulate DELETED event from websocket
+    mockSocket.onmessage?.({
+      data: JSON.stringify({
+        type: 'DELETED',
+        object: mockPod,
+      }),
+    })
+
+    // Allow the async loadInitialData to complete
+    await jest.advanceTimersByTimeAsync(0)
+
+    // Should have done a GET to confirm the 404
+    expect(mockConsoleFetchJSON).toHaveBeenCalledWith(mockRequestPath, 'GET')
+    // Socket should NOT be closed — it stays open for future ADDED events
+    expect(mockSocket.close).not.toHaveBeenCalled()
+
+    const store = useFleetK8sWatchResourceStore.getState()
+    const result = store.getResult(mockRequestPath)
+    expect(result?.loaded).toBe(true)
+    expect(result?.loadError).toBe(notFoundError)
+  })
+
+  it('should open socket on startup even when initial GET returns 404', async () => {
+    const mockResource: FleetWatchK8sResource = {
+      cluster: 'test-cluster',
+      namespace: 'default',
+      name: 'test-pod',
+      isList: false,
+    }
+
+    // Initial GET returns 404
+    const notFoundError = Object.assign(new Error('Not Found'), { code: 404 })
+    mockConsoleFetchJSON.mockRejectedValue(notFoundError)
+
+    const mockSocket = {
+      onmessage: null as ((event: any) => void) | null,
+      onclose: null,
+      onerror: null,
+      close: jest.fn(),
+      readyState: 1,
+    }
+    ;(apiRequests.fleetWatch as jest.Mock).mockReturnValue(mockSocket)
+
+    await startWatch(mockResource, mockModel, mockBasePath)
+
+    // Socket should be opened despite 404 (watching collection for future ADDED events)
+    expect(apiRequests.fleetWatch).toHaveBeenCalledTimes(1)
+
+    const store = useFleetK8sWatchResourceStore.getState()
+    const result = store.getResult(mockRequestPath)
+    expect(result?.loadError).toBe(notFoundError)
+    expect(store.cache[mockRequestPath]?.socket).toBeDefined()
+  })
+
+  it('should clear 404 when ADDED event is received', async () => {
+    const mockResource: FleetWatchK8sResource = {
+      cluster: 'test-cluster',
+      namespace: 'default',
+      name: 'test-pod',
+      isList: false,
+    }
+
+    const mockPod: K8sResourceCommon = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'test-pod', uid: 'test-uid', resourceVersion: '200' },
+    }
+
+    // Initial GET returns 404
+    const notFoundError = Object.assign(new Error('Not Found'), { code: 404 })
+    mockConsoleFetchJSON.mockRejectedValue(notFoundError)
+
+    const mockSocket = {
+      onmessage: null as ((event: any) => void) | null,
+      onclose: null,
+      onerror: null,
+      close: jest.fn(),
+      readyState: 1,
+    }
+    ;(apiRequests.fleetWatch as jest.Mock).mockReturnValue(mockSocket)
+
+    await startWatch(mockResource, mockModel, mockBasePath)
+
+    // Verify 404 is stored
+    let store = useFleetK8sWatchResourceStore.getState()
+    expect(store.getResult(mockRequestPath)?.loadError).toBe(notFoundError)
+
+    // Simulate ADDED event — resource is created
+    mockSocket.onmessage?.({
+      data: JSON.stringify({
+        type: 'ADDED',
+        object: mockPod,
+      }),
+    })
+
+    // 404 error should be cleared, resource data should be stored
+    store = useFleetK8sWatchResourceStore.getState()
+    const result = store.getResult(mockRequestPath)
+    expect(result?.loadError).toBeUndefined()
+    expect(result?.loaded).toBe(true)
+    expect(result?.data).toEqual({ cluster: 'test-cluster', ...mockPod })
+  })
+
+  it('should not open socket on startup when non-404 error occurs', async () => {
+    const mockResource: FleetWatchK8sResource = {
+      cluster: 'test-cluster',
+      namespace: 'default',
+      name: 'test-pod',
+      isList: false,
+    }
+
+    // Initial GET returns 500
+    const serverError = Object.assign(new Error('Internal Server Error'), { code: 500 })
+    mockConsoleFetchJSON.mockRejectedValue(serverError)
+
+    const mockSocket = {
+      onmessage: null,
+      onclose: null,
+      onerror: null,
+      close: jest.fn(),
+      readyState: 1,
+    }
+    ;(apiRequests.fleetWatch as jest.Mock).mockReturnValue(mockSocket)
+
+    await startWatch(mockResource, mockModel, mockBasePath)
+
+    // Socket should NOT be opened for non-404 errors
+    expect(apiRequests.fleetWatch).not.toHaveBeenCalled()
+  })
+
+  it('should skip reconnect during monitoring when socket is alive and sending bookmarks', async () => {
+    const mockResource: FleetWatchK8sResource = {
+      cluster: 'test-cluster',
+      namespace: 'default',
+      name: 'test-pod',
+      isList: false,
+    }
+
+    const mockPod: K8sResourceCommon = {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: { name: 'test-pod', uid: 'test-uid', resourceVersion: '100' },
+    }
+
+    mockConsoleFetchJSON.mockResolvedValueOnce(mockPod)
+
+    const mockSocket = {
+      onmessage: null as ((event: any) => void) | null,
+      onclose: null,
+      onerror: null,
+      close: jest.fn(),
+      readyState: 1,
+    }
+    ;(apiRequests.fleetWatch as jest.Mock).mockReturnValue(mockSocket)
+
+    await startWatch(mockResource, mockModel, mockBasePath)
+
+    // Simulate DELETED then 404
+    const notFoundError = Object.assign(new Error('Not Found'), { code: 404 })
+    mockConsoleFetchJSON.mockRejectedValue(notFoundError)
+
+    mockSocket.onmessage?.({
+      data: JSON.stringify({
+        type: 'DELETED',
+        object: mockPod,
+      }),
+    })
+
+    await jest.advanceTimersByTimeAsync(0)
+
+    // Confirm 404 is stored
+    const store = useFleetK8sWatchResourceStore.getState()
+    expect(store.getResult(mockRequestPath)?.loadError).toBe(notFoundError)
+
+    // Clear mocks to track monitoring behavior
+    ;(apiRequests.fleetWatch as jest.Mock).mockClear()
+    mockSocket.close.mockClear()
+
+    // Simulate a BOOKMARK arriving midway through the monitoring interval
+    // This keeps the entry fresh (proves socket is alive)
+    await jest.advanceTimersByTimeAsync(30000)
+    mockSocket.onmessage?.({
+      data: JSON.stringify({
+        type: 'BOOKMARK',
+        object: { metadata: { resourceVersion: '200' } },
+      }),
+    })
+
+    // Advance past the first monitoring check (at t=65s) but not the second
+    // The BOOKMARK at t=30s makes the entry fresh (age=35s < 65s) when first check fires
+    await jest.advanceTimersByTimeAsync(40000)
+
+    // Socket should NOT be closed — bookmarks prove it's alive
+    expect(mockSocket.close).not.toHaveBeenCalled()
+    // Should NOT attempt to open a new socket
+    expect(apiRequests.fleetWatch).not.toHaveBeenCalled()
+
+    // The 404 error should still be preserved (bookmarks don't clear it)
+    const storeAfter = useFleetK8sWatchResourceStore.getState()
+    expect(storeAfter.getResult(mockRequestPath)?.loadError).toBe(notFoundError)
   })
 })

--- a/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResource.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResource.ts
@@ -94,7 +94,8 @@ const openFleetWatchSocket = (
 
     socket.onerror = (err) => {
       console.error('WebSocket error:', err)
-      store.setResult(requestPath, cachedResult?.data, true, err)
+      // Clear resourceVersion on transport errors to avoid resuming from a potentially stale version
+      store.setResult(requestPath, cachedResult?.data, true, err, '')
     }
   } catch (err) {
     handleError(err, requestPath, resource)
@@ -152,6 +153,9 @@ const checkFleetWatchSocket = async (
         scheduleSocketCheck(requestPath, resource, model, basePath, getErrorRetryInterval())
       }
     }
+  } else {
+    // Monitoring chain ending — clear tracked handle so a later watch can start fresh
+    store.clearMonitorTimeout(requestPath)
   }
 }
 
@@ -162,7 +166,9 @@ const scheduleSocketCheck = (
   basePath: string,
   delay: number
 ) => {
-  setTimeout(() => checkFleetWatchSocket(requestPath, resource, model, basePath), delay)
+  const store = useFleetK8sWatchResourceStore.getState()
+  const timeout = setTimeout(() => checkFleetWatchSocket(requestPath, resource, model, basePath), delay)
+  store.setMonitorTimeout(requestPath, timeout)
 }
 
 const monitorFleetWatchSocket = (
@@ -245,7 +251,11 @@ export const startWatch = async (resource: FleetWatchK8sResource, model: K8sMode
         openFleetWatchSocket(requestPath, resource, model, basePath)
       }
     }
-    monitorFleetWatchSocket(requestPath, resource, model, basePath)
+    // Only start a new monitoring chain if one isn't already pending
+    // (an existing chain survives refCount 0→1 transitions and will continue on its own)
+    if (!useFleetK8sWatchResourceStore.getState().cache[requestPath]?.monitorTimeout) {
+      monitorFleetWatchSocket(requestPath, resource, model, basePath)
+    }
   }
 }
 
@@ -295,6 +305,14 @@ export const handleWebsocketEvent = <R extends FleetK8sResourceCommon | FleetK8s
     return true
   }
 
+  if (eventType === 'ERROR') {
+    if (object?.code === 410) {
+      // 410 Gone — watch expired; clear resourceVersion so reconnect starts fresh
+      store.setResult(requestPath, storedData, currentEntry?.loaded ?? true, currentEntry?.loadError, '')
+    }
+    return false
+  }
+
   if (eventType === 'BOOKMARK') {
     // Update resourceVersion and refresh timestamp, but preserve any existing loadError
     // (e.g. a 404 should not be cleared just because the watch connection sent a bookmark)
@@ -315,9 +333,7 @@ export const handleWebsocketEvent = <R extends FleetK8sResourceCommon | FleetK8s
     return false
   }
 
-  const addOrReplaceObject = Array.isArray(storedData)
-    ? storedData.some(uidMatches)
-    : !storedData || uidMatches(storedData)
+  const addOrReplaceObject = Array.isArray(storedData) ? storedData.some(uidMatches) : true
 
   if (addOrReplaceObject) {
     const objectWithCluster = { cluster, ...object }

--- a/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResource.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResource.ts
@@ -3,7 +3,9 @@
 import { FleetK8sResourceCommon, FleetWatchK8sResource, FleetWatchK8sResultsObject } from '../types'
 import {
   getCacheEntryAge,
+  getErrorRetryInterval,
   getSocketMonitoringInterval,
+  is404Error,
   isCacheEntryFresh,
   isCacheEntryValid,
   useFleetK8sWatchResourceStore,
@@ -61,8 +63,8 @@ const openFleetWatchSocket = (
         cluster,
         fieldSelector: name ? `metadata.name=${name}` : undefined,
         labelSelector: selector || undefined,
-        resourceVersion: isList ? resourceVersion : undefined,
-        allowWatchBookmarks: isList,
+        resourceVersion,
+        allowWatchBookmarks: true,
       },
       basePath
     )
@@ -71,7 +73,11 @@ const openFleetWatchSocket = (
     socket.onmessage = (event) => {
       try {
         // Handle WebSocket event - this will update the store and notify all subscribers
-        handleWebsocketEvent(event, requestPath, isList, cluster as string)
+        const shouldRefresh = handleWebsocketEvent(event, requestPath, isList, cluster as string)
+        if (shouldRefresh) {
+          // Single resource was deleted — confirm 404 via GET but keep socket open
+          loadInitialData(requestPath, resource)
+        }
       } catch (e) {
         console.error('Failed to parse WebSocket message', e)
       }
@@ -104,7 +110,7 @@ const loadInitialData = async (requestPath: string, resource: FleetWatchK8sResou
     const processedData = isList
       ? (data as { items: K8sResourceCommon[] }).items.map((i) => ({ cluster, ...i }))
       : { cluster, ...(data as K8sResourceCommon) }
-    const resourceVersion = isList ? (data as K8sResourceCommon)?.metadata?.resourceVersion : undefined
+    const resourceVersion = (data as K8sResourceCommon)?.metadata?.resourceVersion
     store.setResult(requestPath, processedData, true, undefined, resourceVersion)
   } catch (err) {
     handleError(err, requestPath, resource)
@@ -113,40 +119,59 @@ const loadInitialData = async (requestPath: string, resource: FleetWatchK8sResou
   return true
 }
 
-const monitorFleetWatchSocket = async (
+const checkFleetWatchSocket = async (
   requestPath: string,
   resource: FleetWatchK8sResource,
   model: K8sModel,
   basePath: string
 ) => {
-  async function checkFleetWatchSocket(
-    requestPath: string,
-    resource: FleetWatchK8sResource,
-    model: K8sModel,
-    basePath: string
-  ) {
-    const store = useFleetK8sWatchResourceStore.getState()
-    const entry = store.cache[requestPath]
-    if (entry && entry.refCount > 0) {
-      if (isCacheEntryFresh(entry)) {
-        // check again when data is due to expire
-        setTimeout(
-          () => checkFleetWatchSocket(requestPath, resource, model, basePath),
-          getSocketMonitoringInterval() - getCacheEntryAge(entry)
-        )
+  const store = useFleetK8sWatchResourceStore.getState()
+  const entry = store.cache[requestPath]
+  if (entry && entry.refCount > 0) {
+    const hasLiveSocket = !!entry.socket && entry.socket.readyState <= WebSocket.OPEN
+
+    if (hasLiveSocket && isCacheEntryFresh(entry)) {
+      // Socket is alive and receiving bookmarks — schedule next check at normal interval.
+      scheduleSocketCheck(
+        requestPath,
+        resource,
+        model,
+        basePath,
+        getSocketMonitoringInterval() - getCacheEntryAge(entry)
+      )
+    } else {
+      // Socket may have disconnected or we have a non-404 error; reconnect
+      entry.socket?.close()
+      const initialDataLoaded = await loadInitialData(requestPath, resource)
+      const freshState = useFleetK8sWatchResourceStore.getState()
+      if (initialDataLoaded || (!resource.isList && is404Error(freshState.cache[requestPath]?.result?.loadError))) {
+        openFleetWatchSocket(requestPath, resource, model, basePath)
+        scheduleSocketCheck(requestPath, resource, model, basePath, getSocketMonitoringInterval())
       } else {
-        // Socket may have disconnected; reconnect
-        entry.socket?.close()
-        if (await loadInitialData(requestPath, resource)) {
-          // only start watch if initial load succeeds
-          openFleetWatchSocket(requestPath, resource, model, basePath)
-        }
-        // check again after default interval
-        setTimeout(() => checkFleetWatchSocket(requestPath, resource, model, basePath), getSocketMonitoringInterval())
+        // non-404 error — retry sooner
+        scheduleSocketCheck(requestPath, resource, model, basePath, getErrorRetryInterval())
       }
     }
   }
-  setTimeout(() => checkFleetWatchSocket(requestPath, resource, model, basePath), getSocketMonitoringInterval())
+}
+
+const scheduleSocketCheck = (
+  requestPath: string,
+  resource: FleetWatchK8sResource,
+  model: K8sModel,
+  basePath: string,
+  delay: number
+) => {
+  setTimeout(() => checkFleetWatchSocket(requestPath, resource, model, basePath), delay)
+}
+
+const monitorFleetWatchSocket = (
+  requestPath: string,
+  resource: FleetWatchK8sResource,
+  model: K8sModel,
+  basePath: string
+) => {
+  scheduleSocketCheck(requestPath, resource, model, basePath, getSocketMonitoringInterval())
 }
 
 export function useGetInitialResult() {
@@ -205,13 +230,20 @@ export const startWatch = async (resource: FleetWatchK8sResource, model: K8sMode
   const store = useFleetK8sWatchResourceStore.getState()
   store.incrementRefCount(requestPath)
 
-  // if we are the first subscriber, we are responsible for getting the initial data and watching for updates
+  // If we are the first subscriber, we are responsible for getting the initial data and watching for updates
   if (store.getRefCount(requestPath) === 1) {
-    // if there is a cached value that is not expired, we can skip the initial fetch
     const entry = store.cache[requestPath]
-    if ((entry && isCacheEntryValid(entry)) || (await loadInitialData(requestPath, resource))) {
-      // only start watch if we have valid cached data or an initial load succeeds
+    if (entry && isCacheEntryValid(entry)) {
+      // Cached value is not expired — skip the initial fetch
       openFleetWatchSocket(requestPath, resource, model, basePath)
+    } else {
+      const loadSuccess = await loadInitialData(requestPath, resource)
+      // For non-list: open socket even on 404 (resource may be created later via ADDED event)
+      // For list or non-404 errors: only open socket on success
+      const freshState = useFleetK8sWatchResourceStore.getState()
+      if (loadSuccess || (!resource.isList && is404Error(freshState.cache[requestPath]?.result?.loadError))) {
+        openFleetWatchSocket(requestPath, resource, model, basePath)
+      }
     }
     monitorFleetWatchSocket(requestPath, resource, model, basePath)
   }
@@ -228,68 +260,77 @@ export const handleWebsocketEvent = <R extends FleetK8sResourceCommon | FleetK8s
   requestPath: string,
   isList: boolean | undefined,
   cluster: string
-): void => {
+): boolean => {
   if (!event) {
     console.warn('Received undefined event', event)
-    return
+    return false
   }
 
   const eventDataParsed = JSON.parse(event.data)
   const eventType = eventDataParsed?.type
   const object = eventDataParsed?.object
 
-  if (!object) return
+  if (!object) return false
 
   const store = useFleetK8sWatchResourceStore.getState()
 
-  if (!isList) {
-    const currentEntry = store.getResult(requestPath)
-    if (eventType === 'ADDED' && currentEntry?.data) return
-
-    const processedEventData = { cluster, ...(object as K8sResourceCommon) }
-
-    if (processedEventData) {
-      // Update the store with the new data - this will notify all subscribers
-      store.setResult(requestPath, processedEventData, true)
-    }
-
-    return
-  }
-
   const currentEntry = store.getResult(requestPath)
-  const storedData = currentEntry?.data as K8sResourceCommon[]
-  if (!storedData) {
-    return
+  const storedData = currentEntry?.data
+  if (isList && !storedData) {
+    return false
   }
+
+  const uidMatches = (i: FleetK8sResourceCommon | undefined) => i?.metadata?.uid === object?.metadata?.uid
 
   if (eventType === 'DELETED') {
-    const updatedData = storedData.filter((i) => i.metadata?.uid !== object?.metadata?.uid)
-    store.setResult(requestPath, updatedData, true)
-    return
+    if (Array.isArray(storedData)) {
+      store.setResult(
+        requestPath,
+        storedData.filter((i) => !uidMatches(i)),
+        true
+      )
+      return false
+    }
+    // Signal caller to do a GET to confirm 404 (socket stays open)
+    return true
   }
 
   if (eventType === 'BOOKMARK') {
-    store.setResult(requestPath, storedData, true, undefined, object?.metadata?.resourceVersion)
+    // Update resourceVersion and refresh timestamp, but preserve any existing loadError
+    // (e.g. a 404 should not be cleared just because the watch connection sent a bookmark)
+    store.setResult(
+      requestPath,
+      storedData,
+      currentEntry?.loaded ?? true,
+      currentEntry?.loadError,
+      object?.metadata?.resourceVersion
+    )
   }
 
   if (eventType !== 'ADDED' && eventType !== 'MODIFIED') {
-    return
+    return false
   }
   if (!object?.metadata?.uid) {
     console.warn('Event object does not have a metadata.uid', eventDataParsed)
-    return
+    return false
   }
 
-  const objectExists = storedData.some((i) => i.metadata?.uid === object?.metadata?.uid)
+  const addOrReplaceObject = Array.isArray(storedData)
+    ? storedData.some(uidMatches)
+    : !storedData || uidMatches(storedData)
 
-  if (objectExists && eventType === 'MODIFIED') {
-    const updatedData = storedData.map((i) => (i.metadata?.uid === object?.metadata?.uid ? { cluster, ...object } : i))
+  if (addOrReplaceObject) {
+    const objectWithCluster = { cluster, ...object }
+    const updatedData = Array.isArray(storedData)
+      ? storedData.map((i) => (uidMatches(i) ? objectWithCluster : i))
+      : objectWithCluster
     store.setResult(requestPath, updatedData, true)
-    return
+    return false
   }
 
-  if (!objectExists) {
+  if (!addOrReplaceObject && Array.isArray(storedData)) {
     const updatedData = [...storedData, { cluster, ...(object as K8sResourceCommon) }] as R
     store.setResult(requestPath, updatedData, true)
   }
+  return false
 }

--- a/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResourceStore.test.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResourceStore.test.ts
@@ -1,11 +1,11 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { renderHook, act } from '@testing-library/react-hooks'
+import { act, renderHook } from '@testing-library/react-hooks'
 import {
-  useFleetK8sWatchResourceStore,
-  isCacheEntryValid,
-  isCacheEntryFresh,
   getCacheEntryAge,
   getSocketMonitoringInterval,
+  isCacheEntryFresh,
+  isCacheEntryValid,
+  useFleetK8sWatchResourceStore,
 } from './fleetK8sWatchResourceStore'
 
 // Mock WebSocket
@@ -355,7 +355,7 @@ describe('isCacheEntryFresh function', () => {
 
     const entry = {
       refCount: 1,
-      timestamp: now - 60000, // 60 seconds ago
+      timestamp: now - getSocketMonitoringInterval() - 3000, // 3 seconds before TTL
     }
 
     expect(isCacheEntryFresh(entry)).toBe(false)
@@ -432,11 +432,6 @@ describe('getCacheEntryAge function', () => {
 })
 
 describe('getSocketMonitoringInterval function', () => {
-  it('should return the cache TTL value', () => {
-    // The monitoring interval should match the cache TTL (30 seconds)
-    expect(getSocketMonitoringInterval()).toBe(30000)
-  })
-
   it('should return a consistent value', () => {
     const interval1 = getSocketMonitoringInterval()
     const interval2 = getSocketMonitoringInterval()
@@ -560,7 +555,7 @@ describe('Cache timeout and cleanup', () => {
 
     // Fast-forward time past TTL + grace period
     act(() => {
-      jest.advanceTimersByTime(41000) // 30s TTL + 10s grace + 1s buffer
+      jest.advanceTimersByTime(getSocketMonitoringInterval() + 10000 + 1000) // 65s TTL + 10s grace + 1s buffer
     })
 
     // Entry should be removed

--- a/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResourceStore.test.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResourceStore.test.ts
@@ -355,7 +355,7 @@ describe('isCacheEntryFresh function', () => {
 
     const entry = {
       refCount: 1,
-      timestamp: now - getSocketMonitoringInterval() - 3000, // 3 seconds before TTL
+      timestamp: now - getSocketMonitoringInterval() - 3000, // 3 seconds past the TTL
     }
 
     expect(isCacheEntryFresh(entry)).toBe(false)

--- a/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResourceStore.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResourceStore.ts
@@ -1,7 +1,8 @@
 /* Copyright Contributors to the Open Cluster Management project */
+import { FleetK8sResourceCommon, FleetWatchK8sResultsObject } from '../types'
+
 import { create } from 'zustand'
 import { subscribeWithSelector } from 'zustand/middleware'
-import { FleetK8sResourceCommon, FleetWatchK8sResultsObject } from '../types'
 
 type Data = FleetK8sResourceCommon | FleetK8sResourceCommon[]
 
@@ -11,11 +12,12 @@ type CacheEntry = {
   refCount: number
   timestamp: number
   resourceVersion?: string
-  timeout?: NodeJS.Timeout
+  timeout?: ReturnType<typeof setTimeout>
 }
 
-const CACHE_TTL = 30 * 1000 // 30 seconds
+const CACHE_TTL = 65 * 1000 // 65 seconds - k8s API sends BOOKMARK event about every 60 seconds
 const CACHE_REMOVE_GRACE = 10 * 1000 // 10 seconds; wait a bit longer than TTL to remove cache entry so it is not removed between retrieval of initial value and start of watching
+const ERROR_RETRY_INTERVAL = 15 * 1000 // 15 seconds - shorter retry when in an error state
 
 export const isCacheEntryValid = (entry: CacheEntry) => {
   return !entry.result?.loadError && (!!entry.socket || isCacheEntryFresh(entry))
@@ -30,6 +32,8 @@ export const getCacheEntryAge = (entry: CacheEntry) => {
 }
 
 export const getSocketMonitoringInterval = () => CACHE_TTL
+export const getErrorRetryInterval = () => ERROR_RETRY_INTERVAL
+export const is404Error = (error: any): boolean => error?.code === 404 || error?.response?.status === 404
 
 export type FleetK8sWatchResourceStore = {
   // Cache
@@ -106,28 +110,27 @@ export const useFleetK8sWatchResourceStore = create<FleetK8sWatchResourceStore>(
     decrementRefCount: (key) => {
       set((state) => {
         const entry = state.cache[key]
-        if (entry) {
-          const { socket, refCount } = entry
-          const newRefCount = refCount > 0 ? refCount - 1 : 0
-          if (newRefCount === 0 && socket) {
-            socket.close()
-          }
-          return {
-            cache: {
-              ...state.cache,
-              [key]: {
-                ...entry,
-                refCount: newRefCount,
-                socket: newRefCount > 0 ? socket : undefined,
-                timeout:
-                  newRefCount === 0
-                    ? setTimeout(() => state.removeEntry(key), CACHE_TTL + CACHE_REMOVE_GRACE) // schedule removal of entry
-                    : undefined,
-              },
-            },
-          }
+        if (!entry) {
+          return state
         }
-        return state
+        const newRefCount = Math.max(0, entry.refCount - 1)
+        if (newRefCount === 0) {
+          entry.socket?.close()
+        }
+        return {
+          cache: {
+            ...state.cache,
+            [key]: {
+              ...entry,
+              refCount: newRefCount,
+              socket: newRefCount > 0 ? entry.socket : undefined,
+              timeout:
+                newRefCount === 0
+                  ? setTimeout(() => state.removeEntry(key), CACHE_TTL + CACHE_REMOVE_GRACE) // schedule removal of entry
+                  : undefined,
+            },
+          },
+        }
       })
     },
 
@@ -145,7 +148,11 @@ export const useFleetK8sWatchResourceStore = create<FleetK8sWatchResourceStore>(
 
     removeEntry: (key) => {
       set((state) => {
-        const { [key]: removed, ...rest } = state.cache
+        const removed = state.cache[key]
+        if (removed?.timeout) {
+          clearTimeout(removed.timeout)
+        }
+        const { [key]: _removed, ...rest } = state.cache
         return {
           cache: {
             ...rest,

--- a/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResourceStore.ts
+++ b/frontend/packages/multicluster-sdk/src/internal/fleetK8sWatchResourceStore.ts
@@ -13,6 +13,7 @@ type CacheEntry = {
   timestamp: number
   resourceVersion?: string
   timeout?: ReturnType<typeof setTimeout>
+  monitorTimeout?: ReturnType<typeof setTimeout>
 }
 
 const CACHE_TTL = 65 * 1000 // 65 seconds - k8s API sends BOOKMARK event about every 60 seconds
@@ -46,6 +47,8 @@ export type FleetK8sWatchResourceStore = {
   decrementRefCount: (key: string) => void
   touchEntry: (key: string) => void
   removeEntry: (key: string) => void
+  setMonitorTimeout: (key: string, timeout: ReturnType<typeof setTimeout>) => void
+  clearMonitorTimeout: (key: string) => void
 
   // Getters for cache
   getResult: (key: string) => FleetWatchK8sResultsObject<Data> | undefined
@@ -125,9 +128,9 @@ export const useFleetK8sWatchResourceStore = create<FleetK8sWatchResourceStore>(
               refCount: newRefCount,
               socket: newRefCount > 0 ? entry.socket : undefined,
               timeout:
-                newRefCount === 0
+                newRefCount === 0 && !entry.timeout // if timeout is set, the entry is already scheduled for removal
                   ? setTimeout(() => state.removeEntry(key), CACHE_TTL + CACHE_REMOVE_GRACE) // schedule removal of entry
-                  : undefined,
+                  : entry.timeout,
             },
           },
         }
@@ -152,10 +155,43 @@ export const useFleetK8sWatchResourceStore = create<FleetK8sWatchResourceStore>(
         if (removed?.timeout) {
           clearTimeout(removed.timeout)
         }
+        if (removed?.monitorTimeout) {
+          clearTimeout(removed.monitorTimeout)
+        }
         const { [key]: _removed, ...rest } = state.cache
         return {
           cache: {
             ...rest,
+          },
+        }
+      })
+    },
+
+    setMonitorTimeout: (key, timeout) => {
+      set((state) => {
+        const entry = state.cache[key]
+        if (!entry) return state
+        if (entry.monitorTimeout) {
+          clearTimeout(entry.monitorTimeout)
+        }
+        return {
+          cache: {
+            ...state.cache,
+            [key]: { ...entry, monitorTimeout: timeout },
+          },
+        }
+      })
+    },
+
+    clearMonitorTimeout: (key) => {
+      set((state) => {
+        const entry = state.cache[key]
+        if (!entry?.monitorTimeout) return state
+        clearTimeout(entry.monitorTimeout)
+        return {
+          cache: {
+            ...state.cache,
+            [key]: { ...entry, monitorTimeout: undefined },
           },
         }
       })


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
multicluster-sdk useFleetK8sWatchResource(s) hooks overload cluster-proxy

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-42787

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
Uses watch bookmarks (which are expected every ~60s) to reduce churn on websockets. If the watch bookmarks do not arrive, polling is reduced to every 65s from every 30, but in most cases the bookmarks seem to arrive dependably.

Also fixes an issue when single items being watched are deleted. The hook will return an error immediately, and the websocket is kept open so that if the item is re-created, it will be available instantly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved live updates when individual resources are deleted, replaced, or restored.
  - Added more reliable handling for missing resources, expired connections, and other watch failures.
  - Preserved load errors during bookmark updates.
  - Improved connection recovery and lifecycle management, including recreated resources.

- **Performance**
  - Added faster retries after recoverable monitoring errors.
  - Improved cache freshness, timeout handling, and cleanup for watched resources.
  - Prevented duplicate monitoring activity and unnecessary removal scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->