### PR TITLE
ACM-44177 npm update fast-uri [release-5.0]

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20029,9 +20029,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
-      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Updates package fast-uri to version 3.1.7 to addresses CVEs:
CVE-2026-84292
CVE-2026-84394

Jira ticket:
https://redhat.atlassian.net/browse/ACM-44177