### PR TITLE
fix(topology): enrich cluster data with consoleURL from search results (ACM-37275)

### DIFF
--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProviderStatuses.test.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProviderStatuses.test.ts
@@ -1,0 +1,151 @@
+/* Copyright Contributors to the Open Cluster Management project */
+
+import { t } from '~/lib/test-helpers'
+import { setClusterStatus } from './NodeDetailsProviderStatuses'
+import type { ClusterInfo, DetailItem, TopologyNodeWithStatus } from '../types'
+
+jest.mock('../../../../../lib/AcmTimestamp', () => () => null)
+jest.mock('../../../../../resources', () => ({}))
+jest.mock('../helpers/ansible-task', () => ({ showAnsibleJobDetails: jest.fn() }))
+jest.mock('../helpers/diagram-helpers', () => ({
+  addDetails: jest.fn(),
+  addNodeServiceLocation: jest.fn(),
+  addOCPRouteLocation: jest.fn(),
+  addPropertyToList: jest.fn(),
+  createEditLink: jest.fn(),
+  getNodePropery: jest.fn(),
+}))
+jest.mock('../helpers/diagram-helpers-utils', () => ({
+  filterSubscriptionObject: jest.fn(),
+  getActiveFilterCodes: jest.fn(),
+  getClusterName: jest.fn(),
+  getTargetNsForNode: jest.fn(),
+  isDeployableResource: jest.fn(),
+  nodeMustHavePods: jest.fn(),
+  showMissingClusterDetails: jest.fn(),
+}))
+jest.mock('../helpers/search-helper', () => ({ isSearchAvailable: jest.fn() }))
+jest.mock('./computeStatuses', () => ({
+  apiVersionPath: 'apiVersion',
+  argoAppHealthyStatus: 'Healthy',
+  argoAppProgressingStatus: 'Progressing',
+  argoAppUnknownStatus: 'Unknown',
+  checkmarkCode: 'checkmark',
+  checkmarkStatus: 'checkmark',
+  failureCode: 'failure',
+  failureStatus: 'failure',
+  getOnlineClusters: jest.fn(() => []),
+  metadataName: 'metadata.name',
+  pendingCode: 'pending',
+  pendingStatus: 'pending',
+  resErrorStates: [],
+  showResourceYaml: jest.fn(),
+  warningCode: 'warning',
+  warningStatus: 'warning',
+}))
+
+const hubClusterName = 'local-cluster'
+
+const makeClusterNode = (overrides: Record<string, unknown> = {}): TopologyNodeWithStatus =>
+  ({
+    id: 'member--clusters--test',
+    type: 'cluster',
+    specs: {
+      clusters: [],
+      appClusters: [],
+      clustersNames: [],
+      searchClusters: [],
+      targetNamespaces: {},
+      ...overrides,
+    },
+  }) as unknown as TopologyNodeWithStatus
+
+describe('setClusterStatus', () => {
+  it('should enrich clusters with consoleURL from searchClusters', () => {
+    const node = makeClusterNode({
+      clusters: [{ name: 'managed-1', status: 'ok' }] as ClusterInfo[],
+      searchClusters: [
+        { name: 'managed-1', status: 'ok', consoleURL: 'https://console.managed-1.example.com' },
+      ] as ClusterInfo[],
+    })
+
+    const details: DetailItem[] = []
+    setClusterStatus(node, details, t, hubClusterName)
+
+    const combobox = details.find((d) => d.type === 'clusterdetailcombobox')
+    expect(combobox).toBeDefined()
+    const clusterList = combobox!.comboboxdata!.clusterList
+    expect(clusterList).toHaveLength(1)
+    expect(clusterList[0].consoleURL).toBe('https://console.managed-1.example.com')
+  })
+
+  it('should not overwrite existing consoleURL on clusters', () => {
+    const node = makeClusterNode({
+      clusters: [{ name: 'managed-1', status: 'ok', consoleURL: 'https://original.example.com' }] as ClusterInfo[],
+      searchClusters: [{ name: 'managed-1', status: 'ok', consoleURL: 'https://search.example.com' }] as ClusterInfo[],
+    })
+
+    const details: DetailItem[] = []
+    setClusterStatus(node, details, t, hubClusterName)
+
+    const combobox = details.find((d) => d.type === 'clusterdetailcombobox')
+    const clusterList = combobox!.comboboxdata!.clusterList
+    expect(clusterList[0].consoleURL).toBe('https://original.example.com')
+  })
+
+  it('should add consoleURL to Argo appClusters not in specs.clusters', () => {
+    const node = makeClusterNode({
+      clusters: [] as ClusterInfo[],
+      appClusters: ['argo-cluster'],
+      searchClusters: [
+        { name: 'argo-cluster', status: 'ok', consoleURL: 'https://console.argo-cluster.example.com' },
+      ] as ClusterInfo[],
+    })
+
+    const details: DetailItem[] = []
+    setClusterStatus(node, details, t, hubClusterName)
+
+    const combobox = details.find((d) => d.type === 'clusterdetailcombobox')
+    const clusterList = combobox!.comboboxdata!.clusterList
+    const argoCluster = clusterList.find((c) => c.name === 'argo-cluster')
+    expect(argoCluster).toBeDefined()
+    expect(argoCluster!.consoleURL).toBe('https://console.argo-cluster.example.com')
+  })
+
+  it('should handle missing searchClusters gracefully', () => {
+    const node = makeClusterNode({
+      clusters: [{ name: 'managed-1', status: 'ok' }] as ClusterInfo[],
+    })
+    delete (node.specs as Record<string, unknown>).searchClusters
+
+    const details: DetailItem[] = []
+    setClusterStatus(node, details, t, hubClusterName)
+
+    const combobox = details.find((d) => d.type === 'clusterdetailcombobox')
+    const clusterList = combobox!.comboboxdata!.clusterList
+    expect(clusterList).toHaveLength(1)
+    expect(clusterList[0].consoleURL).toBeUndefined()
+  })
+
+  it('should enrich multiple clusters from searchClusters', () => {
+    const node = makeClusterNode({
+      clusters: [
+        { name: 'cluster-a', status: 'ok' },
+        { name: 'cluster-b', status: 'ok' },
+      ] as ClusterInfo[],
+      searchClusters: [
+        { name: 'cluster-a', status: 'ok', consoleURL: 'https://console.cluster-a.example.com' },
+        { name: 'cluster-b', status: 'ok', consoleURL: 'https://console.cluster-b.example.com' },
+      ] as ClusterInfo[],
+    })
+
+    const details: DetailItem[] = []
+    setClusterStatus(node, details, t, hubClusterName)
+
+    const combobox = details.find((d) => d.type === 'clusterdetailcombobox')
+    const clusterList = combobox!.comboboxdata!.clusterList
+    expect(clusterList).toHaveLength(2)
+    expect(clusterList[0].consoleURL).toBe('https://console.cluster-a.example.com')
+    expect(clusterList[1].consoleURL).toBe('https://console.cluster-b.example.com')
+  })
+})

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProviderStatuses.tsx
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/model/NodeDetailsProviderStatuses.tsx
@@ -799,24 +799,45 @@ export const setClusterStatus = (
     clusters = [],
     appClusters = [],
     clustersNames = [],
+    searchClusters = [],
   } = specs as {
     cluster?: ClusterInfo
     targetNamespaces?: Record<string, unknown>
     clusters?: ClusterInfo[]
     appClusters?: string[]
     clustersNames?: string[]
+    searchClusters?: ClusterInfo[]
   }
 
   const clusterArr = cluster ? [cluster] : clusters
   const appClustersList = appClusters.length > 0 ? appClusters : Object.keys(targetNamespaces)
 
