### PR TITLE
ACM-44868 Switch to trusted, staged publishing for multicluster-sdk

### DIFF
--- a/.github/workflows/publish-multicluster-sdk.yml
+++ b/.github/workflows/publish-multicluster-sdk.yml
@@ -13,14 +13,11 @@ on:
           - minor
           - patch
 
-permissions:
-  id-token: write # Required for OIDC
-  contents: read
-
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write # Required for OIDC
       contents: write
       packages: write
 

--- a/.github/workflows/publish-multicluster-sdk.yml
+++ b/.github/workflows/publish-multicluster-sdk.yml
@@ -13,6 +13,10 @@ on:
           - minor
           - patch
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -60,7 +64,7 @@ jobs:
         run: npm run build
 
       - name: Test publish (dry run)
-        run: npm publish --dry-run
+        run: npm stage publish --dry-run
 
       - name: Add and commit version update
         uses: EndBug/add-and-commit@v11
@@ -70,6 +74,4 @@ jobs:
           tag: ${{ env.TAG }}
 
       - name: Publish to npm
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm stage publish


### PR DESCRIPTION
# 📝 Summary

**Ticket Summary (Title):**  
Fix automatic npm package publishing

**Ticket Link:**  
https://redhat.atlassian.net/browse/ACM-44868

**Type of Change:**  
<!-- Select one -->
- [ ] 🐞 Bug Fix  
- [ ] ✨ Feature  
- [ ] 🔧 Refactor
- [x] 💸 Tech Debt
- [ ] 🧪 Test-related  
- [ ] 📄 Docs

---

## ✅ Checklist

### General

- [x] PR title follows the convention (e.g. `ACM-12340 Fix bug with...`)
- [x] Code builds and runs locally without errors
- [x] No console logs, commented-out code, or unnecessary files
- [x] All commits are meaningful and well-labeled
- [x] All new display strings are externalized for localization (English only)
- [x] *(Nice to have)* JSDoc comments added for new functions and interfaces


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package publishing workflows to use staged publishing for both dry-run and production releases.
  * Adjusted workflow permissions to support secure publishing operations.
  * Simplified production publishing configuration by removing the separate package registry token.
  * Improved consistency between preview and production package release processes while maintaining the required publishing access controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->