### PR TITLE
ACM-43028: OpenShift Virtualization wizard does not pause NodePool when an automation is used

### DIFF
--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/CreateCluster/templates/assisted-installer/hypershift-template.hbs
@@ -113,6 +113,9 @@ metadata:
   namespace: '{{{this.clusterName}}}'
 spec:
   clusterName: '{{{this.clusterName}}}'
+  {{#if @root.reconcilePause}}
+  pausedUntil: '{{{@root.reconcilePause}}}'
+  {{/if}}
   {{#if this.manualHostSelect}}
   replicas: {{{this.selectedAgentIDs.length}}}
   {{else}}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
OpenShift Virtualization wizard does not pause NodePool when an automation is used

**Ticket Link:**  
<!-- e.g. https://redhat.atlassian.net/browse/ACM-12345 -->
https://redhat.atlassian.net/browse/ACM-43028

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [ ] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [ ] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster node pools now honor the configured reconciliation pause setting, keeping their pause behavior consistent with the associated hosted cluster.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->