### PR TITLE
ACM-43003 Pause NodePool when automation pre-hook is used for OpenShift Virtualization

### DIFF
--- a/frontend/src/resources/hosted-cluster.ts
+++ b/frontend/src/resources/hosted-cluster.ts
@@ -31,6 +31,7 @@ export interface HostedCluster extends IResource {
   }
   spec?: {
     channel?: string
+    pausedUntil?: string
     etcd: {
       managed: {
         storage: {

--- a/frontend/src/resources/node-pool.ts
+++ b/frontend/src/resources/node-pool.ts
@@ -185,6 +185,7 @@ export interface NodePool extends IResource {
   metadata: Metadata
   spec: {
     clusterName: string
+    pausedUntil?: string
     management: any
     platform: {
       aws?: {

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/CreateCluster.test.tsx
@@ -1606,7 +1606,34 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
     },
   }
 
-  const AutomationComponent = () => {
+  // ACM-43003: an automation template with an install pre-hook must pause the NodePool
+  // (not just the HostedCluster). Otherwise the NodePool starts deploying nodes before the
+  // pre-hook completes, and ClusterCurator later errors trying to unpause a NodePool that was
+  // never paused in the first place.
+  const installPrehookCurator: ClusterCurator = {
+    apiVersion: ClusterCuratorApiVersion,
+    kind: ClusterCuratorKind,
+    metadata: {
+      name: 'kubevirt-automation-prehook',
+      namespace: 'test-ii',
+      labels: {
+        'open-cluster-management': 'curator',
+      },
+    },
+    spec: {
+      install: {
+        prehook: [
+          {
+            name: 'test-prehook-install',
+            extra_vars: {},
+          },
+        ],
+        towerAuthSecret: 'ansible-connection',
+      },
+    },
+  }
+
+  const AutomationComponent = ({ curator = upgradeOnlyCurator }: { curator?: ClusterCurator }) => {
     return (
       <RecoilRoot
         initializeState={(snapshot) => {
@@ -1662,7 +1689,7 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
             },
           ])
           snapshot.set(secretsState, [mockKubevirtSecret as Secret, providerConnectionAnsible as Secret])
-          snapshot.set(clusterCuratorsState, [upgradeOnlyCurator])
+          snapshot.set(clusterCuratorsState, [curator])
           snapshot.set(subscriptionOperatorsState, [subscriptionOperator])
           snapshot.set(settingsState, { ansibleIntegration: 'enabled' })
         }}
@@ -1770,6 +1797,131 @@ describe('CreateCluster KubeVirt with RH OpenShift Virtualization credential tha
       nockCreate(mockNodePools),
       nockCreate(managedCluster),
       nockCreate(mockHostedClusterKubervirt),
+      nockCreate(mockKlusterletAddonConfigKubevirt),
+      nockCreate(mockKubeConfigSecretKubevirt),
+      nockCreate(mockPullSecretKubevirt),
+      nockCreate(mockSSHKeySecret),
+      nockCreate(expectedCurator),
+      nockCreate(expectedAnsibleSecret),
+    ]
+
+    await clickByText('Create')
+
+    await waitForText('Creating cluster ...')
+
+    await waitForNocks(createNocks)
+  })
+
+  test('pauses the NodePool as well as the HostedCluster when an automation template with an install pre-hook is used (ACM-43003)', async () => {
+    window.scrollBy = () => {}
+    const initialNocks = [
+      nockList(clusterImageSetKubervirt as IResource, [clusterImageSetKubervirt] as IResource[]),
+      nockList(storageClass as IResource, [storageClass] as IResource[]),
+    ]
+    render(<AutomationComponent curator={installPrehookCurator} />)
+
+    await new Promise((resolve) => setTimeout(resolve, 500))
+
+    await waitForNocks(initialNocks)
+
+    await waitForText('Cluster details', true)
+
+    // step 1 -- cluster details
+    await typeByTestId('clusterName', clusterName)
+    await clickByPlaceholderText('Select or enter a release image')
+    await clickByRole('option', { name: /OpenShift 4\.15\.36/i })
+
+    // step 2 -- node pools
+    await clickByText('Next')
+    const nodePoolNameInput = screen.getByTestId('nodePoolName')
+    fireEvent.change(nodePoolNameInput, { target: { value: 'nodepool' } })
+
+    // storage mappings
+    await clickByText('Next')
+    await clickByText('Add storage class mapping')
+    await typeByTestId('infraStorageClassName', 'storage-class1')
+    await typeByTestId('guestStorageClassName', 'guest-storage1')
+    await typeByTestId('storageClassGroup', 'group1')
+    await clickByText('Add volume snapshot class mapping')
+    await typeByTestId('infraVolumeSnapshotClassName', 'snapshot-class1')
+    await typeByTestId('guestVolumeSnapshotClassName', 'guest-snap1')
+    await typeByTestId('volumeSnapshotGroup', 'group1')
+    await clickByText('Next')
+
+    // step -- automation: select a template with an install pre-hook, which should pause
+    // reconciliation until the pre-hook completes
+    await waitForText('Automation template')
+    await waitForNotText('Install the operator')
+    await clickByPlaceholderText('Select an automation template')
+    await clickByText('kubevirt-automation-prehook')
+    await clickByText('Next')
+
+    // both the HostedCluster and the NodePool must be paused, otherwise the NodePool starts
+    // deploying nodes before the pre-hook runs and ClusterCurator later fails to unpause it
+    const expectedHostedCluster = {
+      ...mockHostedClusterKubervirt,
+      spec: {
+        ...mockHostedClusterKubervirt.spec,
+        pausedUntil: 'true',
+      },
+    }
+    const expectedNodePool = {
+      ...mockNodePools,
+      spec: {
+        ...mockNodePools.spec,
+        pausedUntil: 'true',
+      },
+    }
+
+    const expectedAnsibleSecret: Secret = {
+      apiVersion: 'v1',
+      kind: 'Secret',
+      type: 'Opaque',
+      metadata: {
+        name: 'toweraccess-install-test',
+        namespace: 'clusters',
+        labels: {
+          'cluster.open-cluster-management.io/type': 'ans',
+          'cluster.open-cluster-management.io/copiedFromNamespace': 'test-ii',
+          'cluster.open-cluster-management.io/copiedFromSecretName': 'ansible-connection',
+          'cluster.open-cluster-management.io/backup': 'cluster',
+        },
+      },
+      stringData: {
+        host: 'test',
+        token: 'test',
+      },
+    }
+    const expectedCurator: ClusterCurator = {
+      apiVersion: ClusterCuratorApiVersion,
+      kind: ClusterCuratorKind,
+      metadata: {
+        name: 'test',
+        namespace: 'clusters',
+        labels: {
+          'open-cluster-management': 'curator',
+        },
+      },
+      spec: {
+        install: {
+          prehook: [
+            {
+              name: 'test-prehook-install',
+              extra_vars: {},
+            },
+          ],
+          towerAuthSecret: 'toweraccess-install-test',
+        },
+        desiredCuration: 'install',
+      },
+    }
+
+    const createNocks = [
+      nockCreate(mockProject, mockProjectResponse),
+      nockCreate(mockClusterProjectKubevirt, mockClusterProjectKubevirtResponse),
+      nockCreate(expectedNodePool),
+      nockCreate(managedCluster),
+      nockCreate(expectedHostedCluster),
       nockCreate(mockKlusterletAddonConfigKubevirt),
       nockCreate(mockKubeConfigSecretKubevirt),
       nockCreate(mockPullSecretKubevirt),

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/kubevirt-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/kubevirt-template.hbs
@@ -149,6 +149,9 @@ spec:
   arch: amd64
   clusterName: '{{{@root.clusterName}}}'
   replicas: {{{this.nodePoolReplica}}}
+  {{#if @root.reconcilePause}}
+  pausedUntil: '{{{@root.reconcilePause}}}'
+  {{/if}}
   management:
     autoRepair: {{#if this.nodePoolAutoRepair}}{{{this.nodePoolAutoRepair}}}{{else}}false{{/if}}
     upgradeType: Replace


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**
OpenShift Virtualization wizard does not pause NodePool when an automation is used

**Ticket Link:**
https://redhat.atlassian.net/browse/ACM-43003

**Type of Change:**
- [x] 🐞 Bug Fix
- [ ] ✨ Feature
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related
- [ ] 📄 Docs

---

## Root cause

The OpenShift Virtualization (KubeVirt) create-cluster wizard sets `pausedUntil` on the
generated `HostedCluster` resource when an automation template with an install pre-hook is
selected, so reconciliation pauses until the pre-hook Ansible job completes. However, the
same field was never set on the generated `NodePool` resource(s).

As a result, the NodePool controller started provisioning worker nodes immediately, racing
the pre-hook instead of waiting for it. When ClusterCurator later finished the pre-hook and
tried to unpause all paused resources, it errored trying to unpause a NodePool that had
never actually been paused.

## Fix

- `kubevirt-template.hbs`: emit `pausedUntil: '{{{@root.reconcilePause}}}'` on each generated
  `NodePool` spec, guarded the same way as the existing `HostedCluster` field.
- `hosted-cluster.ts`: added the missing `pausedUntil` field to the `HostedCluster` TypeScript
  type (it was already emitted by the template for the HostedCluster, just untyped).

## Test plan

- Added a regression test (`CreateCluster.test.tsx`) that selects an automation template with
  an install pre-hook in the KubeVirt wizard and asserts both the `HostedCluster` and the
  `NodePool` are created with `pausedUntil: 'true'`.
- Verified the new test fails against the pre-fix template (missing `pausedUntil` on the
  NodePool) and passes with the fix.
- `npm test` (CreateCluster + ControlDataKubeVirt suites) and `npm run check` (lint, prettier,
  tsc, i18n) all pass.

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [x] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers

The Agent-based Hypershift wizard (`assisted-installer/hypershift-template.hbs`) has the same
gap (NodePool never gets `pausedUntil`), but per the Jira comments that is being tracked by a
separate cloned ticket, so it's intentionally out of scope here to keep this fix minimal.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for pausing hosted KubeVirt cluster installations until a specified time.
  - KubeVirt node pools now inherit the cluster’s installation pause setting when configured.
  - Cluster automation with installation pre-hooks now creates the required installation secret and curator configuration.

- **Tests**
  - Added coverage verifying pause settings and installation pre-hook behavior for hosted KubeVirt clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->