### PR TITLE
ACM-43055 npm update fast-uri [release-5.0]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20029,9 +20029,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Updates package `fast-uri` to version 3.1.6  to addresses CVEs:
CVE-2026-75899
CVE-2026-75931 
CVE-2026-75975
CVE-2026-76172

Jira ticket:
https://redhat.atlassian.net/browse/ACM-43055