### PR TITLE
ACM-42838 ACM-42840 ACM-42842 ACM-42846 ACM-42861 ACM-42863 ACM-42865 ACM-42867 npm update fast-uri [release-2.16]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19986,9 +19986,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Updates package `fast-uri` to version 3.1.6  to addresses CVEs:
CVE-2026-75899
CVE-2026-75931 
CVE-2026-75975
CVE-2026-76172

Jira tickets:
https://redhat.atlassian.net/browse/ACM-42838
https://redhat.atlassian.net/browse/ACM-42840
https://redhat.atlassian.net/browse/ACM-42842
https://redhat.atlassian.net/browse/ACM-42846
https://redhat.atlassian.net/browse/ACM-42861
https://redhat.atlassian.net/browse/ACM-42863
https://redhat.atlassian.net/browse/ACM-42865
https://redhat.atlassian.net/browse/ACM-42867