### PR TITLE
ACM-40740 Add seccompProfile to example policy

### DIFF
--- a/frontend/src/wizards/Governance/Policy/stable/CM-Configuration-Management/policy-pod.yaml
+++ b/frontend/src/wizards/Governance/Policy/stable/CM-Configuration-Management/policy-pod.yaml
@@ -39,3 +39,5 @@ spec:
                             - ALL
                         privileged: false
                         runAsNonRoot: true
+                        seccompProfile:
+                          type: RuntimeDefault


### PR DESCRIPTION
# 📝 Summary

**GRC policy wizard "Pod - Pod must exist" template missing seccompProfile, causes enforcement failure on OCP 5.0**  

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-40740

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression (we already have RHAMC4K-14942 to catch regression)

---

### 🗒️ Notes for Reviewers

Problem: On an OCP 5.0 cluster with a restricted pod security profile, enforcing the "pod must exist" policy always results in a violation
<img width="1866" height="865" alt="Screenshot From 2026-08-31 10-52-23" src="https://github.com/user-attachments/assets/05c8fa69-6d9e-467d-a5a4-e7ede632117f" />

Cause: The example pod is missing the field `seccompProfile.type: RuntimeDefault`

### GRC QE test result
On my team's test cluster, I don't have permissions to edit the pod security profile for the `default` namespace, so I temporarily changed the RHAMC4K-14942 namespace to `jalaw` and verified the steps manually
```
oc create namespace jalaw
oc label namespace jalaw pod-security.kubernetes.io/enforce=restricted --overwrite
```
<img width="1000" height="235" alt="Screenshot From 2026-08-31 12-02-00" src="https://github.com/user-attachments/assets/83cc8be7-f34c-4369-9fa3-8b4cf46b93b1" />

<img width="2096" height="471" alt="Screenshot From 2026-08-31 12-02-33" src="https://github.com/user-attachments/assets/a6d64af8-2814-4aca-bb4d-2b6f6a01609b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Enabled the Kubernetes `RuntimeDefault` seccomp profile for the policy pod, strengthening its runtime security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->