### PR TITLE
ACM-42793 Hide OpenShift Virtualization operator alert for external infrastructure

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -2415,7 +2415,7 @@
   "OpenShift GitOps Operator Missing": "OpenShift GitOps Operator Missing",
   "OpenShift release images unavailable": "OpenShift release images unavailable",
   "OpenShift version": "OpenShift version",
-  "OpenShift Virtualization operator is required to create a cluster.": "OpenShift Virtualization operator is required to create a cluster.",
+  "OpenShift Virtualization operator is required to create a cluster when not using external infrastructure.": "OpenShift Virtualization operator is required to create a cluster when not using external infrastructure.",
   "openshift.cluster.manager": "OpenShift Cluster Manager",
   "OpenStack clouds.yaml": "OpenStack clouds.yaml",
   "Operator": "Operator",

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
@@ -4403,3 +4403,159 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
     await waitForNocks(createNocks)
   })
 })
+
+// ACM-42793: the OpenShift Virtualization operator alert must not be shown when the
+// selected credential uses external infrastructure, since the operator is not required
+// on the hub in that case. When it is shown, it must explain the external infrastructure exception.
+describe('CreateCluster KubeVirt operator alert', () => {
+  const kubevirtSecretWithExternalInfra: Secret = {
+    apiVersion: ProviderConnectionApiVersion,
+    kind: ProviderConnectionKind,
+    type: 'Opaque',
+    metadata: {
+      name: 'kubevirt-with-ei',
+      namespace: 'clusters',
+      labels: {
+        'cluster.open-cluster-management.io/type': 'kubevirt',
+        'cluster.open-cluster-management.io/credentials': '',
+      },
+    },
+    stringData: {
+      pullSecret: '{"pullSecret":"secret"}\n',
+      'ssh-publickey': 'ssh-rsa AAAAB1 fake@email.com',
+      kubeconfig: kubeconfig,
+      externalInfraNamespace: 'kubevirt-namespace',
+    },
+  } as unknown as Secret
+
+  const kubevirtSecretWithoutExternalInfra: Secret = {
+    apiVersion: ProviderConnectionApiVersion,
+    kind: ProviderConnectionKind,
+    type: 'Opaque',
+    metadata: {
+      name: 'kubevirt-no-ei',
+      namespace: 'clusters',
+      labels: {
+        'cluster.open-cluster-management.io/type': 'kubevirt',
+        'cluster.open-cluster-management.io/credentials': '',
+      },
+    },
+    stringData: {
+      pullSecret: '{"pullSecret":"secret"}\n',
+      'ssh-publickey': 'ssh-rsa AAAAB1 fake@email.com',
+    },
+  } as unknown as Secret
+
+  const Component = (props: { secret: Secret }) => {
+    return (
+      <RecoilRoot
+        initializeState={(snapshot) => {
+          snapshot.set(configMapsState, [
+            {
+              kind: 'ConfigMap',
+              apiVersion: 'v1',
+              metadata: {
+                name: 'supported-versions',
+                namespace: 'hypershift',
+              },
+              data: {
+                'supported-versions': '{"versions":["4.15","4.14","4.13"]}',
+              },
+            },
+          ])
+          snapshot.set(namespacesState, [
+            {
+              apiVersion: NamespaceApiVersion,
+              kind: NamespaceKind,
+              metadata: { name: 'clusters' },
+            },
+          ])
+          snapshot.set(managedClustersState, [])
+          snapshot.set(managedClusterSetsState, [])
+          snapshot.set(managedClusterInfosState, [
+            {
+              apiVersion: ManagedClusterInfoApiVersion,
+              kind: ManagedClusterInfoKind,
+              metadata: { name: 'local-cluster', namespace: 'local-cluster' },
+              status: {
+                consoleURL: 'https://testCluster.com',
+                conditions: [
+                  {
+                    type: 'ManagedClusterConditionAvailable',
+                    reason: 'ManagedClusterConditionAvailable',
+                    status: 'True',
+                  },
+                  { type: 'ManagedClusterJoined', reason: 'ManagedClusterJoined', status: 'True' },
+                  { type: 'HubAcceptedManagedCluster', reason: 'HubAcceptedManagedCluster', status: 'True' },
+                ],
+                version: '1.17',
+                distributionInfo: {
+                  type: 'ocp',
+                  ocp: {
+                    version: '1.2.3',
+                    availableUpdates: [],
+                    desiredVersion: '1.2.3',
+                    upgradeFailed: false,
+                  },
+                },
+              },
+            },
+          ])
+          snapshot.set(secretsState, [props.secret])
+          // No SubscriptionOperator for kubevirt-hyperconverged: operator is not installed on the hub
+          snapshot.set(subscriptionOperatorsState, [])
+        }}
+      >
+        <MemoryRouter initialEntries={[`${NavigationPath.createCluster}?${CLUSTER_INFRA_TYPE_PARAM}=kubevirt`]}>
+          <Routes>
+            <Route path={NavigationPath.createCluster} element={<CreateClusterPage />} />
+          </Routes>
+        </MemoryRouter>
+      </RecoilRoot>
+    )
+  }
+
+  beforeEach(() => {
+    nockIgnoreRBAC()
+    nockIgnoreApiPaths()
+    // operator is not installed on the hub for either scenario
+    nockIgnoreOperatorCheck(true)
+    nockIgnoreClusterVersion()
+  })
+
+  test('hides the operator alert when the selected credential uses external infrastructure, even though the operator is not installed', async () => {
+    const initialNocks = [
+      nockList(clusterImageSetKubervirt as IResource, [clusterImageSetKubervirt] as IResource[]),
+      nockList(storageClass as IResource, [storageClass] as IResource[]),
+    ]
+    render(<Component secret={kubevirtSecretWithExternalInfra} />)
+
+    await waitForNocks(initialNocks)
+    await waitForText('Cluster details', true)
+
+    await waitForNotText('Operator required')
+    expect(
+      screen.queryByText(
+        'OpenShift Virtualization operator is required to create a cluster when not using external infrastructure.'
+      )
+    ).not.toBeInTheDocument()
+  })
+
+  test('shows the operator alert with the external infrastructure exception text when the selected credential does not use external infrastructure', async () => {
+    const initialNocks = [
+      nockList(clusterImageSetKubervirt as IResource, [clusterImageSetKubervirt] as IResource[]),
+      nockList(storageClass as IResource, [storageClass] as IResource[]),
+    ]
+    render(<Component secret={kubevirtSecretWithoutExternalInfra} />)
+
+    await waitForNocks(initialNocks)
+    await waitForText('Cluster details', true)
+
+    await waitForText('Operator required')
+    expect(
+      screen.getByText(
+        'OpenShift Virtualization operator is required to create a cluster when not using external infrastructure.'
+      )
+    ).toBeInTheDocument()
+  })
+})

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.tsx
@@ -190,10 +190,15 @@ export default function CreateCluster(props: { infrastructureType: ClusterInfras
         }
         setSelectedConnection(providerConnections.find((provider) => control.active === provider.metadata.name))
       } else if (control.id === 'kubevirt-operator-alert') {
-        control.hidden = isKubevirtEnabled
+        // the OpenShift Virtualization operator is only needed on the hub when the
+        // selected credential does not delegate to an external infrastructure cluster
+        const usesExternalInfrastructure = !!(
+          selectedConnection?.stringData?.kubeconfig || selectedConnection?.stringData?.externalInfraNamespace
+        )
+        control.hidden = isKubevirtEnabled || usesExternalInfrastructure
       }
     },
