### PR TITLE
WIP ACM-42605 Credential fields with validation cannot be edited manually

### DIFF
--- a/frontend/src/components/AcmDataForm.test.tsx
+++ b/frontend/src/components/AcmDataForm.test.tsx
@@ -1,7 +1,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
+import { FormGroup } from '@patternfly/react-core'
+import { render } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { axe } from 'jest-axe'
+import { useState } from 'react'
 import i18next from 'i18next'
 const t = i18next.t.bind(i18next)
-import { generalValidationMessage, requiredValidationMessage } from './AcmDataForm'
+import { AcmDataFormInput, generalValidationMessage, requiredValidationMessage } from './AcmDataForm'
+import { Input } from './AcmFormData'
 
 describe('ACMDataForm', () => {
   describe('generalValidationMessage', () => {
@@ -13,6 +19,61 @@ describe('ACMDataForm', () => {
   describe('requiredValidationMessage', () => {
     test('requiredValidationMessage should render the expected string', () => {
       expect(requiredValidationMessage(t)).toEqual('You must fill out all required fields before you can proceed.')
+    })
+  })
+
+  describe('AcmDataFormInput masked secret TextArea', () => {
+    const multilineSecret = [
+      '-----BEGIN OPENSSH PRIVATE KEY-----',
+      'abc123def456',
+      '-----END OPENSSH PRIVATE KEY-----',
+    ].join('\n')
+
+    function SecretHarness(props: { onValue: (value: string) => void }) {
+      const [value, setValue] = useState(multilineSecret)
+      const input: Input = {
+        id: 'ssh-privatekey',
+        type: 'TextArea',
+        label: 'SSH private key',
+        value,
+        isSecret: true,
+        onChange: (next: string) => {
+          setValue(next)
+          props.onValue(next)
+        },
+      }
+      // Mirror how the form renders inputs, so the field is labelled as it is in the real page.
+      return (
+        <FormGroup label="SSH private key" fieldId="ssh-privatekey">
+          <AcmDataFormInput input={input} isReadOnly={false} />
+        </FormGroup>
+      )
+    }
+
+    test('renders a hidden multiline secret in a textarea so line breaks survive editing', async () => {
+      const onValue = jest.fn()
+      const { container } = render(<SecretHarness onValue={onValue} />)
+
+      // A hidden secret must remain a multiline textarea (not a single-line password input) so that
+      // typing into it preserves the value's newlines.
+      const field = container.querySelector('textarea')
+      expect(field).toBeInTheDocument()
+      expect(field).toHaveValue(multilineSecret)
+
+      // Append text while the field is still masked, without clicking the eyeball icon.
+      await userEvent.type(field!, ' # edited while hidden')
+
+      // The value handed to onChange keeps every original line break intact.
+      const lastValue = onValue.mock.calls[onValue.mock.calls.length - 1][0] as string
+      expect(lastValue.startsWith(multilineSecret)).toBe(true)
+      expect(lastValue.endsWith(' # edited while hidden')).toBe(true)
+      expect(lastValue.split('\n')).toEqual([
+        '-----BEGIN OPENSSH PRIVATE KEY-----',
+        'abc123def456',
+        '-----END OPENSSH PRIVATE KEY----- # edited while hidden',
+      ])
+
+      expect(await axe(container)).toHaveNoViolations()
     })
   })
 })

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -76,6 +76,7 @@ import {
   TimesCircleIcon,
   TrashIcon,
 } from '@patternfly/react-icons'
+import { css } from '@emotion/css'
 import useResizeObserver from '@react-hook/resize-observer'
 import { Schema } from 'ajv'
 import { Fragment, ReactElement, ReactNode, useCallback, useContext, useRef, useState } from 'react'
@@ -96,6 +97,12 @@ import {
 import { AcmSelectBase, AcmSelectBaseProps, SelectOptionObject, SelectVariant } from './AcmSelectBase'
 import { LostChangesContext, LostChangesPrompt } from './LostChanges'
 import { SyncEditor, ValidationStatus } from './SyncEditor/SyncEditor'
+
+// Masks the characters of a multiline secret TextArea while preserving its real (newline-containing) value.
+const maskedSecretTextArea = css`
+  -webkit-text-security: disc;
+  text-security: disc;
+`
 
 export interface AcmDataFormProps {
   formData: FormData
@@ -1052,29 +1059,22 @@ export function AcmDataFormInput(props: { input: Input; validated?: 'error'; isR
       )
     }
     case 'TextArea': {
-      const hideSecretInput = input.isSecret === true && !showSecrets
+      // Mask secret values with CSS rather than swapping in a single-line password input, so that
+      // multiline secrets (e.g. SSH private keys) keep their line breaks while being edited.
+      const maskSecret = input.isSecret === true && !showSecrets
       const { onChange, ...inputProps } = input
       return (
         <InputGroup>
-          {hideSecretInput ? (
-            <TextInput
-              {...inputProps}
-              onChange={(_event, value) => onChange(value)}
-              validated={validated}
-              type={'password'}
-              readOnlyVariant={isReadOnly ? 'default' : undefined}
-            />
-          ) : (
-            <TextArea
-              {...inputProps}
-              onChange={(_event, value) => onChange(value)}
-              validated={validated}
-              spellCheck="false"
-              resizeOrientation="vertical"
-              autoResize={true}
-              readOnlyVariant={isReadOnly ? 'default' : undefined}
-            />
-          )}
+          <TextArea
+            {...inputProps}
+            onChange={(_event, value) => onChange(value)}
+            validated={validated}
+            spellCheck="false"
+            resizeOrientation="vertical"
+            autoResize={true}
+            readOnlyVariant={isReadOnly ? 'default' : undefined}
+            className={maskSecret ? maskedSecretTextArea : undefined}
+          />
 
           {input.value === '' ? (
             <PasteInputButton setValue={input.onChange} setShowSecrets={setShowSecrets} />
@@ -1530,13 +1530,19 @@ function PasteInputButton(props: { setValue: (value: string) => void; setShowSec
 
 function ClearInputButton(props: { onClick: () => void }) {
   const { onClick } = props
-  return <Button icon={<TimesCircleIcon />} variant="control" onClick={onClick}></Button>
+  const { t } = useTranslation()
+  return <Button aria-label={t('Clear')} icon={<TimesCircleIcon />} variant="control" onClick={onClick}></Button>
 }
 
 function ShowSecretsButton(props: { showSecrets: boolean; setShowSecrets: (value: boolean) => void }) {
   const { showSecrets, setShowSecrets } = props
+  const { t } = useTranslation()
   return (
-    <Button variant="control" onClick={() => setShowSecrets(!showSecrets)}>
+    <Button
+      aria-label={showSecrets ? t('Hide secret') : t('Show secret')}
+      variant="control"
+      onClick={() => setShowSecrets(!showSecrets)}
+    >
       {showSecrets ? <EyeIcon /> : <EyeSlashIcon />}
     </Button>
   )

--- a/frontend/src/components/AcmDataForm.tsx
+++ b/frontend/src/components/AcmDataForm.tsx
@@ -1052,7 +1052,7 @@ export function AcmDataFormInput(props: { input: Input; validated?: 'error'; isR
       )
     }
     case 'TextArea': {
-      const hideSecretInput = input.value !== '' && input.isSecret === true && !showSecrets
+      const hideSecretInput = input.isSecret === true && !showSecrets
       const { onChange, ...inputProps } = input
       return (
         <InputGroup>
@@ -1060,7 +1060,6 @@ export function AcmDataFormInput(props: { input: Input; validated?: 'error'; isR
             <TextInput
               {...inputProps}
               onChange={(_event, value) => onChange(value)}
-              value={'**************'}
               validated={validated}
               type={'password'}
               readOnlyVariant={isReadOnly ? 'default' : undefined}


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
<!-- Use the exact title from Jira or a brief, clear summary -->
Fix editing masked secret fields without revealing

**Ticket Link:**  
<!-- e.g. https://redhat.atlassian.net/browse/ACM-12345 -->
https://redhat.atlassian.net/browse/ACM-42605

**Type of Change:**  
<!-- Select one -->
- [x] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [ ] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [ ] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [ ] Code builds and runs locally without errors
- [ ] No console logs, commented-out code, or unnecessary files
- [ ] All commits are meaningful and well-labeled
- [ ] All new display strings are externalized for localization (English only)
- [ ] *(Nice to have)* JSDoc comments added for new functions and interfaces

#### If Feature

- [ ] UI/UX reviewed (if applicable)
- [ ] All acceptance criteria met
- [ ] Unit test coverage added or updated
- [ ] Relevant documentation or comments included

#### If Bugfix

- [x] Root cause and fix summary are documented in the ticket (for future reference / errata)
- [x] Fix tested thoroughly and resolves the issue
- [ ] Test(s) added to prevent regression

---

### 🗒️ Notes for Reviewers
<!-- Optional: anything reviewers should know, special context, etc. -->
Before:

https://github.com/user-attachments/assets/898b6b83-c57b-435c-8821-3273947b157d

After:

https://github.com/user-attachments/assets/2b57f70f-63fd-4a89-97ed-5bbf3326f7b9

Dummy secret for testing:

```
cat <<'EOF' | oc apply -f -
apiVersion: v1
kind: Secret
metadata:
  name: test-hostinventory-acm-42605
  namespace: default
  labels:
    cluster.open-cluster-management.io/type: hostinventory
    cluster.open-cluster-management.io/credentials: ""
type: Opaque
stringData:
  baseDomain: example.com
  pullSecret: |
    {"auths":{}}
  ssh-publickey: ssh-rsa AAAAB3NzaC1yc2E= test@example.com
EOF

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secret multiline fields now remain editable as text areas while their contents are concealed.
  * Line breaks and the underlying secret value are preserved when editing concealed fields.
  * Clear and show/hide controls now include accessible, localized labels.
  * Concealed fields remain hidden even when empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->