### PR TITLE
ACM-43046 ACM-43049 npm update immutable [release-2.15]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2396,7 +2396,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=0.1.90"
@@ -6429,9 +6428,9 @@
       }
     },
     "node_modules/@openshift-console/dynamic-plugin-sdk/node_modules/immutable": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.3.tgz",
-      "integrity": "sha512-AUY/VyX0E5XlibOmWt10uabJzam1zlYjwiEgQSDc5+UIkFNaF9WM0JxXKaNMGf+F/ffUF+7kRKXM9A7C0xXqMg==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.4.tgz",
+      "integrity": "sha512-ZQv17KolYrYmsDoDB8N67zhIKsNi9mGYlk96y/yuxyAqJB2hLzSGSM7k/sB0/ZvO4kx27U9+fBeD/XlLGh/uXQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -22125,9 +22124,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
Updates package `immutable` to versions 3.8.4 and 4.3.9 to address CVE-2026-59879

Jira tickets:
https://redhat.atlassian.net/browse/ACM-43046
https://redhat.atlassian.net/browse/ACM-43049