-    [providerConnections, setSelectedConnection, newSecret, isKubevirtEnabled]
+    [providerConnections, setSelectedConnection, newSecret, isKubevirtEnabled, selectedConnection]
   )
   const agentClusterInstalls = useRecoilValue(agentClusterInstallsState)
   const infraEnvs = useRecoilValue(infraEnvironmentsState)
@@ -226,13 +231,14 @@ export default function CreateCluster(props: { infrastructureType: ClusterInfras
     </div>
   )
 
-  // If KubeVirt operator is installed/uninstalled toggle the Alert via control data
+  // Toggle the operator Alert when the KubeVirt operator install state changes or the
+  // selected credential (and its external infrastructure setting) changes
   const [kubeVirtOperatorControl, setKubeVirtOperatorControl] = useState<any>()
   useEffect(() => {
     if (kubeVirtOperatorControl) {
       onControlChange(kubeVirtOperatorControl)
     }
-  }, [isKubevirtEnabled, kubeVirtOperatorControl, onControlChange])
+  }, [isKubevirtEnabled, kubeVirtOperatorControl, onControlChange, selectedConnection])
 
   const localCluster = useMemo(() => allClusters.find((cls) => cls.name === localHubName), [allClusters, localHubName])
 

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataKubeVirt.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataKubeVirt.js
@@ -33,7 +33,9 @@ const OperatorAlert = ({ localCluster, t }) => {
     <Alert style={{ marginBottom: '1rem' }} isInline variant={'danger'} title={t('Operator required')}>
       <div style={{ display: 'flex', flexDirection: 'column' }}>
         <span style={{ margin: '0.5rem 0' }}>
-          {t('OpenShift Virtualization operator is required to create a cluster.')}
+          {t(
+            'OpenShift Virtualization operator is required to create a cluster when not using external infrastructure.'
+          )}
         </span>
         <AcmButton
           variant="link"

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataKubeVirt.test.js
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/controlData/ControlDataKubeVirt.test.js
@@ -152,7 +152,11 @@ describe('Cluster creation control data for KubeVirt', () => {
     const operatorAlert = findControl(controlData, 'kubevirt-operator-alert')
     render(operatorAlert.component)
     expect(screen.getByText('Operator required')).toBeInTheDocument()
-    expect(screen.getByText('OpenShift Virtualization operator is required to create a cluster.')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'OpenShift Virtualization operator is required to create a cluster when not using external infrastructure.'
+      )
+    ).toBeInTheDocument()
     const installLink = screen.getByRole('link', { name: /install operator/i })
     expect(installLink).toHaveAttribute(
       'href',


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**
Operator alert displays erroneously when using OpenShift Virtualization with external infrastructure

**Ticket Link:**
https://redhat.atlassian.net/browse/ACM-42793

**Type of Change:**
- [x] 🐞 Bug Fix

---

## Root cause

When creating a Hosted Control Plane cluster on OpenShift Virtualization, the "Operator required" alert was shown whenever the `kubevirt-hyperconverged` operator wasn't installed on the hub — even when the selected credential has external infrastructure enabled, in which case the operator isn't needed on the hub at all.

`CreateCluster.tsx` toggled the `kubevirt-operator-alert` control's `hidden` flag using only whether the operator was installed (`isKubevirtEnabled`), and never considered the selected credential's external infrastructure setting (`stringData.kubeconfig` / `stringData.externalInfraNamespace`). The effect that re-evaluates the alert also didn't re-run when the selected connection changed.

The alert copy also didn't mention the external-infrastructure exception.

## Fix

- `CreateCluster.tsx`: the alert is now hidden when the operator is installed **or** the selected credential has external infrastructure configured, and re-evaluates whenever the selected connection changes.
- `ControlDataKubeVirt.js`: updated the alert text to "OpenShift Virtualization operator is required to create a cluster when not using external infrastructure."

## Regression test

Added two tests in `CreateCluster.test.tsx` that render the KubeVirt wizard with the operator **not installed** on the hub:
- alert is hidden when the selected credential has external infrastructure configured
- alert is shown with the updated text when the selected credential does not use external infrastructure

Verified both tests fail without the fix and pass with it.

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

- `npm run lint` and `npm run i18n` pass cleanly.
- `tsc --noEmit` has pre-existing errors in unrelated files (confirmed identical on the unmodified `main` baseline); not caused by this change.
- The Playwright E2E step was skipped for this change (no local dev cluster/session available in this environment).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the KubeVirt cluster creation wizard to hide the operator warning when external infrastructure is configured.
  * The warning now refreshes correctly when a different credential is selected.
  * Clarified that the OpenShift Virtualization operator is required only when external infrastructure is not used.

* **Tests**
  * Added coverage for operator alert behavior with and without external infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->