+  const searchClusterArr = Array.isArray(searchClusters) ? searchClusters.filter(Boolean) : []
+  if (searchClusterArr.length > 0) {
+    clusterArr.forEach((cls) => {
+      if (!cls.consoleURL) {
+        const clsName = cls.name || cls.metadata?.name || ''
+        const match = searchClusterArr.find(
+          (sc) => typeof sc === 'object' && (sc.name === clsName || sc.metadata?.name === clsName)
+        )
+        if (match?.consoleURL) {
+          cls.consoleURL = match.consoleURL
+        }
+      }
+    })
+  }
+
   // Add Argo app clusters not covered by deployed resource clusters
   appClustersList.forEach((appCls: string) => {
     if (clusters.findIndex((obj: any) => safeGet(obj, 'name') === appCls) === -1) {
+      const searchMatch = searchClusterArr.find(
+        (sc) => typeof sc === 'object' && (sc.name === appCls || sc.metadata?.name === appCls)
+      )
       clusterArr.push({
         name: appCls,
         _clusterNamespace: appCls === hubClusterName ? appCls : '_',
         status: appCls === hubClusterName ? 'ok' : '',
+        consoleURL: searchMatch?.consoleURL,
       })
     }
   })

--- a/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/types.ts
+++ b/frontend/src/routes/Applications/ApplicationDetails/ApplicationTopology/types.ts
@@ -376,6 +376,7 @@ export interface ClusterInfo {
   name?: string
   namespace?: string
   status?: ClusterStatus
+  consoleURL?: string
   metadata?: {
     name: string
     [key: string]: unknown


### PR DESCRIPTION
## Root Cause Analysis

The "Open cluster console" link in Application Topology's `ClusterDetailsContainer` never displayed because `consoleURL` from the Search API was stored in `specs.searchClusters` but never merged into `specs.clusters`, which is what the rendering path reads.

**Data flow trace:**

1. **Search API** returns cluster objects **with** `consoleURL` ✅
2. **`topologyDetails.ts:86`** — `getResourcesClustersForApp()` extracts clusters from search results → stored as `clustersObjects`
3. **`topologyDetails.ts:120`** — Sets `specs.searchClusters = clustersObjects` on all nodes ✅ (has `consoleURL`)
4. **`resourceStatusesArgo.ts:232-240`** — For Argo/AppSet apps, creates `specs.clusters = [{ name: cls }]` with **only the cluster name** ❌ (no `consoleURL`)
5. **`diagram-helpers-utils.ts:233`** — `updateAppClustersMatchingSearch()` for cluster-type nodes does **NOT** update `specs.clusters` — only updates `specs.appClusters`
6. **`NodeDetailsProviderStatuses.tsx:810`** — Reads `specs.clusters` (without `consoleURL`) and passes as `clusterArr` to `ClusterDetailsContainer`
7. **`ClusterDetailsContainer.tsx:565`** — Destructures `consoleURL` from each cluster → always `undefined`

**Root cause:** `specs.clusters` and `specs.searchClusters` are never merged. The rendering path reads from `specs.clusters` (minimal data) while `consoleURL` lives in `specs.searchClusters` (rich search data).

## Fix

- Added `consoleURL?: string` to the `ClusterInfo` interface in `types.ts`
- In `setClusterStatus` (`NodeDetailsProviderStatuses.tsx`), enrich each cluster in `clusterArr` with `consoleURL` from matching `searchClusters` entries before passing to `ClusterDetailsContainer`
- Also enrich dynamically added Argo `appClusters` entries with `consoleURL`

<img width="1584" height="803" alt="image" src="https://github.com/user-attachments/assets/a13bd40b-6605-4299-b635-e2b19ed8780b" />

<img width="1598" height="794" alt="image" src="https://github.com/user-attachments/assets/d0a45e2f-6518-404b-bbd7-31a9da8dd807" />

<img width="1596" height="777" alt="image" src="https://github.com/user-attachments/assets/ee345abc-3573-4ff5-bd4b-55285f0c4c70" />

## Regression Tests

5 new tests in `NodeDetailsProviderStatuses.test.ts`:
- `consoleURL` enriched from `searchClusters` into clusters
- Existing `consoleURL` not overwritten
- Argo `appClusters` get `consoleURL` from `searchClusters`
- Missing `searchClusters` handled gracefully
- Multiple clusters enriched correctly

## How to Test

1. Navigate to Applications → select any ArgoCD or ApplicationSet app → Topology view
2. Click on a cluster node in the topology graph
3. Expand the cluster details in the side panel
4. Verify the **"Open cluster console"** link is displayed
5. Click the link — it should open the cluster's console in a new tab

Fixes: https://issues.redhat.com/browse/ACM-37275

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cluster details now include console links when available.
  - Console links are automatically populated for existing clusters and Argo application clusters.

- **Bug Fixes**
  - Preserved existing cluster console links while filling in missing links from available cluster data.

- **Tests**
  - Added coverage for console link enrichment across single and multiple clusters, including missing-data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->